### PR TITLE
fix(search): boundary values for search limit.

### DIFF
--- a/api/schemas/search.py
+++ b/api/schemas/search.py
@@ -21,7 +21,7 @@ class SearchMethod(str, Enum):
 class SearchArgs(BaseModel):
     collections: List[Any] = Field(default=[], description="List of collections ID")
     rff_k: int = Field(default=20, description="k constant in RFF algorithm")
-    k: int = Field(gt=0, default=4, description="Number of results to return")
+    k: int = Field(gt=0, le=100, default=10, description="Number of results to return")
     method: SearchMethod = Field(default=SearchMethod.SEMANTIC)
     score_threshold: Optional[float] = Field(default=0.0, ge=0.0, le=1.0, description="Score of cosine similarity threshold for filtering results, only available for semantic search method.")  # fmt: off
     web_search: bool = Field(default=False, description="Whether add internet search to the results.")


### PR DESCRIPTION
In this PR, we

- Set the maximum of  search results to 100
- Set the default number of search results to 10 as it gives better result as shown in the last RAG evaluation : https://evalap.etalab.gouv.fr/experiments_set?expset=76