### PR TITLE
fix request to update token value on token creation

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"88.15%","color":"green"}
+{"schemaVersion":1,"label":"coverage","message":"88.25%","color":"green"}

--- a/.github/compose.test.yml
+++ b/.github/compose.test.yml
@@ -55,7 +55,6 @@ services:
       service: redis
     ports: !override
       - 8335:6379
-
   mcp-bridge:
     extends:
       file: ../compose.yml

--- a/app/helpers/_identityaccessmanager.py
+++ b/app/helpers/_identityaccessmanager.py
@@ -355,7 +355,7 @@ class IdentityAccessManager:
         # update the token
         expires_at = func.to_timestamp(expires_at) if expires_at is not None else None
         await session.execute(
-            statement=update(table=TokenTable).values(token=f"{token[:8]}...{token[-8:]}", expires_at=expires_at).where(TokenTable.name == name)
+            statement=update(table=TokenTable).values(token=f"{token[:8]}...{token[-8:]}", expires_at=expires_at).where(TokenTable.id == token_id)
         )
         await session.commit()
 


### PR DESCRIPTION
Just update request on token creation. Add a lot of tests to ensure that token issue does not involve identity usurpation like reported on yes we hack.