### PR TITLE
Add item count validation and batch size limits for embeddings and rerank requests

### DIFF
--- a/api/clients/model/_teimodelclient.py
+++ b/api/clients/model/_teimodelclient.py
@@ -76,6 +76,9 @@ class TeiModelClient(BaseModelClient):
 
         # set attributes of the model
         self.max_context_length = response.get("max_input_length")
+        # TEI server-reported client batch limit (number of items per request)
+        # None means no explicit limit provided by the server
+        self.max_items = response.get("max_client_batch_size")
 
         # set vector size
         response = requests.post(

--- a/api/endpoints/embeddings.py
+++ b/api/endpoints/embeddings.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Security
+from fastapi import APIRouter, Request, Security, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.helpers._accesscontroller import AccessController
@@ -16,6 +16,34 @@ async def embeddings(request: Request, body: EmbeddingsRequest) -> JSONResponse:
     """
 
     async def handler(client):
+        # Compute number of items in the request according to OpenAI-compatible schema
+        input_data = body.input
+
+        def count_items(inp) -> int:
+            # A single string or a single token array (List[int]) counts as 1 item
+            if isinstance(inp, str):
+                return 1
+            if isinstance(inp, list):
+                if len(inp) == 0:
+                    return 0
+                first = inp[0]
+                # List[str] or List[List[int]] => multiple items
+                if isinstance(first, str) or isinstance(first, list):
+                    return len(inp)
+                # List[int] (tokens) => single item
+                return 1
+            # Fallback: treat anything else as a single item
+            return 1
+
+        items_count = count_items(input_data)
+        max_items = getattr(client, "max_items", None)
+
+        if max_items is not None and items_count > max_items:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Too many items in embeddings request: {items_count} provided, maximum allowed is {max_items}. Split the batch into chunks of at most {max_items} items.",
+            )
+
         response = await client.forward_request(method="POST", json=body.model_dump())
         return JSONResponse(content=Embeddings(**response.json()).model_dump(), status_code=response.status_code)
 

--- a/api/endpoints/rerank.py
+++ b/api/endpoints/rerank.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Security
+from fastapi import APIRouter, Request, Security, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.helpers._accesscontroller import AccessController
@@ -16,6 +16,16 @@ async def rerank(request: Request, body: RerankRequest) -> JSONResponse:
     """
     model = await global_context.model_registry(model=body.model)
     client = model.get_client(endpoint=ENDPOINT__RERANK)
+
+    # Validate batch size against client's max_items if provided
+    items_count = len(body.input)
+    max_items = getattr(client, "max_items", None)
+    if max_items is not None and items_count > max_items:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many items in rerank request: {items_count} provided, maximum allowed is {max_items}. Split the batch into chunks of at most {max_items} texts.",
+        )
+
     response = await client.forward_request(method="POST", json=body.model_dump())
 
     return JSONResponse(content=Reranks(**response.json()).model_dump(), status_code=response.status_code)

--- a/api/tests/unit/test_endpoints/test_embeddings_and_rerank_limits.py
+++ b/api/tests/unit/test_endpoints/test_embeddings_and_rerank_limits.py
@@ -1,0 +1,136 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.utils.context import global_context
+from api.tests.unit.test_endpoints.mock import MockIdentityAccessManagerSuccess
+
+
+class FakeLimiter:
+    async def hit(self, user_id, model, type, value, cost: int | None = None):
+        return True
+
+    async def remaining(self, user_id, model, type, value):
+        return value
+
+
+class FakeTokenizer:
+    def get_prompt_tokens(self, endpoint, body):
+        return 0
+
+
+class FakeClient:
+    def __init__(self, max_items: int):
+        self.max_items = max_items
+
+    async def forward_request(self, method: str, json: dict, files=None, data=None, additional_data=None):
+        # Return a minimal successful response shape where needed
+        if json.get("input") is not None and json.get("prompt") is None:  # embeddings
+            payload = {
+                "object": "list",
+                "data": [
+                    {"object": "embedding", "index": 0, "embedding": [0.0, 0.1, 0.2]},
+                ],
+                "model": json.get("model", "test-embeddings"),
+                "usage": {"prompt_tokens": 0, "total_tokens": 0},
+            }
+        else:  # rerank
+            payload = {
+                "id": "test-rerank",
+                "object": "list",
+                "data": [{"object": "rerank", "index": 0, "score": 0.5}],
+                "usage": {"prompt_tokens": 0, "total_tokens": 0},
+            }
+
+        return SimpleNamespace(status_code=200, json=lambda: payload, headers={}, request=None)
+
+
+class FakeModel:
+    def __init__(self, max_items: int):
+        self.max_items = max_items
+        self.cost_prompt_tokens = 0.0
+        self.cost_completion_tokens = 0.0
+
+    async def safe_client_access(self, endpoint, handler):
+        client = FakeClient(self.max_items)
+        return await handler(client)
+
+    def get_client(self, endpoint):
+        return FakeClient(self.max_items)
+
+
+class FakeModelRegistry:
+    def __init__(self):
+        self.models = ["test-embeddings", "test-rerank"]
+        self.aliases = {}
+
+    async def __call__(self, model: str):
+        # Different limits per model
+        max_items_by_model = {"test-embeddings": 2, "test-rerank": 3}
+        return FakeModel(max_items=max_items_by_model.get(model, 2))
+
+
+@pytest.fixture(autouse=True)
+def setup_context():
+    # Inject minimal context for AccessController and model lookup
+    global_context.identity_access_manager = MockIdentityAccessManagerSuccess()
+    global_context.model_registry = FakeModelRegistry()
+    global_context.limiter = FakeLimiter()
+    global_context.tokenizer = FakeTokenizer()
+    yield
+
+
+def test_embeddings_too_many_items_returns_400():
+    client = TestClient(app)
+    headers = MockIdentityAccessManagerSuccess.HEADERS
+
+    # max_items for test-embeddings is 2; send 3 items
+    body = {"model": "test-embeddings", "input": ["a", "b", "c"]}
+    res = client.post("/v1/embeddings", json=body, headers=headers)
+
+    assert res.status_code == 400
+    assert "Too many items in embeddings request" in res.json()["detail"]
+    assert "maximum allowed is 2" in res.json()["detail"]
+
+
+def test_rerank_too_many_items_returns_400():
+    client = TestClient(app)
+    headers = MockIdentityAccessManagerSuccess.HEADERS
+
+    # max_items for test-rerank is 3; send 4 items
+    body = {"model": "test-rerank", "prompt": "q", "input": ["t1", "t2", "t3", "t4"]}
+    res = client.post("/v1/rerank", json=body, headers=headers)
+
+    assert res.status_code == 400
+    assert "Too many items in rerank request" in res.json()["detail"]
+    assert "maximum allowed is 3" in res.json()["detail"]
+
+
+def test_embeddings_within_limit_returns_200():
+    client = TestClient(app)
+    headers = MockIdentityAccessManagerSuccess.HEADERS
+
+    # max_items for test-embeddings is 2; send 2 items
+    body = {"model": "test-embeddings", "input": ["a", "b"]}
+    res = client.post("/v1/embeddings", json=body, headers=headers)
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["object"] == "list"
+    assert "data" in data
+
+
+def test_rerank_within_limit_returns_200():
+    client = TestClient(app)
+    headers = MockIdentityAccessManagerSuccess.HEADERS
+
+    # max_items for test-rerank is 3; send 3 items
+    body = {"model": "test-rerank", "prompt": "q", "input": ["t1", "t2", "t3"]}
+    res = client.post("/v1/rerank", json=body, headers=headers)
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["object"] == "list"
+    assert "data" in data

--- a/docs/models.md
+++ b/docs/models.md
@@ -24,6 +24,8 @@ Si vous souhaitez déployer un modèle d'embeddings, vous recommandons d'utilise
 
 **⚠️ Le déploiement de l'API est conditionné à la fourniture d'un modèle d'embeddings.**
 
+Note sur la taille des lots (batch): l’API vérifie le nombre d’éléments fournis dans `input` (texte(s) ou liste de tokens) et renvoie une erreur 400 si ce nombre dépasse la limite maximale autorisée par le modèle (valeur exposée par le serveur TEI via l’endpoint `/info`, champ `max_client_batch_size`). Scindez vos entrées en lots d’au plus cette taille pour éviter l’erreur.
+
 ## automatic-speech-recognition
 
 Pour les modèles de transcription audio, vous pouvez utiliser n'importe quel API compatible avec le format [OpenAI](https://platform.openai.com/docs/api-reference/audio/create-transcription), c'est-à-dire disposant d'un endpoint `/v1/audio/transcriptions`.
@@ -39,3 +41,5 @@ Pour les modèles de reranking, vous devez une API compatible avec le format pro
 Si vous souhaitez déployer un modèle de reranking, vous recommandons d'utiliser [HuggingFace Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference). Exemple de modèle de reranking : [bge-reranker-v2-m3](https://huggingface.co/BAAI/bge-reranker-v2-m3).
 
 Le déploiement de l'API n'est pas conditionné à la fourniture d'un modèle de reranking.
+
+Note sur la taille des lots (batch): l’API vérifie le nombre de textes fournis dans `input` et renvoie une erreur 400 si ce nombre dépasse la limite maximale autorisée par le modèle (valeur exposée par le serveur TEI via l’endpoint `/info`, champ `max_client_batch_size`). Scindez vos entrées en lots d’au plus cette taille pour éviter l’erreur.


### PR DESCRIPTION
Introduce a maximum items attribute to the TeiModelClient to enforce server-reported batch limits. Implement validation for item counts in embeddings and rerank requests, ensuring requests do not exceed the specified limits. Add tests to verify these validations and update documentation to reflect batch size considerations.