### PR TITLE
Added support for environnement variables names with numbers

### DIFF
--- a/app/schemas/core/settings.py
+++ b/app/schemas/core/settings.py
@@ -331,7 +331,7 @@ class Settings(BaseSettings):
             file.close()
 
         # replace environment variables (pattern: ${VARIABLE_NAME})
-        for match in set(re.findall(pattern=r"\${[A-Z_]+}", string=file_content)):
+        for match in set(re.findall(pattern=r"\${[A-Z_][A-Z_0-9]*}", string=file_content)):
             variable = match.replace("${", "").replace("}", "")
             if os.getenv(variable) is None or os.getenv(variable) == "":
                 logging.warning(f"Environment variable {variable} not found or empty to replace {match}.")

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
             file.close()
 
         # replace environment variables (pattern: ${VARIABLE_NAME})
-        for match in set(re.findall(pattern=r"\${[A-Z_]+}", string=file_content)):
+        for match in set(re.findall(pattern=r"\${[A-Z_][A-Z_0-9]*}", string=file_content)):
             variable = match.replace("${", "").replace("}", "")
             if os.getenv(variable) is None or os.getenv(variable) == "":
                 logging.warning(f"Environment variable {variable} not found or empty to replace {match}.")


### PR DESCRIPTION
Les variables d'environnement contenant des nombres dans la configuration ne sont pas détectées par Albert.

Cette MR rajoute le support des nombres dans les variables d'environnement à l'exception du premier caractère.