### PR TITLE
feat(playground): add pagination on router and provider pages

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"46.18%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"46.17%","color":"red"}

--- a/api/endpoints/admin/providers.py
+++ b/api/endpoints/admin/providers.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import APIRouter, Depends, Path, Query, Request, Security
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -99,12 +101,24 @@ async def get_provider(
 async def get_providers(
     request: Request,
     router: int | None = Query(default=None, description="Filter providers by router ID."),
+    offset: int = Query(default=0, ge=0, description="The offset of the tokens to get."),
+    limit: int = Query(default=10, ge=1, le=100, description="The limit of the tokens to get."),
+    order_by: Literal["id", "name", "created"] = Query(default="id", description="The field to order the tokens by."),
+    order_direction: Literal["asc", "desc"] = Query(default="asc", description="The direction to order the tokens by."),
     postgres_session: AsyncSession = Depends(get_postgres_session),
     model_registry: ModelRegistry = Depends(get_model_registry),
 ) -> JSONResponse:
     """
     Get all model providers for a router.
     """
-    providers = await model_registry.get_providers(router_id=router, provider_id=None, postgres_session=postgres_session)
+    providers = await model_registry.get_providers(
+        router_id=router,
+        provider_id=None,
+        postgres_session=postgres_session,
+        offset=offset,
+        limit=limit,
+        order_by=order_by,
+        order_direction=order_direction,
+    )
 
     return JSONResponse(status_code=200, content=Providers(data=providers).model_dump())

--- a/api/endpoints/admin/routers.py
+++ b/api/endpoints/admin/routers.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Body, Depends, Path, Request, Security
+from typing import Literal
+
+from fastapi import APIRouter, Body, Depends, Path, Query, Request, Security
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -113,12 +115,24 @@ async def get_router(
 )
 async def get_routers(
     request: Request,
+    offset: int = Query(default=0, ge=0, description="The offset of the tokens to get."),
+    limit: int = Query(default=10, ge=1, le=100, description="The limit of the tokens to get."),
+    order_by: Literal["id", "name", "created"] = Query(default="id", description="The field to order the tokens by."),
+    order_direction: Literal["asc", "desc"] = Query(default="asc", description="The direction to order the tokens by."),
     postgres_session: AsyncSession = Depends(get_postgres_session),
     model_registry: ModelRegistry = Depends(get_model_registry),
 ) -> JSONResponse:
     """
     Get all routers.
     """
-    routers = await model_registry.get_routers(router_id=None, name=None, postgres_session=postgres_session)
+    routers = await model_registry.get_routers(
+        router_id=None,
+        name=None,
+        postgres_session=postgres_session,
+        offset=offset,
+        limit=limit,
+        order_by=order_by,
+        order_direction=order_direction,
+    )
 
     return JSONResponse(status_code=200, content=Routers(data=routers).model_dump())

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -62,6 +62,7 @@ class KeysState(EntityState):
                 response.raise_for_status()
                 data = response.json()
                 self.entities = []
+
                 for key in data.get("data", []):
                     if key["name"] != "playground":
                         self.entities.append(self._format_key(key))

--- a/playground/app/features/providers/components/lists.py
+++ b/playground/app/features/providers/components/lists.py
@@ -88,5 +88,6 @@ def providers_list() -> rx.Component:
         settings_dialog=provider_settings_dialog(),
         delete_dialog=provider_delete_dialog(),
         filters=provider_filters(),
-        pagination=False,
+        pagination=True,
+        sorting=True,
     )

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -104,6 +104,32 @@ class ProvidersState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
+                # Load routers
+                if not self.routers_list:
+                    offset = 0
+                    self.routers_list = []
+                    self.routers_dict = {}
+                    while True:
+                        response = await client.get(
+                            url=f"{self.opengatellm_url}/v1/admin/routers",
+                            params={"offset": offset, "limit": 100},
+                            headers={"Authorization": f"Bearer {self.api_key}"},
+                            timeout=configuration.settings.playground_opengatellm_timeout,
+                        )
+
+                        response.raise_for_status()
+                        data = response.json()
+                        routers_data = data.get("data", [])
+
+                        if not routers_data:
+                            break
+
+                        self.routers_list.extend([{"id": role["id"], "name": role["name"]} for role in routers_data])
+                        self.routers_dict.update({role["name"]: role["id"] for role in routers_data})
+                        offset += 100
+                        if len(routers_data) < 100:
+                            break
+
                 response = await client.get(
                     f"{self.opengatellm_url}/v1/admin/providers",
                     params=params,

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -91,7 +91,13 @@ class ProvidersState(EntityState):
         self.entities_loading = True
         yield
 
-        params = {}
+        params = {
+            "offset": (self.page - 1) * self.per_page,
+            "limit": self.per_page,
+            "order_by": self.order_by_value,
+            "order_direction": self.order_direction_value,
+        }
+
         if self.filter_router_value != "0":
             params["router"] = int(self.filter_router_value)
 
@@ -108,6 +114,7 @@ class ProvidersState(EntityState):
                 response.raise_for_status()
                 data = response.json()
                 self.entities = []
+
                 for provider in data.get("data", []):
                     if provider["user_id"] not in self.provider_owners:
                         response = await client.get(
@@ -140,22 +147,11 @@ class ProvidersState(EntityState):
 
                     self.entities.append(self._format_provider(provider))
 
+            self.has_more_page = len(self.entities) == self.per_page
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
             self.entities_loading = False
-            yield
-
-    ############################################################
-    # Pagination & filters
-    ############################################################
-    filter_router_value: str = "0"
-
-    @rx.event
-    async def set_filter_router(self, value: str):
-        self.filter_router_value = value
-        yield
-        async for _ in self.load_entities():
             yield
 
     ############################################################
@@ -300,3 +296,53 @@ class ProvidersState(EntityState):
         finally:
             self.create_entity_loading = False
             yield
+
+    ############################################################
+    # Pagination & filters
+    ############################################################
+    filter_router_value: str = "0"
+    per_page: int = 20
+    order_by_options: list[str] = ["id", "name", "created"]
+
+    @rx.event
+    async def set_filter_router(self, value: str):
+        self.filter_router_value = value
+        yield
+        async for _ in self.load_entities():
+            yield
+
+    @rx.event
+    async def set_order_by(self, value: str):
+        """Set order by field and reload."""
+        self.order_by_value = value
+        self.page = 1
+        self.has_more_page = False
+        yield
+        async for _ in self.load_entities():
+            yield
+
+    @rx.event
+    async def set_order_direction(self, value: str):
+        """Set order direction and reload."""
+        self.order_direction_value = value
+        self.page = 1
+        self.has_more_page = False
+        yield
+        async for _ in self.load_entities():
+            yield
+
+    @rx.event
+    async def prev_page(self):
+        if self.page > 1:
+            self.page -= 1
+            yield
+            async for _ in self.load_entities():
+                yield
+
+    @rx.event
+    async def next_page(self):
+        if self.has_more_page:
+            self.page += 1
+            yield
+            async for _ in self.load_entities():
+                yield

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -120,12 +120,8 @@ class ProvidersState(EntityState):
                         response.raise_for_status()
                         data = response.json()
                         routers_data = data.get("data", [])
-
-                        if not routers_data:
-                            break
-
-                        self.routers_list.extend([{"id": role["id"], "name": role["name"]} for role in routers_data])
-                        self.routers_dict.update({role["name"]: role["id"] for role in routers_data})
+                        self.routers_list.extend([{"id": router["id"], "name": router["name"]} for router in routers_data])
+                        self.routers_dict.update({router["name"]: router["id"] for router in routers_data})
                         offset += 100
                         if len(routers_data) < 100:
                             break

--- a/playground/app/features/routers/components/lists.py
+++ b/playground/app/features/routers/components/lists.py
@@ -71,8 +71,9 @@ def routers_list() -> rx.Component:
         entities=RoutersState.routers,
         renderer_entity_row=router_renderer_row,
         settings_dialog=router_settings_dialog(),
-        delete_dialog=router_delete_dialog(),
         no_entities_message="No routers yet",
         no_entities_description="Create your first router to get started",
-        pagination=False,
+        delete_dialog=router_delete_dialog(),
+        pagination=True,
+        sorting=True,
     )

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -119,10 +119,6 @@ class UsersState(EntityState):
                         response.raise_for_status()
                         data = response.json()
                         organizations_data = data.get("data", [])
-
-                        if not organizations_data:
-                            break
-
                         self.organizations_list.extend([{"id": org["id"], "name": org["name"]} for org in organizations_data])
                         self.organizations_dict.update({org["name"]: org["id"] for org in organizations_data})
                         offset += 100

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -119,8 +119,10 @@ class UsersState(EntityState):
                         response.raise_for_status()
                         data = response.json()
                         organizations_data = data.get("data", [])
+
                         if not organizations_data:
                             break
+
                         self.organizations_list.extend([{"id": org["id"], "name": org["name"]} for org in organizations_data])
                         self.organizations_dict.update({org["name"]: org["id"] for org in organizations_data})
                         offset += 100


### PR DESCRIPTION
There is still a bug on this version (and the main one too):
- The `page` value linked to pagination looks shared between components (and so, pages too).
- So, when going to the page 2 on a specific page (e.g. router page), the page 2 is also selected when going to another page (e.g. API keys / tokens).
- This also means that, if the other page does not have enough elements to display them on two pages (e.g. only 5 elements), the interface will display the empty category message (e.g. "no providers yet").

This error exists on all the pages that display elements arrays. Another issue needs to be created on this topic imo.

<img width="1728" height="1084" alt="Screenshot 2025-12-15 at 15 26 53" src="https://github.com/user-attachments/assets/d8d1e7a8-df21-423f-a731-5067ac849cdf" />
