### PR TITLE
Add healthcheck status message

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"45.70%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"45.69%","color":"red"}

--- a/api/main.py
+++ b/api/main.py
@@ -2,11 +2,12 @@ from importlib import import_module
 import logging
 import pkgutil
 
-from fastapi import APIRouter, Depends, FastAPI, Request, Response
+from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.dependencies.utils import get_dependant
 from prometheus_fastapi_instrumentator import Instrumentator
 import sentry_sdk
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.responses import JSONResponse
 
 from api.helpers._accesscontroller import AccessController
 from api.schemas.admin.roles import PermissionType
@@ -93,5 +94,5 @@ if ROUTER__MONITORING not in configuration.settings.disabled_routers:
         app.instrumentator.expose(app=app, should_gzip=True, tags=[ROUTER__MONITORING.title()], dependencies=[Depends(dependency=AccessController(permissions=[PermissionType.READ_METRIC]))], include_in_schema=include_in_schema)  # fmt: off
 
     @app.get(path="/health", tags=[ROUTER__MONITORING.title()], include_in_schema=include_in_schema)
-    def health() -> Response:
-        return Response(status_code=200)
+    def health() -> JSONResponse:
+        return JSONResponse(content={"status": "ok"}, status_code=200)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Health check now returns a structured JSON status (e.g., {"status":"ok"}) with an explicit 200 response, improving machine-readable health reporting for monitoring and integrations.
* **Chores**
  * Small update to the project coverage badge display value (minor metadata tweak).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->