### PR TITLE
Fix idle_in_transaction sql sessions

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"80.94%","color":"green"}
+{"schemaVersion":1,"label":"coverage","message":"80.87%","color":"green"}

--- a/api/clients/vector_store/_elasticsearchvectorstoreclient.py
+++ b/api/clients/vector_store/_elasticsearchvectorstoreclient.py
@@ -43,13 +43,7 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
 
         mappings = {
             "dynamic_templates": [
-                {
-                    "metadata_objects_disabled": {
-                        "path_match": "metadata.*",
-                        "match_mapping_type": "object",
-                        "mapping": {"enabled": False}
-                    }
-                },
+                {"metadata_objects_disabled": {"path_match": "metadata.*", "match_mapping_type": "object", "mapping": {"enabled": False}}},
                 {
                     "metadata_dates_by_name": {
                         "path_match": "metadata.*",
@@ -58,38 +52,32 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
                         "mapping": {
                             "type": "date",
                             "ignore_malformed": True,
-                            "format": "strict_date_optional_time||strict_date_time||yyyy-MM-dd'T'HH:mm:ssZ||epoch_millis"
-                        }
+                            "format": "strict_date_optional_time||strict_date_time||yyyy-MM-dd'T'HH:mm:ssZ||epoch_millis",
+                        },
                     }
                 },
-                {
-                    "metadata_bools": {
-                        "path_match": "metadata.*",
-                        "match_mapping_type": "boolean",
-                        "mapping": {"type": "boolean"}
-                    }
-                },
+                {"metadata_bools": {"path_match": "metadata.*", "match_mapping_type": "boolean", "mapping": {"type": "boolean"}}},
                 {
                     "metadata_numbers_long": {
                         "path_match": "metadata.*",
                         "match_mapping_type": "long",
-                        "mapping": {"type": "long", "ignore_malformed": True, "coerce": True}
+                        "mapping": {"type": "long", "ignore_malformed": True, "coerce": True},
                     }
                 },
                 {
                     "metadata_numbers_double": {
                         "path_match": "metadata.*",
                         "match_mapping_type": "double",
-                        "mapping": {"type": "double", "ignore_malformed": True, "coerce": True}
+                        "mapping": {"type": "double", "ignore_malformed": True, "coerce": True},
                     }
                 },
                 {
                     "metadata_strings": {
                         "path_match": "metadata.*",
                         "match_mapping_type": "string",
-                        "mapping": {"type": "keyword", "ignore_above": 1024}
+                        "mapping": {"type": "keyword", "ignore_above": 1024},
                     }
-                }
+                },
             ],
             "date_detection": False,
             "numeric_detection": False,

--- a/api/helpers/_accesscontroller.py
+++ b/api/helpers/_accesscontroller.py
@@ -8,7 +8,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.schemas.admin.roles import Limit, LimitType, PermissionType, Role
+from api.schemas.admin.roles import Limit, LimitType, PermissionType
 from api.schemas.admin.users import User
 from api.schemas.collections import CollectionVisibility
 from api.schemas.me import UserInfo
@@ -115,7 +115,6 @@ class AccessController:
         if request.url.path.endswith(ENDPOINT__ROUTERS) and request.method in ["GET"]:
             await self._check_provider(user_info=user_info, limits=limits, request=request)
 
-        await session.rollback()
         return user_info
 
     def __get_user_limits(self, user_info: UserInfo) -> Dict[str, _UserModelLimits]:
@@ -144,7 +143,7 @@ class AccessController:
 
     async def _check_api_key(
         self, api_key: HTTPAuthorizationCredentials, session: AsyncSession
-    ) -> tuple[User, Role, Dict[str, _UserModelLimits], int | None]:
+    ) -> tuple[User, Dict[str, _UserModelLimits], int | None]:
         if api_key.scheme != "Bearer":
             raise InvalidAuthenticationSchemeException()
 

--- a/api/helpers/_identityaccessmanager.py
+++ b/api/helpers/_identityaccessmanager.py
@@ -212,7 +212,6 @@ class IdentityAccessManager:
                 role_id = row.role_id
                 if role_id in roles:
                     roles[role_id].limits.append(Limit(model=row.model, type=row.type, value=row.value))
-
             # Query permissions for these roles
             permissions_query = select(PermissionTable.role_id, PermissionTable.permission).where(PermissionTable.role_id.in_(list(roles.keys())))
 
@@ -221,7 +220,6 @@ class IdentityAccessManager:
                 role_id = row.role_id
                 if role_id in roles:
                     roles[role_id].permissions.append(PermissionType(value=row.permission))
-
         return list(roles.values())
 
     async def create_user(
@@ -739,7 +737,7 @@ class IdentityAccessManager:
         if email == "master" and password == self.master_key:
             return 0, self.master_key
 
-        user = await self.get_user_info(session, email=email)  # raise UserNotFoundException (404) if user not found
+        user = await self.get_user_info(session=session, email=email)  # raise UserNotFoundException (404) if user not found
         result = await session.execute(statement=select(UserTable.password).where(UserTable.id == user.id))
         user_password = result.scalar_one()
 

--- a/api/sql/session.py
+++ b/api/sql/session.py
@@ -36,3 +36,5 @@ async def get_db_session():
     get_db_func = get_db_dependency()
     async for session in get_db_func():
         yield session
+        if session.in_transaction():
+            await session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opengatellm"
-version = "0.2.3"
+version = "0.2.4"
 description = "OpenGateLLM project"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "alembic==1.15.1",
     "psycopg2-binary==2.9.10",
     "asyncpg==0.30.0",
-    "sqlalchemy[asyncio]==2.0.38",
+    "sqlalchemy[asyncio]==2.0.43",
     "sqlalchemy-utils==0.41.2",
     "sentry-sdk[fastapi]>=2.28.0",
     "bcrypt==4.3.0"
@@ -47,7 +47,7 @@ api = [
 
     # app
     "gunicorn==23.0.0",
-    "fastapi==0.115.8",
+    "fastapi==0.117.1",
     "prometheus-fastapi-instrumentator==7.0.2",
     "pyyaml==6.0.2",
     "uvicorn==0.34.0",


### PR DESCRIPTION
# 🎯 Objectif de la PR
Cette PR vise à le problème des connnexions `idle_in_transaction` des sessions sql :  

---

# 🚀 Principales modifications impactant le développement


1. **Nettoyage dans `AccessController`**  
   - Suppression de l’import inutilisé `Role`.  
   - Retrait de l’appel forcé à `session.rollback()` après la vérification des accès.  
   - **Avantage** : évite des rollbacks non nécessaires qui pouvaient impacter les transactions en cours.


2. **Amélioration de la gestion des sessions SQLAlchemy**  
   - Fermeture explicite des sessions encore actives après `yield`.  
   - **Avantage** : évite les fuites de connexion et les transactions laissées ouvertes (meilleure stabilité en production).

3**Mise à jour des dépendances**  
   - `sqlalchemy[asyncio]` → `2.0.43`  
   - `fastapi` → `0.117.1`  
   - **Avantage** : compatibilité avec les dernières corrections de bugs, meilleures performances et support futur garanti.

---

# 🔄 Impact sur l'équipe
- **Ops / Production** : réduction du risque de fuite de connexions et de sessions bloquées → améliore la stabilité de l’API sous charge.  
