### PR TITLE
fix rerank once for all

### DIFF
--- a/app/endpoints/rerank.py
+++ b/app/endpoints/rerank.py
@@ -18,4 +18,4 @@ async def rerank(request: Request, body: RerankRequest, user: User = Security(ch
     client = model.get_client(endpoint=ENDPOINT__RERANK)
     response = await client.forward_request(method="POST", json=body.model_dump())
 
-    return Reranks(data=response.json())
+    return Reranks(**response.json())

--- a/app/schemas/rerank.py
+++ b/app/schemas/rerank.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import List
 
 from pydantic import BaseModel, Field
 
@@ -15,5 +15,4 @@ class Rerank(BaseModel):
 
 
 class Reranks(BaseModel):
-    object: Literal["list"] = "list"
     data: List[Rerank]


### PR DESCRIPTION
Le souci c'est que le model Pydantic Reranks ne correspondait pas au retour de l'API du model. J'avais adapté l'appel à Reranks pour que ça colle. Mais le souci, c'est que quand on passe avec le client type albert, il reçoit la réponse dans le format Reranks OK.

Bref, à priori, le model pydantic doit correspondre au données retournées par les API, donc ce fix doit être le bon.