### PR TITLE
fix(search): set limit parameter for semantic search.

### DIFF
--- a/api/clients/vector_store/_elasticsearchvectorstoreclient.py
+++ b/api/clients/vector_store/_elasticsearchvectorstoreclient.py
@@ -165,7 +165,11 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
     async def _lexical_search(self, query_prompt: str, collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:
         collection_ids = [str(x) for x in collection_ids]
         fuzziness = {"fuzziness": "AUTO"} if len(query_prompt.split()) < 25 else {}
-        body = {"query": {"multi_match": {"query": query_prompt, **fuzziness}}, "size": k, "_source": {"excludes": ["embedding"]}}
+        body = {
+            "query": {"multi_match": {"query": query_prompt, **fuzziness}},
+            "size": k,
+            "_source": {"excludes": ["embedding"]},
+        }
         results = await AsyncElasticsearch.search(self, index=collection_ids, body=body)
         hits = [hit for hit in results["hits"]["hits"] if hit]
         searches = [
@@ -184,7 +188,11 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
 
     async def _semantic_query(self, query_vector: list[float], collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:  # fmt: off
         collection_ids = [str(x) for x in collection_ids]
-        body = {"knn": {"field": "embedding", "query_vector": query_vector, "k": k, "num_candidates": 200}}
+        body = {
+            "knn": {"field": "embedding", "query_vector": query_vector, "k": k, "num_candidates": 200},
+            "size": k,
+            "_source": {"excludes": ["embedding"]},
+        }
         results = await AsyncElasticsearch.search(self, index=collection_ids, body=body)
         hits = [hit for hit in results["hits"]["hits"] if hit]
         searches = [

--- a/api/clients/vector_store/_elasticsearchvectorstoreclient.py
+++ b/api/clients/vector_store/_elasticsearchvectorstoreclient.py
@@ -152,7 +152,7 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
         score_threshold: float = 0.0,
     ) -> List[Search]:
         if method == SearchMethod.SEMANTIC:
-            searches = await self._semantic_query(query_vector=query_vector, collection_ids=collection_ids, k=k, score_threshold=score_threshold)
+            searches = await self._semantic_search(query_vector=query_vector, collection_ids=collection_ids, k=k, score_threshold=score_threshold)
 
         elif method == SearchMethod.LEXICAL:
             searches = await self._lexical_search(query_prompt=query_prompt, collection_ids=collection_ids, k=k, score_threshold=score_threshold)
@@ -186,7 +186,7 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
 
         return searches
 
-    async def _semantic_query(self, query_vector: list[float], collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:  # fmt: off
+    async def _semantic_search(self, query_vector: list[float], collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:  # fmt: off
         collection_ids = [str(x) for x in collection_ids]
         body = {
             "knn": {"field": "embedding", "query_vector": query_vector, "k": k, "num_candidates": 200},
@@ -227,7 +227,7 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
             A combined list of searches with updated scores
         """
         lexical_searches = await self._lexical_search(query_prompt=query_prompt, collection_ids=collection_ids, k=int(k * expansion_factor))
-        semantic_searches = await self._semantic_query(query_vector=query_vector, collection_ids=collection_ids, k=int(k * expansion_factor))
+        semantic_searches = await self._semantic_search(query_vector=query_vector, collection_ids=collection_ids, k=int(k * expansion_factor))
 
         combined_scores = {}
         search_map = {}

--- a/api/clients/vector_store/_qdrantvectorstoreclient.py
+++ b/api/clients/vector_store/_qdrantvectorstoreclient.py
@@ -115,7 +115,7 @@ class QdrantVectorStoreClient(BaseVectorStoreClient, AsyncQdrantClient):
             searches = await self._lexical_search(query_prompt=query_prompt, collection_ids=collection_ids, k=k)
 
         elif method == SearchMethod.SEMANTIC:
-            searches = await self._semantic_query(query_vector=query_vector, collection_ids=collection_ids, k=k, score_threshold=score_threshold)
+            searches = await self._semantic_search(query_vector=query_vector, collection_ids=collection_ids, k=k, score_threshold=score_threshold)
 
         else:  # method == SearchMethod.HYBRID
             searches = await self._hybrid_search(query_prompt=query_prompt, query_vector=query_vector, collection_ids=collection_ids, k=k, rff_k=rff_k)  # fmt: off
@@ -125,7 +125,7 @@ class QdrantVectorStoreClient(BaseVectorStoreClient, AsyncQdrantClient):
     async def _lexical_search(self, query_prompt: str, collection_ids: List[int], k: int) -> List[Search]:
         raise NotImplementedException("Only semantic search is available for Qdrant database.")
 
-    async def _semantic_query(self, query_vector: list[float], collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:
+    async def _semantic_search(self, query_vector: list[float], collection_ids: List[int], k: int, score_threshold: float = 0.0) -> List[Search]:
         searches = []
         for collection_id in collection_ids:
             results = await AsyncQdrantClient.search(


### PR DESCRIPTION
The default size value for elasticsearch is 10, and was no set for semantic search : https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results