### PR TITLE
Fix client lock handling in base model router

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"80.87%","color":"green"}
+{"schemaVersion":1,"label":"coverage","message":"80.88%","color":"green"}

--- a/api/helpers/models/routers/_basemodelrouter.py
+++ b/api/helpers/models/routers/_basemodelrouter.py
@@ -210,10 +210,13 @@ class BaseModelRouter(ABC):
             # another thread to remove it while in use
             await client.lock.acquire()
 
-        if inspect.iscoroutinefunction(handler):
-            result = await handler(client)
-        else:
-            result = handler(client)
+        try:
+            if inspect.iscoroutinefunction(handler):
+                result = await handler(client)
+            else:
+                result = handler(client)
+        finally:
+            # Always release the client lock, even if handler raises
+            client.lock.release()
 
-        client.lock.release()
         return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opengatellm"
-version = "0.2.4"
+version = "0.2.5"
 description = "OpenGateLLM project"
 requires-python = ">=3.12"
 license = { text = "MIT" }


### PR DESCRIPTION
Ensure the client lock is always released after handler execution, even if an exception occurs. This explain why we saw pending DB transaction because DB transaction are never closed in code and all rely on get_db dependency exit. But if process is stuck by a lock, dependency db exit never happen.