### PR TITLE
fix(playground): clarify playground wording

### DIFF
--- a/playground/configuration.py
+++ b/playground/configuration.py
@@ -31,6 +31,7 @@ class Playground(ConfigBaseModel):
     cache_ttl: int = 1800  # 30 minutes
     default_model: Optional[str] = None
     proconnect_enabled: bool = False
+    app_name: str = "OpenGateLLM"
 
 
 class ConfigFile(ConfigBaseModel):

--- a/playground/configuration.py
+++ b/playground/configuration.py
@@ -31,7 +31,7 @@ class Playground(ConfigBaseModel):
     cache_ttl: int = 1800  # 30 minutes
     default_model: Optional[str] = None
     proconnect_enabled: bool = False
-    app_name: str = "OpenGateLLM"
+    app_name: Optional[str] = Field(default="OpenGateLLM", description="The name of the application.")
 
 
 class ConfigFile(ConfigBaseModel):

--- a/playground/frontend/chat.py
+++ b/playground/frontend/chat.py
@@ -11,10 +11,7 @@ from playground.variables import MODEL_TYPE_IMAGE_TEXT_TO_TEXT, MODEL_TYPE_LANGU
 
 SEARCH_METHODS = ["hybrid", "semantic", "lexical"]
 header()
-st.error(
-    """**Cette page va être dépréciée à partir du 22 octobre 2025 pour laisser place Assistant IA, l'interface de Chatbot de la DINUM. 
-Pour plus d'informations, rendez-vous sur le canal Tchap d'Assistant IA en cliquant [ici](https://www.tchap.gouv.fr/#/room/!gpLYRJyIwdkcHBGYeC:agent.dinum.tchap.gouv.fr).**"""
-)
+
 # Data
 models = get_models(types=[MODEL_TYPE_LANGUAGE, MODEL_TYPE_IMAGE_TEXT_TO_TEXT])
 limits = format_limits(models=models)
@@ -192,7 +189,7 @@ with st.sidebar:
 # Main
 with st.chat_message(name="assistant"):
     st.markdown(
-        body="""Bonjour je suis Albert, et je peux vous aider si vous avez des questions administratives !
+        body=f"""Bonjour, je suis {configuration.playground.app_name}, et je peux vous aider si vous avez des questions administratives ! Testez-moi directement dans ce chat.
 
 Je peux me connecter à vos bases de connaissances, pour ça sélectionnez les collections voulues dans le menu de gauche. Si vous ne souhaitez pas utiliser de collection, désactivez le RAG en décochant la fonction "Activated RAG".
 

--- a/playground/frontend/documents.py
+++ b/playground/frontend/documents.py
@@ -6,10 +6,7 @@ from playground.frontend.header import header
 from playground.frontend.utils import input_new_collection_description, input_new_collection_name, resources_selector
 
 header()
-st.error(
-    """**Cette page va être dépréciée à partir du 22 octobre 2025 pour laisser place Assistant IA, l'interface de Chatbot de la DINUM.
-Pour plus d'informations, rendez-vous sur le canal Tchap d'Assistant IA en cliquant [ici](https://www.tchap.gouv.fr/#/room/!gpLYRJyIwdkcHBGYeC:agent.dinum.tchap.gouv.fr).**"""
-)
+
 if st.session_state["user"].id == 0:
     st.info("Master user can not create collections.")
     st.stop()

--- a/playground/frontend/header.py
+++ b/playground/frontend/header.py
@@ -62,12 +62,22 @@ def header():
     with stylable_container(key="Header", css_styles="button{float: right;}"):
         col1, col2 = st.columns(2)
         with col1:
-            st.subheader("Albert playground")
+            st.subheader(f"{configuration.playground.app_name} playground")
+
+        st.info(f"👋 Welcome to the {configuration.playground.app_name} playground! " + 
+                f"Use this interface to explore the capabilities of {configuration.playground.app_name} " +
+                f"by navigating through the various sections available in the sidebar. " +
+                f"Whether you want to chat with the model, manage your documents, " + 
+                f"or summarize content, everything is just a click away.")
 
         # Authentication
         authenticate()
         if st.session_state.get("login_status") is None:
             st.stop()
+
+        st.warning(f"⚠️ This playground should only be used for testing and evaluation purposes, " +
+                   f"when developing your applications using {configuration.playground.app_name}. " +
+                   f"This is NOT an AI assistant for professional use.")
 
         with col2:
             logout = st.button("Logout")

--- a/playground/frontend/summarize.py
+++ b/playground/frontend/summarize.py
@@ -10,10 +10,7 @@ from playground.frontend.utils import resources_selector
 from playground.variables import MODEL_TYPE_LANGUAGE, MODEL_TYPE_IMAGE_TEXT_TO_TEXT
 
 header()
-st.error(
-    """**Cette page va être dépréciée à partir du 22 octobre 2025 pour laisser place Assistant IA, l'interface de Chatbot de la DINUM. 
-Pour plus d'informations, rendez-vous sur le canal Tchap d'Assistant IA en cliquant [ici](https://www.tchap.gouv.fr/#/room/!gpLYRJyIwdkcHBGYeC:agent.dinum.tchap.gouv.fr).**"""
-)
+
 models = get_models(types=[MODEL_TYPE_LANGUAGE, MODEL_TYPE_IMAGE_TEXT_TO_TEXT])
 limits = format_limits(models=models)
 limits = [model for model, values in limits.items() if (values["rpd"] is None or values["rpd"] > 0) and (values["rpm"] is None or values["rpm"] > 0)]

--- a/playground/frontend/transcription.py
+++ b/playground/frontend/transcription.py
@@ -9,10 +9,6 @@ from playground.frontend.header import header
 from playground.variables import MODEL_TYPE_AUDIO, TRANSCRIPTION_SUPPORTED_LANGUAGES
 
 header()
-st.error(
-    """**Cette page va être dépréciée à partir du 22 octobre 2025 pour laisser place Assistant IA, l'interface de Chatbot de la DINUM. 
-Pour plus d'informations, rendez-vous sur le canal Tchap d'Assistant IA en cliquant [ici](https://www.tchap.gouv.fr/#/room/!gpLYRJyIwdkcHBGYeC:agent.dinum.tchap.gouv.fr).**"""
-)
 
 # Data
 try:


### PR DESCRIPTION
[This is mostly a way for me to get familiar with the repo]

In this PR we clarify some wordings in the playground to address the fact that people were using the playground as their AI assistant, and that the recent warning message was confusing them a bit more.

Also this adresses some unfortunate coupling there was between the Albert API product and the OpenGateLLM repo, removing some AI Assistant specific messages, and introducing an "app_name" as a config variable (to be updated in the deployment). This will help getting rid of the concept of "Albert", which does not mean anything anymore (the product is Albert API, not an assistant).