### PR TITLE
fix: makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,11 @@ dev:
 		cp config.example.yml "$$CONFIG_FILE"; \
 	fi'
 
+	@if [ ! -f $(compose) ]; then \
+		echo "🔄 Creating $(compose) file from compose.example.yml and using it"; \
+		cp compose.example.yml $(compose); \
+	fi
+
 	@# Start services
 	@services=$$(docker compose --file $(compose) config --services | grep -v -E '^(api|playground)$$' | tr '\n' ' '); \
 	echo "🔄 Starting services: $$services"; \
@@ -162,6 +167,11 @@ quickstart:
 		echo "🔄 Creating $$CONFIG_FILE file from config.example.yml and using it"; \
 		cp config.example.yml "$$CONFIG_FILE"; \
 	fi'
+
+	@if [ ! -f $(compose) ]; then \
+		echo "🔄 Creating $(compose) file from compose.example.yml and using it"; \
+		cp compose.example.yml $(compose); \
+	fi
 
 	@# Start services
 	@echo "🚀 Starting services with $(env) file and $(compose) file"; \

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -1,7 +1,6 @@
 name: opengatellm
 
 services:
-# quickstart services --------------------------------------------------------------------------------------------------------------------------------
   api:
     image: ghcr.io/etalab-ia/opengatellm/app:latest
     restart: always


### PR DESCRIPTION
### Objet
**Rendre `make dev` et `make quickstart` plus robustes en créant automatiquement le fichier Docker Compose si absent, et nettoyer un commentaire obsolète.**

### Contexte
Actuellement, si le fichier pointé par `$(compose)` n’existe pas, les commandes échouent ou nécessitent une config manuelle. Cette PR automatise la création à partir de `compose.example.yml` pour améliorer l’onboarding et la DX.

### Changements principaux
- **Makefile**
  - Dans les cibles `dev` et `quickstart`, ajout d’un garde-fou:
    - Si `$(compose)` est absent, copier `compose.example.yml` vers `$(compose)` et l’utiliser.
    - Message explicite affiché lors de la création.
- **compose.example.yml**
  - **Suppression** d’un commentaire long et non pertinent.