### PR TITLE
fix: auth playground

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ CONFIG_FILE=./config.yml
 # Playground
 ## replace API_HOST by localhost for local development
 API_HOST=api
-API_PORT=8080
 
 # Dependencies
 ## replace POSTGRES_HOST by localhost for local development

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"85.49%","color":"green"}
+{"schemaVersion":1,"label":"coverage","message":"85.53%","color":"green"}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ It is recommended to use a Python [virtualenv](https://docs.python.org/3/library
 2. Create a *env* file based on the example environment file *[env.example](./env.example)*
 
   ```bash
-  cp env.example .env
+  cp .env.example .env
   ```
 
 3. Replace host names variables by `localhost` like this:

--- a/Makefile
+++ b/Makefile
@@ -46,47 +46,55 @@ help:
 	@echo "╚██████╔╝██║     ███████╗██║ ╚████║╚██████╔╝██║  ██║   ██║   ███████╗███████╗███████╗██║ ╚═╝ ██║"
 	@echo " ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝╚══════╝╚══════╝╚═╝     ╚═╝"
 	@echo ""
+	@echo "┌─────────────────────────────────────────────────────────────────┐"
+	@echo "│                        🚀 Services ready                        │"
+	@echo "├─────────────────────────────────────────────────────────────────┤"
+
+	@if [ "$(service)" = "api" ]; then \
+		echo "│ ▶️  API URL: http://localhost:8080                               │"; \
+	elif [ "$(service)" = "playground" ]; then \
+		echo "│ ▶️  Playground URL: http://localhost:8501                        │"; \
+	elif [ "$(service)" = "both" ]; then \
+		echo "│ ▶️  API URL: http://localhost:8080                               │"; \
+		echo "│ ▶️  Playground URL: http://localhost:8501                        │"; \
+	fi
+	@if [ "$(command)" = "quickstart" ]; then \
+		echo "│ ⏸️  Execute 'make quickstart action=down' to stop services       │"; \
+	elif [ "$(command)" = "start" ]; then \
+		echo "│ ⏸️   Press Ctrl+C to stop all services                           │"; \
+	fi
+	@echo "└─────────────────────────────────────────────────────────────────┘"
+	@echo ""
 
 .start:
 	@if [ "$(service)" = "api" ]; then \
-		$(MAKE) .banner; \
-		echo "┌─────────────────────────────────────────────────────────────────┐"; \
-		echo "│                        🚀 Services ready                        │"; \
-		echo "├─────────────────────────────────────────────────────────────────┤"; \
-		echo "│ ▶️  API URL: http://localhost:8080                               │"; \
-		echo "│ ⏸️  Press Ctrl+C to stop all services                            │"; \
-		echo "└─────────────────────────────────────────────────────────────────┘"; \
-		echo ""; \
-		bash -c 'set -a; . $(env); GUNICORN_CMD_ARGS="--reload --log-level debug --access-logfile - --error-logfile -" ./scripts/startup_api.sh'; \
+		$(MAKE) .banner command=start; \
+		$(MAKE) .start-api; \
 		wait; \
 	elif [ "$(service)" = "playground" ]; then \
-		$(MAKE) .banner; \
-		echo "┌─────────────────────────────────────────────────────────────────┐"; \
-		echo "│                        🚀 Services ready                        │"; \
-		echo "├─────────────────────────────────────────────────────────────────┤"; \
-		echo "│ ▶️  Playground URL: http://localhost:8081                        │"; \
-		echo "│ ⏸️  Press Ctrl+C to stop all services                            │"; \
-		echo "└─────────────────────────────────────────────────────────────────┘"; \
-		echo ""; \
-		bash -c 'set -a; . $(env); STREAMLIT_CMD_ARGS="--server.port 8081" ./scripts/startup_ui.sh'; \
+		$(MAKE) .banner command=start; \
+		$(MAKE) .start-playground; \
 		wait; \
 	elif [ "$(service)" = "both" ]; then \
-		$(MAKE) .banner; \
-		echo "┌─────────────────────────────────────────────────────────────────┐"; \
-		echo "│                        🚀 Services ready                        │"; \
-		echo "├─────────────────────────────────────────────────────────────────┤"; \
-		echo "│ ▶️  API URL: http://localhost:8080                               │"; \
-		echo "│ ▶️  Playground URL: http://localhost:8081                        │"; \
-		echo "│ ⏸️  Press Ctrl+C to stop all services                            │"; \
-		echo "└─────────────────────────────────────────────────────────────────┘"; \
-		echo ""; \
-		bash -c 'set -a; . $(env); GUNICORN_CMD_ARGS="--reload --log-level debug --access-logfile - --error-logfile -" ./scripts/startup_api.sh' & \
-		bash -c 'set -a; . $(env); STREAMLIT_CMD_ARGS="--server.port 8081" ./scripts/startup_ui.sh' & \
+		$(MAKE) .banner command=start; \
+		$(MAKE) .start-api & \
+		$(MAKE) .start-playground & \
 		wait; \
 	else \
 		echo "❌ Error: service must be 'api' or 'playground' or 'both'"; \
 		exit 1; \
 	fi
+
+
+
+.start-api:
+	@mkdir -p ~/.streamlit/
+	@echo "[general]"  > ~/.streamlit/credentials.toml
+	@echo "email = \"\""  >> ~/.streamlit/credentials.toml
+	@bash -c 'set -a; . $(env); GUNICORN_CMD_ARGS="--reload --log-level debug --access-logfile - --error-logfile -" ./scripts/startup_api.sh'
+
+.start-playground:
+	@bash -c 'set -a; . $(env); ./scripts/startup_ui.sh'
 
 .docker-compose:
 	@if [ "$(action)" = "up" ]; then \
@@ -96,7 +104,6 @@ help:
 	elif [ "$(action)" = "down" ]; then \
 		docker compose --env-file $(env) --file $(compose) down; \
 	fi
-	
 
 .check-service-status:
 	@echo "🐳 Checking if $(service) container is running..."; \
@@ -130,7 +137,6 @@ dev:
 
 	@# Start services
 	@services=$$(docker compose --file $(compose) config --services | grep -v -E '^(api|playground)$$' | tr '\n' ' '); \
-	echo "🔄 Starting services: $$services"; \
 	echo "🚀 Starting services with $(env) file and $(compose) file"; \
 	if [ "$(service)" = "api" ]; then \
 		trap 'echo "🛑 Stopping all services..."; kill $$(jobs -p) 2>/dev/null; $(MAKE) .docker-compose env=$(env) compose=$(compose) action=down; exit' INT TERM; \
@@ -153,6 +159,7 @@ dev:
 		echo "Use 'make help' for more information."; \
 		exit 1; \
 	fi
+	
 
 # quickstart -----------------------------------------------------------------------------------------------------------------------------------------
 quickstart:
@@ -178,15 +185,7 @@ quickstart:
 	if [ "$(action)" = "up" ]; then \
 		$(MAKE) .docker-compose env=$(env) compose=$(compose) action=up; \
 		if $(MAKE) --silent .check-service-status service=api env=$(env) compose=$(compose) && $(MAKE) --silent .check-service-status service=playground env=$(env) compose=$(compose); then \
-			$(MAKE) .banner; \
-			echo "┌─────────────────────────────────────────────────────────────────┐"; \
-			echo "│                        🚀 Services ready                        │"; \
-			echo "├─────────────────────────────────────────────────────────────────┤"; \
-			echo "│ ▶️  API URL: http://localhost:8080                               │"; \
-			echo "│ ▶️  Playground URL: http://localhost:8081                        │"; \
-			echo "│ ⏸️  Execute 'make quickstart action=down' to stop services       │"; \
-			echo "└─────────────────────────────────────────────────────────────────┘"; \
-			echo ""; \
+			$(MAKE) .banner command=quickstart service=both; \
 		fi; \
 	elif [ "$(action)" = "down" ]; then \
 		$(MAKE) .docker-compose env=$(env) compose=$(compose) action=down; \

--- a/app/schemas/core/configuration.py
+++ b/app/schemas/core/configuration.py
@@ -292,14 +292,13 @@ class RedisDependency(ConfigBaseModel):
 
 
 class ProConnect(ConfigBaseModel):
-    client_id: str = Field(default="")
-    client_secret: str = Field(default="")
-    # OpenID Connect discovery endpoint for server metadata
-    server_metadata_url: str = Field(default="https://identite-sandbox.proconnect.gouv.fr/.well-known/openid-configuration")
-    redirect_uri: str = Field(default="https://albert.api.etalab.gouv.fr/v1/oauth2/callback")
-    scope: str = Field(default="openid email given_name usual_name siret organizational_unit belonging_population chorusdt")
+    client_id: str = Field(default="", description="Client ID for the ProConnect application.")  # fmt: off
+    client_secret: str = Field(default="", description="Client secret for the ProConnect application.")  # fmt: off
+    server_metadata_url: str = Field(default="https://identite-sandbox.proconnect.gouv.fr/.well-known/openid-configuration", description="OpenID Connect discovery endpoint for server metadata.")  # fmt: off
+    redirect_uri: str = Field(default="https://albert.api.etalab.gouv.fr/v1/oauth2/callback", description="Redirect URI for the ProConnect application.")  # fmt: off
+    scope: str = Field(default="openid email given_name usual_name siret organizational_unit belonging_population chorusdt", description="Scope for the ProConnect application.")  # fmt: off
     allowed_domains: str = Field(default="localhost,gouv.fr", description="List of allowed domains for OAuth2 login. This is used to restrict the domains that can use the OAuth2 login flow.")  # fmt: off
-    default_role: str = Field(default="Freemium", description="Default role assigned to users when they log in for the first time.")
+    default_role: str = Field(default="Freemium", description="Default role assigned to users when they log in for the first time.")  # fmt: off
 
 
 @custom_validation_error(url="https://github.com/etalab-ia/albert-api/blob/main/docs/configuration.md#dependencies")
@@ -407,7 +406,7 @@ class Settings(ConfigBaseModel):
     mcp_max_iterations: int = Field(default=2, ge=2, description="Maximum number of iterations for MCP agents in `/v1/agents/completions` endpoint.")  # fmt: off
 
     # auth
-    auth_master_key: constr(strip_whitespace=True, min_length=1) = Field(default="changeme", required=False, description="Master key for the API. This key has all permissions and cannot be modified or deleted. This key is used to create the first role and the first user. This key is also used to encrypt user tokens, watch out if you modify the master key, you'll need to update all user API keys.")  # fmt: off
+    auth_master_key: constr(strip_whitespace=True, min_length=1) = Field(default="changeme", required=False, description="Master key for the API. It should be a random string with at least 32 characters. This key has all permissions and cannot be modified or deleted. This key is used to create the first role and the first user. This key is also used to encrypt user tokens, watch out if you modify the master key, you'll need to update all user API keys.")  # fmt: off
     auth_max_token_expiration_days: Optional[int] = Field(default=None, ge=1, description="Maximum number of days for a token to be valid.")  # fmt: off
 
     # rate_limiting
@@ -432,9 +431,6 @@ class Settings(ConfigBaseModel):
     # session
     session_secret_key: Optional[str] = Field(default=None, description='Secret key for session middleware. If not provided, the master key will be used.', examples=["knBnU1foGtBEwnOGTOmszldbSwSYLTcE6bdibC8bPGM"])  # fmt: off
 
-    # oauth2
-    oauth2_encryption_key: Optional[str] = Field(default=None, description="Secret key for encrypting between API and Playground. If not provided, the master key will be used.", examples=["changeme"])  # fmt: off
-
     front_url: str = Field(default="http://localhost:8501", description="Front-end URL for the application.")
 
     @model_validator(mode="after")
@@ -442,9 +438,9 @@ class Settings(ConfigBaseModel):
         if values.session_secret_key is None:
             logging.warning("Session secret key not provided, using master key.")  # fmt: off
             values.session_secret_key = values.auth_master_key
-        if values.oauth2_encryption_key is None:
-            logging.warning("OAuth2 encryption key not provided, using master key.")  # fmt: off
-            values.oauth2_encryption_key = values.auth_master_key
+
+        if len(values.auth_master_key) < 32:
+            logging.warning("Auth master key is too short for production, it should be at least 32 characters.")  # fmt: off
 
         return values
 

--- a/app/tests/integ/config.test.yml
+++ b/app/tests/integ/config.test.yml
@@ -125,7 +125,6 @@ dependencies:
 # ---------------------------------- settings -----------------------------------
 settings:
   session_secret_key: -ftzKBct7qN22sgnkI9ApWD2ny_dHQVlPd2OPDSk5MM
-  oauth2_encryption_key: 5Uwc8CRD5cca8D8_tB5zrgLdXk7sWz3foaeHBuc17eg=
   usage_tokenizer: tiktoken_gpt2
   log_level: DEBUG
   auth_max_token_expiration_days: 365

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -27,7 +27,7 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeme}"
       - "TZ=Europe/Paris"
     ports:
-      - 8081:8501
+      - 8501:8501
     volumes:
       - "./${CONFIG_FILE:-config.yml}:/config.yml:ro"
     depends_on:

--- a/config.example.yml
+++ b/config.example.yml
@@ -52,7 +52,6 @@ dependencies:
 # ---------------------------------- settings -----------------------------------
 settings:
   # session_secret_key: # optional
-  # oauth2_encryption_key: # optional
 
   # disabled_routers: # optional - default: [] - values: ["agents", "audio", "chat", "chunks", "collections", "completions", "documents", "embeddings", "files", "models", "ocr", "parse", "rerank", "roles", "search", "tokens", "users", "usage"]
 
@@ -95,7 +94,18 @@ playground:
   postgres:
     url: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/playground
   
-  # oauth2_encryption_key: # optional - default: master key
-  # proconnect_enabled: ${PROCONNECT_ENABLED:-False}  # Enable or disable ProConnect integration
-  # auth_master_username: master # optional - default: master
-  # auth_master_key: changeme # optional - default: changeme
+
+
+  # auth_master_username: # optional - default: master
+  # auth_master_key: # optional - default: changeme
+  # auth_max_token_expiration_days: # optional - default: None, ex: 365
+  # home_url: # optional - default: http://localhost:8501
+  # page_icon: # optional - default: https://github.com/etalab-ia/opengatellm/blob/main/docs/assets/logo.png?raw=true
+  # menu_items: # optional - default: MenuItems()
+  #   get_help: # optional - default: None
+  #   report_a_bug: # optional - default: None
+  #   about: # optional - default: None
+  # logo: # optional - default: https://github.com/etalab-ia/opengatellm/blob/main/docs/assets/logo.png?raw=true
+  # cache_ttl: # optional - default: 1800  # 30 minutes
+  # default_model: # optional - default: None
+  # proconnect_enabled: # optional - default: False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ Refer to the [configuration example file](../../../config.example.yml) for an ex
 ## Settings
 | Attribute | Type | Description | Required | Default | Values | Examples |
 | --- | --- | --- | --- | --- | --- | --- |
+| auth_encryption_key | string | Secret key for encrypting between API and Playground. If not provided, the master key will be used. |  | None |  | changeme |
 | auth_master_key | string | Master key for the API. This key has all permissions and cannot be modified or deleted. This key is used to create the first role and the first user. This key is also used to encrypt user tokens, watch out if you modify the master key, you'll need to update all user API keys. | False | changeme |  |  |
 | auth_max_token_expiration_days | integer | Maximum number of days for a token to be valid. |  | None |  |  |
 | disabled_routers | array | Disabled routers to limits services of the API. |  |  | • agents<br/>• audio<br/>• auth<br/>• chat<br/>• chunks<br/>• collections<br/>• completions<br/>• deepsearch<br/>• ... | ['agents', 'embeddings'] |
@@ -23,7 +24,6 @@ Refer to the [configuration example file](../../../config.example.yml) for an ex
 | metrics_retention_ms | integer | Retention time for metrics in milliseconds. |  | 40000 |  |  |
 | monitoring_postgres_enabled | boolean | If true, the log usage will be written in the PostgreSQL database. | False | True |  |  |
 | monitoring_prometheus_enabled | boolean | If true, Prometheus metrics will be exposed in the `/metrics` endpoint. | False | True |  |  |
-| oauth2_encryption_key | string | Secret key for encrypting between API and Playground. If not provided, the master key will be used. |  | None |  | changeme |
 | rate_limiting_strategy | string | Rate limiting strategy for the API. | False | fixed_window | • moving_window<br/>• fixed_window<br/>• sliding_window |  |
 | search_multi_agents_reranker_model | string | Model used to rerank the results of multi-agents search. If not provided, multi-agents search is disabled. This model must be defined in the `models` section and have type `text-generation` or `image-text-to-text`. | False | None |  |  |
 | search_multi_agents_synthesis_model | string | Model used to synthesize the results of multi-agents search. If not provided, multi-agents search is disabled. This model must be defined in the `models` section and have type `text-generation` or `image-text-to-text`. | False | None |  |  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,8 +13,7 @@ Refer to the [configuration example file](../../../config.example.yml) for an ex
 ## Settings
 | Attribute | Type | Description | Required | Default | Values | Examples |
 | --- | --- | --- | --- | --- | --- | --- |
-| auth_encryption_key | string | Secret key for encrypting between API and Playground. If not provided, the master key will be used. |  | None |  | changeme |
-| auth_master_key | string | Master key for the API. This key has all permissions and cannot be modified or deleted. This key is used to create the first role and the first user. This key is also used to encrypt user tokens, watch out if you modify the master key, you'll need to update all user API keys. | False | changeme |  |  |
+| auth_master_key | string | Master key for the API. It should be a random string with at least 32 characters. This key has all permissions and cannot be modified or deleted. This key is used to create the first role and the first user. This key is also used to encrypt user tokens, watch out if you modify the master key, you'll need to update all user API keys. | False | changeme |  |  |
 | auth_max_token_expiration_days | integer | Maximum number of days for a token to be valid. |  | None |  |  |
 | disabled_routers | array | Disabled routers to limits services of the API. |  |  | • agents<br/>• audio<br/>• auth<br/>• chat<br/>• chunks<br/>• collections<br/>• completions<br/>• deepsearch<br/>• ... | ['agents', 'embeddings'] |
 | front_url | string | Front-end URL for the application. |  | http://localhost:8501 |  |  |
@@ -128,12 +127,12 @@ See https://github.com/SecretiveShell/MCP-Bridge for more information.
 | Attribute | Type | Description | Required | Default | Values | Examples |
 | --- | --- | --- | --- | --- | --- | --- |
 | allowed_domains | string | List of allowed domains for OAuth2 login. This is used to restrict the domains that can use the OAuth2 login flow. |  | localhost,gouv.fr |  |  |
-| client_id | string |  |  |  |  |  |
-| client_secret | string |  |  |  |  |  |
+| client_id | string | Client ID for the ProConnect application. |  |  |  |  |
+| client_secret | string | Client secret for the ProConnect application. |  |  |  |  |
 | default_role | string | Default role assigned to users when they log in for the first time. |  | Freemium |  |  |
-| redirect_uri | string |  |  | https://albert.api.etalab.gouv.fr/v1/oauth2/callback |  |  |
-| scope | string |  |  | openid email given_name usual_name siret organizational_unit belonging_population chorusdt |  |  |
-| server_metadata_url | string |  |  | https://identite-sandbox.proconnect.gouv.fr/.well-known/openid-configuration |  |  |
+| redirect_uri | string | Redirect URI for the ProConnect application. |  | https://albert.api.etalab.gouv.fr/v1/oauth2/callback |  |  |
+| scope | string | Scope for the ProConnect application. |  | openid email given_name usual_name siret organizational_unit belonging_population chorusdt |  |  |
+| server_metadata_url | string | OpenID Connect discovery endpoint for server metadata. |  | https://identite-sandbox.proconnect.gouv.fr/.well-known/openid-configuration |  |  |
 
 <br>
 

--- a/docs/oauth2_encryption.md
+++ b/docs/oauth2_encryption.md
@@ -33,7 +33,7 @@ oauth2:
 ```yaml
 playground:
   api_url: http://localhost:8000
-  oauth2_encryption_key: YOUR_GENERATED_KEY_HERE  # Same key as the backend
+  auth_encryption_key: YOUR_GENERATED_KEY_HERE  # Same key as the backend
 ```
 
 ## Security

--- a/docs/proconnect.md
+++ b/docs/proconnect.md
@@ -142,7 +142,7 @@ Add the following to your UI `config.yml`:
 ```yaml
 playground:
   api_url: "http://localhost:8000"  # Albert API base URL
-  oauth2_encryption_key: "YOUR_GENERATED_KEY_HERE"  # Same key as backend
+  auth_encryption_key: "YOUR_GENERATED_KEY_HERE"  # Same key as backend
   proconnect_enabled: true
 ```
 

--- a/ui/configuration.py
+++ b/ui/configuration.py
@@ -21,7 +21,9 @@ class MenuItems(ConfigBaseModel):
 
 class Playground(ConfigBaseModel):
     auth_master_username: str = "master"
+    auth_master_key: str = "changeme"
     auth_max_token_expiration_days: Optional[int] = Field(default=None, ge=0)
+    auth_encryption_key: Optional[str] = Field(default="changeme", description="Secret key for encrypting between FastAPI and Playground. Must be 32 url-safe base64-encoded bytes.")  # fmt: off
     api_url: str = "http://localhost:8080"
     home_url: str = "http://localhost:8501"
     page_icon: str = "https://github.com/etalab-ia/opengatellm/blob/main/docs/assets/logo.png?raw=true"
@@ -29,8 +31,7 @@ class Playground(ConfigBaseModel):
     logo: str = "https://github.com/etalab-ia/opengatellm/blob/main/docs/assets/logo.png?raw=true"
     cache_ttl: int = 1800  # 30 minutes
     postgres: dict = {}
-    default_model: Optional[str] = "albert-small"
-    encryption_key: Optional[str] = Field(default=None, description="Secret key for encrypting between FastAPI and Playground. Must be 32 url-safe base64-encoded bytes.")  # fmt: off
+    default_model: Optional[str] = None
     proconnect_enabled: bool = False
 
     @field_validator("postgres", mode="after")


### PR DESCRIPTION
### Objet
Unifier et sécuriser le chiffrement entre l’API et le Playground pour l’authentification (ProConnect), simplifier la configuration, et harmoniser les ports/commandes de démarrage en local et via Docker.

### Principaux changements
- Sécurité/chiffrement
  - Remplacement de la clé `oauth2_encryption_key` par l’usage de la clé maître `auth_master_key` pour le chiffrement API ⇄ Playground. Cela permet de minimiser la configuration.
  - Dérivation de clé via PBKDF2-HMAC-SHA256 (32 bytes, salt fixe, 310000 itérations) avant utilisation par `Fernet`. Cela permet d'avoir un chiffrement plus fort si la master key a peu d'entropie. 
  - Avertissement si `auth_master_key` < 32 caractères en configuration.
- Configuration et docs
  - Suppression de `settings.oauth2_encryption_key` côté API (schemas et config de test).
  - Ajout/clarifications dans la doc: `auth_encryption_key` (docs UI) et renforcement des consignes sur `auth_master_key`.
  - Correction dans le guide de contribution: `cp .env.example .env`.
- Playground et UI
  - Le Playground chiffre/déchiffre désormais avec `playground.auth_master_key` (aligné sur l’API).
  - Ajout de champs `auth_master_key` et `auth_encryption_key` dans `ui/configuration.py` (par défaut `changeme`), retrait de `encryption_key`.
  - `default_model` par défaut passe à `None` (au lieu de `albert-small`).
- Démarrage et ports
  - Harmonisation du port du Playground: 8501 (local et Docker).
  - `compose.example.yml`: mapping `8501:8501` au lieu de `8081:8501`.
  - Retrait de `API_PORT` de `.env.example`.
  - Refonte Makefile:
    - Bannières unifiées et messages dynamiques selon `service`/`command`.
    - Nouvelles cibles: `.start-api` et `.start-playground`.
    - `make dev service=api|playground|both` lance les services appropriés; `make quickstart action=up|down` affiche la bannière consolidée.
- Tests
  - Mises à jour des tests unitaires ProConnect: `get_fernet(key=...)`, suppression des cas liés à la clé par défaut/clé invalide dédiée.
  - Nettoyage de la config d’intégration (suppression `oauth2_encryption_key`).

### Détails techniques
- Backend: `app/endpoints/proconnect/encryption.py`
  - `get_fernet(key: str)` dérive la clé via PBKDF2-HMAC-SHA256 et l’encode URL-safe avant `Fernet`.
  - Toutes les opérations d’encrypt/decrypt ProConnect utilisent désormais `configuration.settings.auth_master_key`.
- UI: `ui/backend/login.py`
  - `get_fernet(key: str)` avec PBKDF2-HMAC-SHA256, usage de `configuration.playground.auth_master_key`.
  - Les fonctions d’encrypt/decrypt du token OAuth2 utilisent cette clé.
- Schemas: `app/schemas/core/configuration.py`
  - Suppression du champ `oauth2_encryption_key`.
  - Avertissement si `auth_master_key` trop courte.

### Migration (breaking change)
- Supprimer `settings.oauth2_encryption_key` de votre `config.yml` et de toute variable d’environnement.
- Vérifier que `settings.auth_master_key` est défini avec au moins 32 caractères (aléatoires en production).
- Côté UI:
  - Définir `playground.auth_master_key` avec la même valeur que l’API.
  - Les références à `oauth2_encryption_key` dans la config UI sont remplacées dans la doc par `auth_encryption_key`, mais le chiffrement courant s’aligne sur `auth_master_key`. Exemple minimal côté UI:
```yaml
playground:
  api_url: http://localhost:8080
  auth_master_key: YOUR_STRONG_RANDOM_KEY  # même clé que l’API
```
- Ports:
  - Adapter vos proxies/configs: le Playground écoute sur 8501 (Docker: `8501:8501`).

### Vérifications attendues
- Auth ProConnect: login, callback, logout toujours fonctionnels (token chiffré/déchiffré correctement).
- UI Playground: ouverture de session et récupération de la clé API OK.
- `make dev` et `make quickstart` affichent bien les bannières et URLs:
  - API: `http://localhost:8080`
  - Playground: `http://localhost:8501`

### Notes diverses
- Correction doc/Contrib: `cp .env.example .env`.
- La doc de config liste désormais `auth_encryption_key` (UI), tandis que l’API utilise `auth_master_key` pour ce flux.

- Changements clés couverts: remplacement de `oauth2_encryption_key` par `auth_master_key`, KDF PBKDF2-HMAC-SHA256, port du Playground → 8501, Makefile refactor, docs et tests mis à jour.