### PR TITLE
fix(qdrant): /chunks offset issue for Qdrant database

### DIFF
--- a/api/clients/vector_store/_elasticsearchvectorstoreclient.py
+++ b/api/clients/vector_store/_elasticsearchvectorstoreclient.py
@@ -125,11 +125,9 @@ class ElasticsearchVectorStoreClient(BaseVectorStoreClient, AsyncElasticsearch):
             body["query"]["bool"]["must"].append({"term": {"id": chunk_id}})
 
         results = await AsyncElasticsearch.search(self, index=str(collection_id), body=body, from_=offset, size=limit)
-
         chunks = []
         for hit in results["hits"]["hits"]:
             chunks.append(Chunk(id=hit["_source"]["id"], content=hit["_source"]["content"], metadata=hit["_source"]["metadata"]))
-
         return chunks
 
     async def upsert(self, collection_id: int, chunks: list[Chunk], embeddings: list[list[float]]) -> None:

--- a/api/clients/vector_store/_qdrantvectorstoreclient.py
+++ b/api/clients/vector_store/_qdrantvectorstoreclient.py
@@ -88,9 +88,8 @@ class QdrantVectorStoreClient(BaseVectorStoreClient, AsyncQdrantClient):
             self,
             collection_name=str(collection_id),
             scroll_filter=doc_filter,
-            order_by=OrderBy(key="id", start_from=offset),
+            order_by=OrderBy(key="id", start_from=offset + 1),  # Add 1 to offset because IDs start from 1 in Qdrant
             limit=limit,
-            offset=offset,
         )
         data = data[0]
         chunks = [Chunk(id=chunk.payload["id"], content=chunk.payload["content"], metadata=chunk.payload["metadata"]) for chunk in data]

--- a/api/schemas/search.py
+++ b/api/schemas/search.py
@@ -22,7 +22,7 @@ class SearchArgs(BaseModel):
     rff_k: int = Field(default=20, description="k constant in RFF algorithm")
     k: int = Field(gt=0, le=200, default=10, deprecated=True, description="[DEPRECATED: use limit instead]Number of results to return")
     limit: int = Field(gt=0, le=200, default=10, description="Number of results to return")
-    offset: int = Field(gt=0, default=0, description="Offset for pagination, specifying how many results to skip from the beginning")
+    offset: int = Field(ge=0, default=0, description="Offset for pagination, specifying how many results to skip from the beginning")
     method: SearchMethod = Field(default=SearchMethod.SEMANTIC)
     score_threshold: float | None = Field(default=0.0, ge=0.0, le=1.0, description="Score of cosine similarity threshold for filtering results, only available for semantic search method.")  # fmt: off
     web_search: bool = Field(default=False, description="Whether add internet search to the results.")

--- a/docs/docs/dependencies/vector_store.md
+++ b/docs/docs/dependencies/vector_store.md
@@ -25,7 +25,7 @@ To enable the vector store, you need:
 
 #### Docker compose
 
-Add an `elasticsearch` container in the `services` section of your `compose.yml` file:
+Add an `elasticsearch` container in the `services` section of your `compose.yml` file, and a volume for data persistence:
 
 ```yaml
 services:
@@ -48,6 +48,10 @@ services:
       interval: 4s
       timeout: 10s
       retries: 5
+
+volumes:
+  [...]
+  elasticsearch:
 ```
 
 #### Configuration file
@@ -95,7 +99,7 @@ For more information about the configuration file, see [Configuration](../gettin
 
 #### Docker Compose
 
-Add a `qdrant` container in the `services` section of your `compose.yml` file:
+Add an `qdrant` container in the `services` section of your `compose.yml` file, and a volume for data persistence:
 
 ```yaml
 services:
@@ -115,6 +119,10 @@ services:
       interval: 4s
       timeout: 10s
       retries: 5
+
+volumes:
+  [...]
+  qdrant:
 ```
 
 #### Configuration file
@@ -123,7 +131,7 @@ services:
 For more information about the configuration file, see [Configuration](../getting-started/configuration.md) documentation.
 :::
 
-1. Add an embedding model in the `models` section of your `config.yml`. Example:
+1. Add an embedding model in the `models` section of your `config.yml`. This model should be of type `text-embeddings-inference`. Example:
 
     ```yaml
     models:

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -15,7 +15,16 @@ class RoutersState(EntityState):
     @rx.var
     def router_types_list(self) -> list[str]:
         """Get list of router types."""
-        return ["image-text-to-text", "automatic-speech-recognition", "text-embeddings-inference", "text-generation", "text-classification"]
+        return sorted(
+            [
+                "image-to-text",
+                "image-text-to-text",
+                "automatic-speech-recognition",
+                "text-embeddings-inference",
+                "text-generation",
+                "text-classification",
+            ]
+        )
 
     @rx.var
     def router_load_balancing_strategies_list(self) -> list[str]:


### PR DESCRIPTION
- update Docusaurus documentation about vector database volume declaration.
- fix /search endpoint with offset equal to 0
- add new router type (`image-to-text`) 