### PR TITLE
720 refacto refacto post v1adminroles endpoint toward clean architecture

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"50.94%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"50.79%","color":"red"}

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -5,9 +5,12 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.key import KeyRepository
+from api.domain.role import LimitRepository, PermissionRepository
 from api.infrastructure.model import ModelProviderGateway
 from api.infrastructure.postgres import (
     PostgresKeyRepository,
+    PostgresLimitRepository,
+    PostgresPermissionRepository,
     PostgresProviderRepository,
     PostgresRolesRepository,
     PostgresRouterRepository,
@@ -69,6 +72,14 @@ def _user_info_repository(session: AsyncSession) -> PostgresUserInfoRepository:
     return PostgresUserInfoRepository(postgres_session=session)
 
 
+def _limit_repository(session: AsyncSession) -> LimitRepository:
+    return PostgresLimitRepository(postgres_session=session)
+
+
+def _permission_repository(session: AsyncSession) -> PermissionRepository:
+    return PostgresPermissionRepository(postgres_session=session)
+
+
 def get_key_repository(postgres_session: AsyncSession = Depends(get_postgres_session)) -> KeyRepository:
     return PostgresKeyRepository(postgres_session=postgres_session)
 
@@ -92,7 +103,12 @@ def create_user_use_case_factory(postgres_session: AsyncSession = Depends(get_po
 
 # roles use cases
 def create_role_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> CreateRoleUseCase:
-    return CreateRoleUseCase(role_repository=_role_repository(postgres_session), user_info_repository=_user_info_repository(postgres_session))
+    return CreateRoleUseCase(
+        role_repository=_role_repository(postgres_session),
+        limit_repository=_limit_repository(postgres_session),
+        permission_repository=_permission_repository(postgres_session),
+        user_info_repository=_user_info_repository(postgres_session),
+    )
 
 
 # routers use cases

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -5,6 +5,7 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.key import KeyRepository
+from api.domain.provider import ProviderRepository
 from api.domain.role import LimitRepository, PermissionRepository
 from api.infrastructure.model import ModelProviderGateway
 from api.infrastructure.postgres import (
@@ -80,6 +81,10 @@ def _permission_repository(session: AsyncSession) -> PermissionRepository:
     return PostgresPermissionRepository(postgres_session=session)
 
 
+def _provider_repository(session: AsyncSession) -> ProviderRepository:
+    return PostgresProviderRepository(postgres_session=session)
+
+
 def get_key_repository(postgres_session: AsyncSession = Depends(get_postgres_session)) -> KeyRepository:
     return PostgresKeyRepository(postgres_session=postgres_session)
 
@@ -136,7 +141,7 @@ def update_router_use_case_factory(postgres_session: AsyncSession = Depends(get_
 def create_provider_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> CreateProviderUseCase:
     return CreateProviderUseCase(
         router_repository=_router_repository(postgres_session),
-        provider_repository=PostgresProviderRepository(postgres_session=postgres_session),
+        provider_repository=_provider_repository(postgres_session),
         provider_gateway=ModelProviderGateway(),
         user_info_repository=_user_info_repository(postgres_session),
     )
@@ -145,27 +150,27 @@ def create_provider_use_case_factory(postgres_session: AsyncSession = Depends(ge
 def update_provider_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> UpdateProviderUseCase:
     return UpdateProviderUseCase(
         router_repository=_router_repository(postgres_session),
-        provider_repository=PostgresProviderRepository(postgres_session=postgres_session),
+        provider_repository=_provider_repository(postgres_session),
         user_info_repository=_user_info_repository(postgres_session),
     )
 
 
 def delete_provider_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> DeleteProviderUseCase:
     return DeleteProviderUseCase(
-        provider_repository=PostgresProviderRepository(postgres_session=postgres_session),
+        provider_repository=_provider_repository(postgres_session),
         user_info_repository=_user_info_repository(postgres_session),
     )
 
 
 def get_one_provider_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetOneProviderUseCase:
     return GetOneProviderUseCase(
-        provider_repository=PostgresProviderRepository(postgres_session=postgres_session),
+        provider_repository=_provider_repository(postgres_session),
         user_info_repository=_user_info_repository(postgres_session),
     )
 
 
 def get_providers_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetProvidersUseCase:
     return GetProvidersUseCase(
-        provider_repository=PostgresProviderRepository(postgres_session=postgres_session),
+        provider_repository=_provider_repository(postgres_session),
         user_info_repository=_user_info_repository(postgres_session),
     )

--- a/api/domain/role/__init__.py
+++ b/api/domain/role/__init__.py
@@ -1,3 +1,5 @@
+from ._limitrepository import LimitRepository
+from ._permissionrepository import PermissionRepository
 from ._rolerepository import RoleRepository
 
-__all__ = ["RoleRepository"]
+__all__ = ["RoleRepository", "LimitRepository", "PermissionRepository"]

--- a/api/domain/role/_limitrepository.py
+++ b/api/domain/role/_limitrepository.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from api.domain.role.entities import Limit
+
+
+class LimitRepository(ABC):
+    @abstractmethod
+    async def create_limits(self, role_id: int, limits: list[Limit]) -> list[Limit]:
+        pass

--- a/api/domain/role/_permissionrepository.py
+++ b/api/domain/role/_permissionrepository.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from api.domain.role.entities import PermissionType
+
+
+class PermissionRepository(ABC):
+    @abstractmethod
+    async def create_permissions(self, role_id: int, permissions: list[PermissionType]) -> list[PermissionType]:
+        pass

--- a/api/domain/role/_rolerepository.py
+++ b/api/domain/role/_rolerepository.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 
-from api.domain.role.entities import Limit, PermissionType, Role
+from api.domain.role.entities import Role
 from api.domain.role.errors import RoleAlreadyExistsError
 
 
 class RoleRepository(ABC):
     @abstractmethod
-    async def create_role(self, name: str, permissions: list[PermissionType], limits: list[Limit]) -> Role | RoleAlreadyExistsError:
+    async def create_role(self, name: str) -> Role | RoleAlreadyExistsError:
         pass
 
     @abstractmethod

--- a/api/domain/role/entities.py
+++ b/api/domain/role/entities.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class PermissionType(StrEnum):
@@ -25,10 +25,23 @@ class Limit(BaseModel):
 
 
 class Role(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     id: int
     name: str
     permissions: list[PermissionType]
     limits: list[Limit]
+
+    @field_validator("permissions")
+    @classmethod
+    def unique_permissions(cls, v: list[PermissionType]) -> list[PermissionType]:
+        return list(dict.fromkeys(v))
+
+    @field_validator("limits")
+    @classmethod
+    def unique_limits(cls, v: list["Limit"]) -> list["Limit"]:
+        return list({(limit.router, limit.type): limit for limit in v}.values())
+
     users: int = 0
     created: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))
     updated: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))

--- a/api/domain/role/entities.py
+++ b/api/domain/role/entities.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class PermissionType(StrEnum):
@@ -19,14 +19,12 @@ class LimitType(StrEnum):
 
 
 class Limit(BaseModel):
-    router: int = Field(description="The router ID.")
+    router_id: int = Field(description="The router ID.")
     type: LimitType = Field(description="The limit type.")
     value: int | None = Field(default=None, ge=0, description="The limit value.")
 
 
 class Role(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-
     id: int
     name: str
     permissions: list[PermissionType]
@@ -40,7 +38,7 @@ class Role(BaseModel):
     @field_validator("limits")
     @classmethod
     def unique_limits(cls, v: list["Limit"]) -> list["Limit"]:
-        return list({(limit.router, limit.type): limit for limit in v}.values())
+        return list({(limit.router_id, limit.type): limit for limit in v}.values())
 
     users: int = 0
     created: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))

--- a/api/endpoints/monitoring.py
+++ b/api/endpoints/monitoring.py
@@ -6,7 +6,6 @@ from starlette.responses import Response
 
 from api.domain.role.entities import PermissionType
 from api.helpers._accesscontroller import AccessController
-from api.schemas.admin.roles import PermissionType
 from api.utils.configuration import configuration
 from api.utils.monitoring import (
     inference_output_tokens_per_second,

--- a/api/helpers/_identityaccessmanager.py
+++ b/api/helpers/_identityaccessmanager.py
@@ -100,7 +100,7 @@ class IdentityAccessManager:
 
         # create the limits
         for limit in limits:
-            await postgres_session.execute(statement=insert(table=LimitTable).values(role_id=role_id, router_id=limit.router, type=limit.type, value=limit.value))  # fmt: off
+            await postgres_session.execute(statement=insert(table=LimitTable).values(role_id=role_id, router_id=limit.router_id, type=limit.type, value=limit.value))  # fmt: off
 
         # create the permissions
         for permission in permissions:
@@ -149,7 +149,7 @@ class IdentityAccessManager:
             await postgres_session.execute(statement=delete(table=LimitTable).where(LimitTable.role_id == role.id))
 
             # create the new limits
-            values = [{"role_id": role.id, "router_id": limit.router, "type": limit.type, "value": limit.value} for limit in limits]
+            values = [{"role_id": role.id, "router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in limits]
             if values:
                 await postgres_session.execute(statement=insert(table=LimitTable).values(values))
 
@@ -228,7 +228,7 @@ class IdentityAccessManager:
             for row in result:
                 role_id = row.role_id
                 if role_id in roles:
-                    roles[role_id].limits.append(Limit(router=row.router_id, type=row.type, value=row.value))
+                    roles[role_id].limits.append(Limit(router_id=row.router_id, type=row.type, value=row.value))
 
             # Query permissions for these roles
             permissions_query = select(PermissionTable.role_id, PermissionTable.permission).where(PermissionTable.role_id.in_(list(roles.keys())))

--- a/api/helpers/_limiter.py
+++ b/api/helpers/_limiter.py
@@ -101,7 +101,7 @@ class Limiter:
         has_access = False
         tpm, tpd, rpm, rpd = 0, 0, 0, 0
         for limit in user_info.limits:
-            if limit.router == router_id:
+            if limit.router_id == router_id:
                 has_access = True
                 match limit.type:
                     case LimitType.TPM:

--- a/api/helpers/models/_modelregistry.py
+++ b/api/helpers/models/_modelregistry.py
@@ -751,7 +751,7 @@ class ModelRegistry:
                 continue
 
             # skip model if user has no access to it
-            router_limit = next((limit for limit in user_info.limits if limit.router == router.id), None)
+            router_limit = next((limit for limit in user_info.limits if limit.router_id == router.id), None)
             has_access = router_limit is not None and (router_limit.value is None or router_limit.value > 0)
             if not has_access:
                 if name is not None:

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([NotAdminUserHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException]),
 )
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),

--- a/api/infrastructure/fastapi/schemas/roles.py
+++ b/api/infrastructure/fastapi/schemas/roles.py
@@ -1,9 +1,29 @@
+from enum import StrEnum
 from typing import Annotated, Literal
 
 from pydantic import Field, StringConstraints
 
-from api.domain.role.entities import Limit, PermissionType
 from api.schemas import BaseModel
+
+
+class PermissionType(StrEnum):
+    ADMIN = "admin"
+    CREATE_PUBLIC_COLLECTION = "create_public_collection"
+    READ_METRIC = "read_metric"
+    PROVIDE_MODELS = "provide_models"
+
+
+class LimitType(StrEnum):
+    TPM = "tpm"
+    TPD = "tpd"
+    RPM = "rpm"
+    RPD = "rpd"
+
+
+class Limit(BaseModel):
+    router_id: int = Field(alias="router_id", description="The router ID.")
+    type: LimitType = Field(description="The limit type.")
+    value: int | None = Field(default=None, ge=0, description="The limit value.")
 
 
 class CreateRoleBody(BaseModel):

--- a/api/infrastructure/postgres/__init__.py
+++ b/api/infrastructure/postgres/__init__.py
@@ -1,4 +1,6 @@
 from ._postgreskeyrepository import PostgresKeyRepository
+from ._postgreslimitrepository import PostgresLimitRepository
+from ._postgrespermissionrepository import PostgresPermissionRepository
 from ._postgresproviderrepository import PostgresProviderRepository
 from ._postgresrolesrepository import PostgresRolesRepository
 from ._postgresrouterrepository import PostgresRouterRepository
@@ -12,4 +14,6 @@ __all__ = [
     "PostgresRolesRepository",
     "PostgresRouterRepository",
     "PostgresProviderRepository",
+    "PostgresPermissionRepository",
+    "PostgresLimitRepository",
 ]

--- a/api/infrastructure/postgres/_postgreslimitrepository.py
+++ b/api/infrastructure/postgres/_postgreslimitrepository.py
@@ -16,9 +16,9 @@ class PostgresLimitRepository(LimitRepository):
 
         result = await self.postgres_session.execute(
             insert(LimitTable)
-            .values([{"role_id": role_id, "router_id": limit.router, "type": limit.type, "value": limit.value} for limit in limits])
+            .values([{"role_id": role_id, "router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in limits])
             .on_conflict_do_nothing()
             .returning(LimitTable.router_id, LimitTable.type, LimitTable.value)
         )
 
-        return [Limit(router=row.router_id, type=row.type, value=row.value) for row in result.all()]
+        return [Limit(router_id=row.router_id, type=row.type, value=row.value) for row in result.all()]

--- a/api/infrastructure/postgres/_postgreslimitrepository.py
+++ b/api/infrastructure/postgres/_postgreslimitrepository.py
@@ -1,0 +1,24 @@
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.domain.role import LimitRepository
+from api.domain.role.entities import Limit
+from api.sql.models import Limit as LimitTable
+
+
+class PostgresLimitRepository(LimitRepository):
+    def __init__(self, postgres_session: AsyncSession):
+        self.postgres_session = postgres_session
+
+    async def create_limits(self, role_id: int, limits: list[Limit]) -> list[Limit]:
+        if not limits:
+            return []
+
+        result = await self.postgres_session.execute(
+            insert(LimitTable)
+            .values([{"role_id": role_id, "router_id": limit.router, "type": limit.type, "value": limit.value} for limit in limits])
+            .on_conflict_do_nothing()
+            .returning(LimitTable.router_id, LimitTable.type, LimitTable.value)
+        )
+
+        return [Limit(router=row.router_id, type=row.type, value=row.value) for row in result.all()]

--- a/api/infrastructure/postgres/_postgrespermissionrepository.py
+++ b/api/infrastructure/postgres/_postgrespermissionrepository.py
@@ -1,0 +1,24 @@
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.domain.role import PermissionRepository
+from api.domain.role.entities import PermissionType
+from api.sql.models import Permission as PermissionTable
+
+
+class PostgresPermissionRepository(PermissionRepository):
+    def __init__(self, postgres_session: AsyncSession):
+        self.postgres_session = postgres_session
+
+    async def create_permissions(self, role_id: int, permissions: list[PermissionType]) -> list[PermissionType]:
+        if not permissions:
+            return []
+
+        result = await self.postgres_session.execute(
+            insert(PermissionTable)
+            .values([{"role_id": role_id, "permission": permission} for permission in permissions])
+            .on_conflict_do_nothing()
+            .returning(PermissionTable.permission)
+        )
+
+        return [PermissionType(row.permission) for row in result.all()]

--- a/api/infrastructure/postgres/_postgresrolesrepository.py
+++ b/api/infrastructure/postgres/_postgresrolesrepository.py
@@ -108,7 +108,7 @@ class PostgresRolesRepository(RoleRepository):
             for row in result:
                 role_id = row.role_id
                 if role_id in roles:
-                    roles[role_id].limits.append(Limit(router=row.router_id, type=row.type, value=row.value))
+                    roles[role_id].limits.append(Limit(router_id=row.router_id, type=row.type, value=row.value))
 
             # Query permissions for these roles
             permissions_query = select(PermissionTable.role_id, PermissionTable.permission).where(PermissionTable.role_id.in_(list(roles.keys())))

--- a/api/infrastructure/postgres/_postgresrolesrepository.py
+++ b/api/infrastructure/postgres/_postgresrolesrepository.py
@@ -18,7 +18,7 @@ class PostgresRolesRepository(RoleRepository):
     def __init__(self, postgres_session: AsyncSession):
         self.postgres_session = postgres_session
 
-    async def create_role(self, name: str, permissions: list[PermissionType], limits: list[Limit]) -> Role | RoleAlreadyExistsError:
+    async def create_role(self, name: str) -> Role | RoleAlreadyExistsError:
         try:
             result = await self.postgres_session.execute(
                 insert(RoleTable)
@@ -34,17 +34,11 @@ class PostgresRolesRepository(RoleRepository):
         except IntegrityError:
             return RoleAlreadyExistsError(name=name)
 
-        for limit in limits:
-            await self.postgres_session.execute(insert(LimitTable).values(role_id=row.id, router_id=limit.router, type=limit.type, value=limit.value))
-
-        for permission in permissions:
-            await self.postgres_session.execute(insert(PermissionTable).values(role_id=row.id, permission=permission))
-
         return Role(
             id=row.id,
             name=row.name,
-            permissions=permissions,
-            limits=limits,
+            permissions=[],
+            limits=[],
             users=0,
             created=row.created,
             updated=row.updated,

--- a/api/infrastructure/postgres/_postgresuserinforepository.py
+++ b/api/infrastructure/postgres/_postgresuserinforepository.py
@@ -91,7 +91,7 @@ class PostgresUserInfoRepository(UserInfoRepository):
             for row in result:
                 role_id = row.role_id
                 if role_id in roles:
-                    roles[role_id].limits.append(Limit(router=row.router_id, type=row.type, value=row.value))
+                    roles[role_id].limits.append(Limit(router_id=row.router_id, type=row.type, value=row.value))
 
             # Query permissions for these roles
             permissions_query = select(PermissionTable.role_id, PermissionTable.permission).where(PermissionTable.role_id.in_(list(roles.keys())))

--- a/api/schemas/admin/roles.py
+++ b/api/schemas/admin/roles.py
@@ -37,9 +37,9 @@ class RoleUpdateRequest(BaseModel):
         keys = set()
         if limits is not None:
             for limit in limits:
-                key = (limit.router, limit.type.value)
+                key = (limit.router_id, limit.type.value)
                 if key in keys:
-                    raise ValueError(f"Duplicate limit found: ({limit.router}, {limit.type}).")
+                    raise ValueError(f"Duplicate limit found: ({limit.router_id}, {limit.type}).")
                 keys.add(key)
         return limits
 
@@ -57,9 +57,9 @@ class CreateRole(BaseModel):
     def check_duplicate_limits(cls, limits):
         keys = set()
         for limit in limits:
-            key = (limit.router, limit.type.value)
+            key = (limit.router_id, limit.type.value)
             if key in keys:
-                raise ValueError(f"Duplicate limit found: ({limit.router}, {limit.type}).")
+                raise ValueError(f"Duplicate limit found: ({limit.router_id}, {limit.type}).")
             keys.add(key)
 
         return limits

--- a/api/schemas/admin/roles.py
+++ b/api/schemas/admin/roles.py
@@ -22,7 +22,7 @@ class LimitType(str, Enum):
 
 
 class Limit(BaseModel):
-    router: int = Field(description="The router ID.")
+    router_id: int = Field(description="The router ID.")
     type: LimitType = Field(description="The limit type.")
     value: int | None = Field(default=None, ge=0, description="The limit value.")
 

--- a/api/tests/integ/conftest.py
+++ b/api/tests/integ/conftest.py
@@ -76,10 +76,10 @@ def roles(test_client: TestClient) -> tuple[dict, dict]:
 
     limits = []
     for router in routers:
-        limits.append({"router": router["id"], "type": LimitType.RPM.value, "value": None})
-        limits.append({"router": router["id"], "type": LimitType.RPD.value, "value": None})
-        limits.append({"router": router["id"], "type": LimitType.TPM.value, "value": None})
-        limits.append({"router": router["id"], "type": LimitType.TPD.value, "value": None})
+        limits.append({"router_id": router["id"], "type": LimitType.RPM.value, "value": None})
+        limits.append({"router_id": router["id"], "type": LimitType.RPD.value, "value": None})
+        limits.append({"router_id": router["id"], "type": LimitType.TPM.value, "value": None})
+        limits.append({"router_id": router["id"], "type": LimitType.TPD.value, "value": None})
 
     # create role admin
     response = test_client.post(

--- a/api/tests/integ/test_admin/test_admin.py
+++ b/api/tests/integ/test_admin/test_admin.py
@@ -198,10 +198,10 @@ class TestAuth:
             json={
                 "name": f"test_role_{str(uuid4())}",
                 "limits": [
-                    {"router": text_generation_router.id, "type": LimitType.RPM.value, "value": None},
-                    {"router": text_generation_router.id, "type": LimitType.RPD.value, "value": None},
-                    {"router": text_generation_router.id, "type": LimitType.TPM.value, "value": None},
-                    {"router": text_generation_router.id, "type": LimitType.TPD.value, "value": 10},  # 10 tokens per days
+                    {"router_id": text_generation_router.id, "type": LimitType.RPM.value, "value": None},
+                    {"router_id": text_generation_router.id, "type": LimitType.RPD.value, "value": None},
+                    {"router_id": text_generation_router.id, "type": LimitType.TPM.value, "value": None},
+                    {"router_id": text_generation_router.id, "type": LimitType.TPD.value, "value": 10},  # 10 tokens per days
                 ],
             },
         )
@@ -263,10 +263,10 @@ class TestAuth:
             json={
                 "name": f"test_role_{str(uuid4())}",
                 "limits": [
-                    {"router": text_generation_router.id, "type": "rpm", "value": None},
-                    {"router": text_generation_router.id, "type": "rpd", "value": None},
-                    {"router": text_generation_router.id, "type": "tpm", "value": None},
-                    {"router": text_generation_router.id, "type": "tpd", "value": 50},  # 50 tokens per days
+                    {"router_id": text_generation_router.id, "type": "rpm", "value": None},
+                    {"router_id": text_generation_router.id, "type": "rpd", "value": None},
+                    {"router_id": text_generation_router.id, "type": "tpm", "value": None},
+                    {"router_id": text_generation_router.id, "type": "tpd", "value": 50},  # 50 tokens per days
                 ],
             },
         )

--- a/api/tests/integ/test_admin/test_identityaccessmanager.py
+++ b/api/tests/integ/test_admin/test_identityaccessmanager.py
@@ -23,8 +23,8 @@ class TestIdentityAccessManager:
             "name": "test-role",
             "permissions": [PermissionType.ADMIN.value],
             "limits": [
-                {"router": router_id, "type": "rpm", "value": 100},
-                {"router": router_id, "type": "rpd", "value": 1000},
+                {"router_id": router_id, "type": "rpm", "value": 100},
+                {"router_id": router_id, "type": "rpd", "value": 1000},
             ],
         }
 
@@ -38,7 +38,7 @@ class TestIdentityAccessManager:
             "name": "updated-role",
             "permissions": [PermissionType.ADMIN.value],
             "limits": [
-                {"router": router_id, "type": "rpm", "value": 200},
+                {"router_id": router_id, "type": "rpm", "value": 200},
             ],
         }
 
@@ -54,7 +54,7 @@ class TestIdentityAccessManager:
         # Verify the updates
         assert updated_role["name"] == "updated-role"
         assert len(updated_role["limits"]) == 1
-        assert updated_role["limits"][0]["router"] == router_id
+        assert updated_role["limits"][0]["router_id"] == router_id
         assert updated_role["limits"][0]["type"] == "rpm"
         assert updated_role["limits"][0]["value"] == 200
         assert len(updated_role["permissions"]) == 1

--- a/api/tests/integ/utils.py
+++ b/api/tests/integ/utils.py
@@ -193,10 +193,10 @@ def create_role(router_id: int, client: TestClient) -> int:
     payload = CreateRole(
         name=f"test-role-{dt.datetime.now().strftime('%Y%m%d%H%M%S')}",
         limits=[
-            Limit(router=router_id, type=LimitType.RPM, value=None),
-            Limit(router=router_id, type=LimitType.RPD, value=None),
-            Limit(router=router_id, type=LimitType.TPM, value=None),
-            Limit(router=router_id, type=LimitType.TPD, value=None),
+            Limit(router_id=router_id, type=LimitType.RPM, value=None),
+            Limit(router_id=router_id, type=LimitType.RPD, value=None),
+            Limit(router_id=router_id, type=LimitType.TPM, value=None),
+            Limit(router_id=router_id, type=LimitType.TPD, value=None),
         ],
     )
 

--- a/api/tests/integration/endpoints/admin/roles/test_create_role.py
+++ b/api/tests/integration/endpoints/admin/roles/test_create_role.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock
+
+from httpx import AsyncClient
+import pytest
+import pytest_asyncio
+
+from api.dependencies import create_role_use_case_factory
+from api.domain.role.errors import RoleAlreadyExistsError
+from api.domain.userinfo.errors import UserIsNotAdminError
+from api.tests.helpers import create_token
+from api.tests.integration.factories import UserSQLFactory
+from api.utils.variables import EndpointRoute
+
+URL = f"/v1{EndpointRoute.ADMIN_ROLES}"
+
+
+def _valid_body(**overrides) -> dict:
+    body = {"name": "new-role"}
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestCreateRole:
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup(self, db_session):
+        self.admin_user = UserSQLFactory(admin_user=True)
+        self.token = await create_token(db_session, name="admin_token", user=self.admin_user)
+
+    async def test_happy_path(self, client: AsyncClient, db_session):
+        await db_session.flush()
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(),
+        )
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["name"] == "new-role"
+        assert isinstance(data["id"], int)
+        assert data["permissions"] == []
+        assert data["limits"] == []
+
+    @pytest.mark.parametrize(
+        "use_case_result,expected_status,expected_detail",
+        [
+            (
+                RoleAlreadyExistsError(name="existing-role"),
+                409,
+                "Role existing-role already exists.",
+            ),
+            (
+                UserIsNotAdminError(),
+                403,
+                "User has no admin rights.",
+            ),
+        ],
+    )
+    async def test_error_maps_to_correct_http_status(self, client: AsyncClient, app, use_case_result, expected_status, expected_detail):
+        mock_use_case = AsyncMock()
+        mock_use_case.execute.return_value = use_case_result
+        app.dependency_overrides[create_role_use_case_factory] = lambda: mock_use_case
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(),
+        )
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail
+
+    @pytest.mark.parametrize(
+        "headers,expected_status,expected_detail",
+        [
+            ({}, 401, "Not authenticated"),
+            ({"Authorization": "Bearer invalid-token"}, 403, "Invalid API key."),
+        ],
+    )
+    async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
+        response = await client.post(url=URL, headers=headers, json=_valid_body())
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/postgres/test_postgreslimitrepository.py
+++ b/api/tests/integration/postgres/test_postgreslimitrepository.py
@@ -1,0 +1,73 @@
+import pytest
+
+from api.domain.role.entities import Limit, LimitType
+from api.infrastructure.postgres._postgreslimitrepository import PostgresLimitRepository
+from api.tests.integration.factories import LimitSQLFactory, RoleSQLFactory, RouterSQLFactory
+
+
+@pytest.fixture
+def repository(db_session):
+    return PostgresLimitRepository(postgres_session=db_session)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestCreateLimits:
+    async def test_returns_empty_list_when_limits_is_empty(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.create_limits(role_id=role.id, limits=[])
+
+        # Assert
+        assert result == []
+
+    async def test_creates_multiple_limits_and_returns_them(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        router_1 = RouterSQLFactory()
+        router_2 = RouterSQLFactory()
+        await db_session.flush()
+        limits = [
+            Limit(router=router_1.id, type=LimitType.TPM, value=100),
+            Limit(router=router_2.id, type=LimitType.RPM, value=200),
+        ]
+
+        # Act
+        result = await repository.create_limits(role_id=role.id, limits=limits)
+
+        # Assert
+        assert len(result) == 2
+        result_by_router = {r.router: r for r in result}
+        assert result_by_router[router_1.id].type == LimitType.TPM
+        assert result_by_router[router_1.id].value == 100
+        assert result_by_router[router_2.id].type == LimitType.RPM
+        assert result_by_router[router_2.id].value == 200
+
+    async def test_limit_value_can_be_none(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        router = RouterSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.create_limits(role_id=role.id, limits=[Limit(router=router.id, type=LimitType.TPD, value=None)])
+
+        # Assert
+        assert result[0].value is None
+
+    async def test_should_create_only_none_duplicate_permission(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        router = RouterSQLFactory()
+        LimitSQLFactory(role=role, router=router, type=LimitType.TPM, value=100)
+        await db_session.flush()
+
+        # Act
+        limits = await repository.create_limits(
+            role_id=role.id, limits=[Limit(router=router.id, type=LimitType.TPM, value=200), Limit(router=router.id, type=LimitType.RPM, value=200)]
+        )
+
+        # Assert
+        assert limits == [Limit(router=router.id, type=LimitType.RPM, value=200)]

--- a/api/tests/integration/postgres/test_postgreslimitrepository.py
+++ b/api/tests/integration/postgres/test_postgreslimitrepository.py
@@ -30,8 +30,8 @@ class TestCreateLimits:
         router_2 = RouterSQLFactory()
         await db_session.flush()
         limits = [
-            Limit(router=router_1.id, type=LimitType.TPM, value=100),
-            Limit(router=router_2.id, type=LimitType.RPM, value=200),
+            Limit(router_id=router_1.id, type=LimitType.TPM, value=100),
+            Limit(router_id=router_2.id, type=LimitType.RPM, value=200),
         ]
 
         # Act
@@ -39,7 +39,7 @@ class TestCreateLimits:
 
         # Assert
         assert len(result) == 2
-        result_by_router = {r.router: r for r in result}
+        result_by_router = {r.router_id: r for r in result}
         assert result_by_router[router_1.id].type == LimitType.TPM
         assert result_by_router[router_1.id].value == 100
         assert result_by_router[router_2.id].type == LimitType.RPM
@@ -52,7 +52,7 @@ class TestCreateLimits:
         await db_session.flush()
 
         # Act
-        result = await repository.create_limits(role_id=role.id, limits=[Limit(router=router.id, type=LimitType.TPD, value=None)])
+        result = await repository.create_limits(role_id=role.id, limits=[Limit(router_id=router.id, type=LimitType.TPD, value=None)])
 
         # Assert
         assert result[0].value is None
@@ -66,8 +66,9 @@ class TestCreateLimits:
 
         # Act
         limits = await repository.create_limits(
-            role_id=role.id, limits=[Limit(router=router.id, type=LimitType.TPM, value=200), Limit(router=router.id, type=LimitType.RPM, value=200)]
+            role_id=role.id,
+            limits=[Limit(router_id=router.id, type=LimitType.TPM, value=200), Limit(router_id=router.id, type=LimitType.RPM, value=200)],
         )
 
         # Assert
-        assert limits == [Limit(router=router.id, type=LimitType.RPM, value=200)]
+        assert limits == [Limit(router_id=router.id, type=LimitType.RPM, value=200)]

--- a/api/tests/integration/postgres/test_postgrespermissionrepository.py
+++ b/api/tests/integration/postgres/test_postgrespermissionrepository.py
@@ -1,0 +1,51 @@
+import pytest
+
+from api.domain.role.entities import PermissionType
+from api.infrastructure.postgres._postgrespermissionrepository import PostgresPermissionRepository
+from api.tests.integration.factories import PermissionSQLFactory, RoleSQLFactory
+
+
+@pytest.fixture
+def repository(db_session):
+    return PostgresPermissionRepository(postgres_session=db_session)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestCreatePermissions:
+    async def test_returns_empty_list_when_permissions_is_empty(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.create_permissions(role_id=role.id, permissions=[])
+
+        # Assert
+        assert result == []
+
+    async def test_creates_multiple_permissions_and_returns_them(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.create_permissions(
+            role_id=role.id,
+            permissions=[PermissionType.ADMIN, PermissionType.READ_METRIC],
+        )
+
+        # Assert
+        assert set(result) == {PermissionType.ADMIN, PermissionType.READ_METRIC}
+
+    async def test_should_create_only_none_duplicate_limits(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        PermissionSQLFactory(role=role, permission=PermissionType.READ_METRIC)
+        await db_session.flush()
+        # Act
+        result = await repository.create_permissions(
+            role_id=role.id, permissions=[PermissionType.READ_METRIC, PermissionType.CREATE_PUBLIC_COLLECTION]
+        )
+
+        # Assert
+        assert result == [PermissionType.CREATE_PUBLIC_COLLECTION]

--- a/api/tests/integration/postgres/test_postgresrolesrepository.py
+++ b/api/tests/integration/postgres/test_postgresrolesrepository.py
@@ -107,7 +107,7 @@ class TestGetRoles:
 
         # Assert
         assert len(result[0].limits) == 1
-        assert result[0].limits[0].router == router.id
+        assert result[0].limits[0].router_id == router.id
         assert result[0].limits[0].type == LimitType.TPM
         assert result[0].limits[0].value == 500
 

--- a/api/tests/integration/postgres/test_postgresrolesrepository.py
+++ b/api/tests/integration/postgres/test_postgresrolesrepository.py
@@ -1,6 +1,6 @@
 import pytest
 
-from api.domain.role.entities import Limit, LimitType, PermissionType, Role
+from api.domain.role.entities import LimitType, PermissionType, Role
 from api.domain.role.errors import RoleAlreadyExistsError
 from api.infrastructure.postgres import PostgresRolesRepository
 from api.tests.integration.factories import LimitSQLFactory, PermissionSQLFactory, RoleSQLFactory, RouterSQLFactory, UserSQLFactory
@@ -16,47 +16,19 @@ def repository(db_session):
 class TestCreateRole:
     async def test_creates_role_and_returns_role_entity(self, repository, db_session):
         # Act
-        result = await repository.create_role(name="test_role", permissions=[], limits=[])
+        result = await repository.create_role(name="test_role")
 
         # Assert
         assert isinstance(result, Role)
         assert result.name == "test_role"
         assert isinstance(result.id, int)
 
-    async def test_creates_role_with_permissions(self, repository, db_session):
-        # Act
-        result = await repository.create_role(
-            name="test_role_with_permissions",
-            permissions=[PermissionType.ADMIN, PermissionType.READ_METRIC],
-            limits=[],
-        )
-
-        # Assert
-        assert isinstance(result, Role)
-        assert set(result.permissions) == {PermissionType.ADMIN, PermissionType.READ_METRIC}
-
-    async def test_creates_role_with_limits(self, repository, db_session):
-        # Arrange
-        router = RouterSQLFactory()
-        await db_session.flush()
-        limit = Limit(router=router.id, type=LimitType.TPM, value=100)
-
-        # Act
-        result = await repository.create_role(name="test_role_with_limits", permissions=[], limits=[limit])
-
-        # Assert
-        assert isinstance(result, Role)
-        assert len(result.limits) == 1
-        assert result.limits[0].router == router.id
-        assert result.limits[0].type == LimitType.TPM
-        assert result.limits[0].value == 100
-
     async def test_returns_role_already_exists_error_when_name_is_duplicate(self, repository, db_session):
         # Arrange
-        await repository.create_role(name="duplicate_role", permissions=[], limits=[])
+        await repository.create_role(name="duplicate_role")
 
         # Act
-        result = await repository.create_role(name="duplicate_role", permissions=[], limits=[])
+        result = await repository.create_role(name="duplicate_role")
 
         # Assert
         assert isinstance(result, RoleAlreadyExistsError)

--- a/api/tests/unit/test_helpers/test_identityaccessmanager/test_login.py
+++ b/api/tests/unit/test_helpers/test_identityaccessmanager/test_login.py
@@ -61,7 +61,7 @@ async def test_login_success_user(postgres_session: AsyncSession, iam: IdentityA
             organization=None,
             budget=None,
             permissions=[PermissionType.READ_METRIC],
-            limits=[Limit(router=1, type=LimitType.TPM, value=100)],
+            limits=[Limit(router_id=1, type=LimitType.TPM, value=100)],
             expires=None,
             created=10,
             updated=11,

--- a/api/tests/unit/test_helpers/test_identityaccessmanager/test_roles.py
+++ b/api/tests/unit/test_helpers/test_identityaccessmanager/test_roles.py
@@ -99,8 +99,8 @@ async def test_update_role_name_limits_permissions(postgres_session: AsyncSessio
         role_id=10,
         name="power-user",
         limits=[
-            Limit(router=1, type=LimitType.TPM, value=100),
-            Limit(router=1, type=LimitType.RPM, value=200),
+            Limit(router_id=1, type=LimitType.TPM, value=100),
+            Limit(router_id=1, type=LimitType.RPM, value=200),
         ],
         permissions=[PermissionType.READ_METRIC, PermissionType.READ_METRIC],  # duplicate intentional
     )

--- a/api/tests/unit/test_helpers/test_identityaccessmanager/test_roles.py
+++ b/api/tests/unit/test_helpers/test_identityaccessmanager/test_roles.py
@@ -161,7 +161,7 @@ async def test_get_roles_with_details(postgres_session: AsyncSession, iam: Ident
     assert len(roles) == 2
     first = next(r for r in roles if r.id == 1)
     assert first.users == 3
-    assert any(limit.router == 1 and limit.type == LimitType.TPM for limit in first.limits)
+    assert any(limit.router_id == 1 and limit.type == LimitType.TPM for limit in first.limits)
     assert PermissionType.ADMIN in first.permissions
 
 

--- a/api/tests/unit/test_helpers/test_identityaccessmanager/test_users.py
+++ b/api/tests/unit/test_helpers/test_identityaccessmanager/test_users.py
@@ -344,7 +344,7 @@ async def test_get_user_info_by_email_success(postgres_session: AsyncSession, ia
     assert user.created == 20
     assert user.updated == 21
     assert any(p.value == "admin" for p in user.permissions)
-    assert any(limit.router == 202 and limit.type == LimitType.RPM and limit.value == 200 for limit in user.limits)
+    assert any(limit.router_id == 202 and limit.type == LimitType.RPM and limit.value == 200 for limit in user.limits)
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_helpers/test_limiter.py
+++ b/api/tests/unit/test_helpers/test_limiter.py
@@ -439,7 +439,7 @@ async def test_limiter_check_user_limits_insufficient_permission(strategy):
         limiter = Limiter(mock_redis_pool, strategy)
 
         # Mock limit with 0 value
-        limit_mock = Limit(router=1, type=LimitType.TPM, value=0)
+        limit_mock = Limit(router_id=1, type=LimitType.TPM, value=0)
 
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=[limit_mock], expires=None, created=0, updated=0)
 
@@ -462,10 +462,10 @@ async def test_limiter_check_user_limits_rpm_exceeded(strategy):
 
         # Mock limits
         limits = [
-            Limit(router=1, type=LimitType.RPM, value=10),
-            Limit(router=1, type=LimitType.RPD, value=1000),
-            Limit(router=1, type=LimitType.TPM, value=500),
-            Limit(router=1, type=LimitType.TPD, value=5000),
+            Limit(router_id=1, type=LimitType.RPM, value=10),
+            Limit(router_id=1, type=LimitType.RPD, value=1000),
+            Limit(router_id=1, type=LimitType.TPM, value=500),
+            Limit(router_id=1, type=LimitType.TPD, value=5000),
         ]
 
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=limits, expires=None, created=0, updated=0)
@@ -505,17 +505,17 @@ async def test_limiter_check_user_limits_with_prompt_tokens_success(strategy):
 
         # Mock limits: RPM, RPD, TPM, TPD
         # We need at least one limit for router 1 so has_access=True
-        limit_rpm = Limit(router=1, type=LimitType.RPM, value=100)
+        limit_rpm = Limit(router_id=1, type=LimitType.RPM, value=100)
 
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=[limit_rpm], expires=None, created=0, updated=0)
 
         limiter.hit = AsyncMock(return_value=True)
 
         limits = [
-            Limit(router=1, type=LimitType.RPM, value=100),
-            Limit(router=1, type=LimitType.RPD, value=1000),
-            Limit(router=1, type=LimitType.TPM, value=500),
-            Limit(router=1, type=LimitType.TPD, value=5000),
+            Limit(router_id=1, type=LimitType.RPM, value=100),
+            Limit(router_id=1, type=LimitType.RPD, value=1000),
+            Limit(router_id=1, type=LimitType.TPM, value=500),
+            Limit(router_id=1, type=LimitType.TPD, value=5000),
         ]
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=limits, expires=None, created=0, updated=0)
 
@@ -544,10 +544,10 @@ async def test_limiter_check_user_limits_rpd_exceeded(strategy):
         limiter = Limiter(mock_redis_pool, strategy)
 
         limits = [
-            Limit(router=1, type=LimitType.RPM, value=100),
-            Limit(router=1, type=LimitType.RPD, value=1000),
-            Limit(router=1, type=LimitType.TPM, value=500),
-            Limit(router=1, type=LimitType.TPD, value=5000),
+            Limit(router_id=1, type=LimitType.RPM, value=100),
+            Limit(router_id=1, type=LimitType.RPD, value=1000),
+            Limit(router_id=1, type=LimitType.TPM, value=500),
+            Limit(router_id=1, type=LimitType.TPD, value=5000),
         ]
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=limits, expires=None, created=0, updated=0)
 
@@ -578,10 +578,10 @@ async def test_limiter_check_user_limits_tpd_exceeded(strategy):
         limiter = Limiter(mock_redis_pool, strategy)
 
         limits = [
-            Limit(router=1, type=LimitType.RPM, value=100),
-            Limit(router=1, type=LimitType.RPD, value=1000),
-            Limit(router=1, type=LimitType.TPM, value=500),
-            Limit(router=1, type=LimitType.TPD, value=5000),
+            Limit(router_id=1, type=LimitType.RPM, value=100),
+            Limit(router_id=1, type=LimitType.RPD, value=1000),
+            Limit(router_id=1, type=LimitType.TPM, value=500),
+            Limit(router_id=1, type=LimitType.TPD, value=5000),
         ]
         user_info = UserInfo(id=1, email="u@test.com", name="User", permissions=[], limits=limits, expires=None, created=0, updated=0)
 

--- a/api/tests/unit/use_case/admin/roles/test_createroleusecase.py
+++ b/api/tests/unit/use_case/admin/roles/test_createroleusecase.py
@@ -5,7 +5,7 @@ import pytest
 from api.domain.role.entities import PermissionType
 from api.domain.role.errors import RoleAlreadyExistsError
 from api.domain.userinfo.errors import UserIsNotAdminError
-from api.tests.unit.use_case.factories import RoleFactory, UserInfoFactory
+from api.tests.unit.use_case.factories import LimitFactory, RoleFactory, UserInfoFactory
 from api.use_cases.admin.roles import CreateRoleCommand, CreateRoleUseCase, CreateRoleUseCaseSuccess
 
 
@@ -15,34 +15,58 @@ def role_repository():
 
 
 @pytest.fixture
+def permission_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def limit_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
 def user_info_repository():
     return AsyncMock()
 
 
 @pytest.fixture
-def use_case(role_repository, user_info_repository):
-    return CreateRoleUseCase(role_repository=role_repository, user_info_repository=user_info_repository)
+def use_case(role_repository, user_info_repository, permission_repository, limit_repository):
+    return CreateRoleUseCase(
+        role_repository=role_repository,
+        permission_repository=permission_repository,
+        limit_repository=limit_repository,
+        user_info_repository=user_info_repository,
+    )
 
 
 class TestCreateRoleUseCase:
     @pytest.mark.asyncio
-    async def test_should_returns_success_instance(self, use_case, role_repository, user_info_repository):
+    async def test_should_create_role_with_limits_and_permissions_when_user_is_admin_and_role_does_not_exist(
+        self, use_case, role_repository, permission_repository, limit_repository, user_info_repository
+    ):
         # Arrange
+        created_role = RoleFactory(name="created_role")
+        limit = LimitFactory()
         user_info_repository.get_user_info.return_value = UserInfoFactory(admin=True)
-        role_repository.create_role.return_value = RoleFactory(name="created_role", permissions=[PermissionType.READ_METRIC])
-        command = CreateRoleCommand(user_id=1, name="created_role", permissions=[PermissionType.READ_METRIC], limits=[])
+        role_repository.create_role.return_value = created_role
+        permission_repository.create_permissions.return_value = [PermissionType.READ_METRIC]
+        limit_repository.create_limits.return_value = [limit]
+        command = CreateRoleCommand(user_id=1, name="new_role", permissions=[PermissionType.READ_METRIC], limits=[limit])
 
         # Act
         result = await use_case.execute(command)
 
         # Assert
         assert isinstance(result, CreateRoleUseCaseSuccess)
-
-        assert result.role.name == "created_role"
+        assert result.role.name == created_role.name
         assert PermissionType.READ_METRIC in result.role.permissions
+        assert limit in result.role.limits
+        role_repository.create_role.assert_called_once_with(name="new_role")
+        permission_repository.create_permissions.assert_awaited_once_with(role_id=created_role.id, permissions=[PermissionType.READ_METRIC])
+        limit_repository.create_limits.assert_awaited_once_with(role_id=created_role.id, limits=[limit])
 
     @pytest.mark.asyncio
-    async def test_should_return_user_is_not_admin_error_when_user_is_not_admin(self, use_case, user_info_repository):
+    async def test_returns_user_is_not_admin_error_when_user_is_not_admin(self, use_case, user_info_repository):
         # Arrange
         user_info_repository.get_user_info.return_value = UserInfoFactory(without_permission=True, limits=[])
         command = CreateRoleCommand(user_id=1, name="new_role", permissions=[], limits=[])
@@ -54,7 +78,7 @@ class TestCreateRoleUseCase:
         assert isinstance(result, UserIsNotAdminError)
 
     @pytest.mark.asyncio
-    async def test_should_return_role_already_exists_error_when_name_conflicts(self, use_case, role_repository, user_info_repository):
+    async def test_returns_role_already_exists_error_when_name_conflicts(self, use_case, role_repository, user_info_repository):
         # Arrange
         user_info_repository.get_user_info.return_value = UserInfoFactory(admin=True)
         role_repository.create_role.return_value = RoleAlreadyExistsError(name="existing_role")

--- a/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
@@ -7,7 +7,7 @@ from api.domain.router.entities import RouterLoadBalancingStrategy
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.domain.userinfo.errors import UserIsNotAdminError
 from api.tests.unit.use_case.factories import RouterFactory, UserInfoFactory
-from api.use_cases.admin.routers._updaterouterusecase import UpdateRouterCommand, UpdateRouterUseCase, UpdateRouterUseCaseSuccess
+from api.use_cases.admin.routers import UpdateRouterCommand, UpdateRouterUseCase, UpdateRouterUseCaseSuccess
 
 
 @pytest.fixture

--- a/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
+++ b/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
@@ -25,8 +25,23 @@ def role_repository():
 
 
 @pytest.fixture
-def use_case(user_repository, role_repository):
-    return BootstrapAdminUseCase(user_repository=user_repository, role_repository=role_repository)
+def permission_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def limit_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def use_case(user_repository, role_repository, permission_repository, limit_repository):
+    return BootstrapAdminUseCase(
+        user_repository=user_repository,
+        role_repository=role_repository,
+        limit_repository=limit_repository,
+        permission_repository=permission_repository,
+    )
 
 
 @pytest.fixture

--- a/api/tests/unit/use_case/factories.py
+++ b/api/tests/unit/use_case/factories.py
@@ -16,7 +16,7 @@ class LimitFactory(factory.Factory):
     class Meta:
         model = Limit
 
-    router = factory.Faker("random_int", min=1, max=1000)
+    router_id = factory.Faker("random_int", min=1, max=1000)
     type = fuzzy.FuzzyChoice([LimitType.TPM, LimitType.TPD, LimitType.RPM, LimitType.RPD])
     value = fuzzy.FuzzyInteger(100, 10000)
 

--- a/api/tests/unit/use_case/test_getmodelsusecase.py
+++ b/api/tests/unit/use_case/test_getmodelsusecase.py
@@ -73,8 +73,8 @@ def user_info_with_access():
     return UserInfoFactory(
         id=1,
         limits=[
-            Limit(router=1, value=100, type=LimitType.RPM),
-            Limit(router=2, value=None, type=LimitType.RPM),
+            Limit(router_id=1, value=100, type=LimitType.RPM),
+            Limit(router_id=2, value=None, type=LimitType.RPM),
         ],
     )
 
@@ -260,8 +260,8 @@ class TestGetModelsUseCase:
         user_info_zero_limit = UserInfoFactory(
             user_id=1,
             limits=[
-                Limit(router=1, value=0, type=LimitType.RPM),
-                Limit(router=2, value=10, type=LimitType.RPM),
+                Limit(router_id=1, value=0, type=LimitType.RPM),
+                Limit(router_id=2, value=10, type=LimitType.RPM),
             ],
             permissions=[],
         )
@@ -286,7 +286,7 @@ class TestGetModelsUseCase:
     @pytest.mark.asyncio
     async def test_shoudl_return_the_router_when_associated_limit_value_is_none(self, router_repository, user_info_repository, sample_routers):
         # Arrange
-        user_info_unlimited = UserInfoFactory(user_id=1, limits=[Limit(router=1, value=None, type=LimitType.RPM)], permissions=[])
+        user_info_unlimited = UserInfoFactory(user_id=1, limits=[Limit(router_id=1, value=None, type=LimitType.RPM)], permissions=[])
         user_info_repository.get_user_info.return_value = user_info_unlimited
         router_repository.get_all_routers.return_value = sample_routers
         router_repository.get_organization_name.return_value = "OpenAI"

--- a/api/use_cases/admin/bootstrapadminusecase.py
+++ b/api/use_cases/admin/bootstrapadminusecase.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import logging
 
-from api.domain.role import RoleRepository
+from api.domain.role import LimitRepository, PermissionRepository, RoleRepository
 from api.domain.role.entities import Limit, PermissionType, Role
 from api.domain.role.errors import RoleAlreadyExistsError
 from api.domain.user import UserRepository
@@ -37,8 +37,16 @@ type BootstrapAdminUseCaseResult = BootstrapAdminUseCaseSuccess | BootstrapAdmin
 
 
 class BootstrapAdminUseCase:
-    def __init__(self, role_repository: RoleRepository, user_repository: UserRepository):
+    def __init__(
+        self,
+        role_repository: RoleRepository,
+        permission_repository: PermissionRepository,
+        limit_repository: LimitRepository,
+        user_repository: UserRepository,
+    ):
         self.role_repository = role_repository
+        self.permission_repository = permission_repository
+        self.limit_repository = limit_repository
         self.user_repository = user_repository
 
     async def execute(self, command: BootstrapAdminCommand) -> BootstrapAdminUseCaseResult:
@@ -47,14 +55,14 @@ class BootstrapAdminUseCase:
 
         result = await self.role_repository.create_role(
             name=command.name,
-            permissions=command.permissions,
-            limits=command.limits,
         )
         match result:
             case Role() as role_result:
                 role = role_result
             case error:
                 return error
+        await self.permission_repository.create_permissions(role_id=role.id, permissions=command.permissions)
+        await self.limit_repository.create_limits(role_id=role.id, limits=command.limits)
 
         result = await self.user_repository.create_user(
             email=command.email,

--- a/api/use_cases/admin/roles/_createroleusecase.py
+++ b/api/use_cases/admin/roles/_createroleusecase.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from api.domain.role import RoleRepository
+from api.domain.role import LimitRepository, PermissionRepository, RoleRepository
 from api.domain.role.entities import Limit, PermissionType, Role
 from api.domain.role.errors import RoleAlreadyExistsError
 from api.domain.userinfo import UserInfoRepository
@@ -24,8 +24,16 @@ type CreateRoleUseCaseResult = CreateRoleUseCaseSuccess | RoleAlreadyExistsError
 
 
 class CreateRoleUseCase:
-    def __init__(self, role_repository: RoleRepository, user_info_repository: UserInfoRepository):
+    def __init__(
+        self,
+        role_repository: RoleRepository,
+        permission_repository: PermissionRepository,
+        limit_repository: LimitRepository,
+        user_info_repository: UserInfoRepository,
+    ):
         self.role_repository = role_repository
+        self.permission_repository = permission_repository
+        self.limit_repository = limit_repository
         self.user_info_repository = user_info_repository
 
     async def execute(
@@ -37,14 +45,14 @@ class CreateRoleUseCase:
         if not user_info.is_admin:
             return UserIsNotAdminError()
 
-        result = await self.role_repository.create_role(
-            name=command.name,
-            permissions=command.permissions,
-            limits=command.limits,
-        )
-
+        result = await self.role_repository.create_role(name=command.name)
         match result:
-            case Role() as role:
-                return CreateRoleUseCaseSuccess(role)
+            case Role() as created_role:
+                role = created_role
             case error:
                 return error
+        permissions = await self.permission_repository.create_permissions(role_id=role.id, permissions=command.permissions)
+        limits = await self.limit_repository.create_limits(role_id=role.id, limits=command.limits)
+        role.permissions = permissions
+        role.limits = limits
+        return CreateRoleUseCaseSuccess(role)

--- a/api/use_cases/admin/roles/_createroleusecase.py
+++ b/api/use_cases/admin/roles/_createroleusecase.py
@@ -53,6 +53,4 @@ class CreateRoleUseCase:
                 return error
         permissions = await self.permission_repository.create_permissions(role_id=role.id, permissions=command.permissions)
         limits = await self.limit_repository.create_limits(role_id=role.id, limits=command.limits)
-        role.permissions = permissions
-        role.limits = limits
-        return CreateRoleUseCaseSuccess(role)
+        return CreateRoleUseCaseSuccess(role=role.model_copy(update={"permissions": permissions, "limits": limits}))

--- a/api/use_cases/models/_getmodelsusecase.py
+++ b/api/use_cases/models/_getmodelsusecase.py
@@ -38,7 +38,7 @@ class GetModelsUseCase:
 
         for router in routers:
             if router.providers > 0:
-                router_limit = next((limit for limit in user_info.limits if limit.router == router.id), None)
+                router_limit = next((limit for limit in user_info.limits if limit.router_id == router.id), None)
                 has_access = (router_limit is not None and (router_limit.value is None or router_limit.value > 0)) or (
                     PermissionType.ADMIN in user_info.permissions
                 )

--- a/api/utils/lifespan.py
+++ b/api/utils/lifespan.py
@@ -18,7 +18,7 @@ from api.helpers._parsermanager import ParserManager
 from api.helpers._usagemanager import UsageManager
 from api.helpers._usagetokenizer import UsageTokenizer
 from api.helpers.models import ModelRegistry
-from api.infrastructure.postgres import PostgresRolesRepository, PostgresUserRepository
+from api.infrastructure.postgres import PostgresLimitRepository, PostgresPermissionRepository, PostgresRolesRepository, PostgresUserRepository
 from api.schemas.core.configuration import Configuration
 from api.use_cases.admin.bootstrapadminusecase import (
     BootstrapAdminCommand,
@@ -105,8 +105,15 @@ def create_postgres_session_factory(configuration: Configuration) -> tuple[Async
 async def bootstrap_default_admin(configuration: Configuration, postgres_session: AsyncSession):
     user_repository = PostgresUserRepository(postgres_session=postgres_session)
     role_repository = PostgresRolesRepository(postgres_session=postgres_session)
+    limit_repository = PostgresLimitRepository(postgres_session=postgres_session)
+    permission_repository = PostgresPermissionRepository(postgres_session=postgres_session)
 
-    result = await BootstrapAdminUseCase(user_repository=user_repository, role_repository=role_repository).execute(
+    result = await BootstrapAdminUseCase(
+        user_repository=user_repository,
+        role_repository=role_repository,
+        limit_repository=limit_repository,
+        permission_repository=permission_repository,
+    ).execute(
         BootstrapAdminCommand(
             name=configuration.settings.auth_default_username,
             email=configuration.settings.auth_default_username,

--- a/playground/app/features/providers/components/forms.py
+++ b/playground/app/features/providers/components/forms.py
@@ -140,7 +140,7 @@ def provider_settings_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Router",
             items=ProvidersState.routers_name_list,
-            value=ProvidersState.entity.router,
+            value=ProvidersState.entity.router_id,
             on_change=lambda value: ProvidersState.set_edit_entity_attribut("router", value),
             disable=ProvidersState.edit_entity_loading,
             tooltip="Router of the provider",

--- a/playground/app/features/providers/components/forms.py
+++ b/playground/app/features/providers/components/forms.py
@@ -140,7 +140,7 @@ def provider_settings_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Router",
             items=ProvidersState.routers_name_list,
-            value=ProvidersState.entity.router_id,
+            value=ProvidersState.entity.router,
             on_change=lambda value: ProvidersState.set_edit_entity_attribut("router", value),
             disable=ProvidersState.edit_entity_loading,
             tooltip="Router of the provider",

--- a/playground/app/features/providers/components/lists.py
+++ b/playground/app/features/providers/components/lists.py
@@ -26,7 +26,7 @@ def provider_row_content(provider: Provider) -> rx.Component:
             ),
             rx.tooltip(
                 rx.badge(
-                    provider.router,
+                    provider.router_id,
                     variant="soft",
                     color_scheme="green",
                 ),

--- a/playground/app/features/providers/components/lists.py
+++ b/playground/app/features/providers/components/lists.py
@@ -26,7 +26,7 @@ def provider_row_content(provider: Provider) -> rx.Component:
             ),
             rx.tooltip(
                 rx.badge(
-                    provider.router_id,
+                    provider.router,
                     variant="soft",
                     color_scheme="green",
                 ),

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -244,11 +244,11 @@ class ProvidersState(EntityState):
     @rx.event
     async def create_entity(self):
         """Create a provider."""
-        if not self.entity_to_create.router:
+        if not self.entity_to_create.router_id:
             yield rx.toast.warning("Router is required", position="bottom-right")
             return
 
-        router_id = self.routers_dict.get(self.entity_to_create.router, None)
+        router_id = self.routers_dict.get(self.entity_to_create.router_id, None)
         if not router_id:
             yield rx.toast.warning("Router not found", position="bottom-right")
             return
@@ -335,7 +335,7 @@ class ProvidersState(EntityState):
         yield
 
         payload = {
-            "router": self.routers_dict.get(self.entity.router, None),
+            "router": self.routers_dict.get(self.entity.router_id, None),
             "timeout": self.entity.timeout,
             "model_hosting_zone": self.entity.model_hosting_zone,
             "model_total_params": self.entity.model_total_params,

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -244,11 +244,11 @@ class ProvidersState(EntityState):
     @rx.event
     async def create_entity(self):
         """Create a provider."""
-        if not self.entity_to_create.router_id:
+        if not self.entity_to_create.router:
             yield rx.toast.warning("Router is required", position="bottom-right")
             return
 
-        router_id = self.routers_dict.get(self.entity_to_create.router_id, None)
+        router_id = self.routers_dict.get(self.entity_to_create.router, None)
         if not router_id:
             yield rx.toast.warning("Router not found", position="bottom-right")
             return
@@ -335,7 +335,7 @@ class ProvidersState(EntityState):
         yield
 
         payload = {
-            "router": self.routers_dict.get(self.entity.router_id, None),
+            "router": self.routers_dict.get(self.entity.router, None),
             "timeout": self.entity.timeout,
             "model_hosting_zone": self.entity.model_hosting_zone,
             "model_total_params": self.entity.model_total_params,

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -30,7 +30,7 @@ class RolesState(EntityState):
         limits_dict = defaultdict(lambda: {"rpm": None, "rpd": None, "tpm": None, "tpd": None})
 
         for limit in role["limits"]:
-            router_name = router_dict_reverse[limit["router"]]
+            router_name = router_dict_reverse[limit["router_id"]]
             limits_dict[router_name][limit["type"]] = limit["value"]
 
         # Ensure limits are returned sorted by router name for consistent UI ordering
@@ -52,10 +52,10 @@ class RolesState(EntityState):
     def _format_limit(self, limit: dict[str, str | int]) -> list[dict[str, str | int]]:
         """Format limit from Playground format to OpenGateLLM format."""
         return [
-            {"router": self.routers_dict[limit["router"]], "type": "rpm", "value": limit["rpm"]},
-            {"router": self.routers_dict[limit["router"]], "type": "rpd", "value": limit["rpd"]},
-            {"router": self.routers_dict[limit["router"]], "type": "tpm", "value": limit["tpm"]},
-            {"router": self.routers_dict[limit["router"]], "type": "tpd", "value": limit["tpd"]},
+            {"router_id": self.routers_dict[limit["router"]], "type": "rpm", "value": limit["rpm"]},
+            {"router_id": self.routers_dict[limit["router"]], "type": "rpd", "value": limit["rpd"]},
+            {"router_id": self.routers_dict[limit["router"]], "type": "tpm", "value": limit["tpm"]},
+            {"router_id": self.routers_dict[limit["router"]], "type": "tpd", "value": limit["tpd"]},
         ]
 
     ############################################################
@@ -191,10 +191,10 @@ class RolesState(EntityState):
 
             limits.extend(
                 [
-                    {"router": self.routers_dict[limit["router"]], "type": "rpm", "value": limit["rpm"]},
-                    {"router": self.routers_dict[limit["router"]], "type": "rpd", "value": limit["rpd"]},
-                    {"router": self.routers_dict[limit["router"]], "type": "tpm", "value": limit["tpm"]},
-                    {"router": self.routers_dict[limit["router"]], "type": "tpd", "value": limit["tpd"]},
+                    {"router_id": self.routers_dict[limit["router"]], "type": "rpm", "value": limit["rpm"]},
+                    {"router_id": self.routers_dict[limit["router"]], "type": "rpd", "value": limit["rpd"]},
+                    {"router_id": self.routers_dict[limit["router"]], "type": "tpm", "value": limit["tpm"]},
+                    {"router_id": self.routers_dict[limit["router"]], "type": "tpd", "value": limit["tpd"]},
                 ]
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ api = [
     "elasticsearch[async]>=9.3.0",
     "fastapi>=0.133.1",
     "gunicorn>=25.1.0",
-    "html-to-markdown>=2.25.1",
+    "html-to-markdown==2.29.0",
     "itsdangerous>=2.2.0",
     "langchain-text-splitters>=1.1.1",
     "limits>=5.8.0",


### PR DESCRIPTION
## Description

Refactoring of the `POST /v1/admin/roles` endpoint toward clean architecture.

The previous implementation handled role, permission, and limit creation within a single `RoleRepository`, coupling distinct responsibilities. This PR splits them into three independent ports and reorganizes the use case accordingly.

Resolves issue #720.

## Overview

### Area
- [x] API

### Type of change
- [x] Refactor (change that neither fixes a bug nor modifies behavior)

## Definition of Done / Technical changes

- [x] `RoleRepository.create_role` now only takes `name` as parameter
- [x] `PermissionRepository` created with `create_permissions(role_id, permissions)`
- [x] `LimitRepository` created with `create_limits(role_id, limits)`
- [x] `CreateRoleUseCase` orchestrates the three repositories and returns an immutable `Role` via `model_copy`
- [x] `PostgresPermissionRepository` uses `INSERT ... ON CONFLICT DO NOTHING` (PostgreSQL dialect)
- [x] `PostgresLimitRepository` same
- [x] `unique_permissions` and `unique_limits` validators added on the `Role` entity

## Breaking changes
- [x] No breaking changes

## Quality assurance & Review readiness

### Documentation
- [x] No documentation needed

### Tests
- [x] Unit tests added (`test_createroleusecase.py` updated)
- [x] Integration tests added (`test_postgrespermissionrepository.py`, `test_postgreslimitrepository.py`, `test_create_role.py`)
- [x] Existing tests updated (`test_postgresrolesrepository.py`)

### Code Standards
- [x] Code follows project conventions and architecture
- [x] No unused imports, variables, functions, or classes
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project tools

### Git & Process Standards
- [x] PR title follows Conventional Commits
- [x] PR is linked to relevant issue(s) / project(s)

### Deployment Notes
- [x] No special deployment steps required

### Database migration
- [x] No database migration required

