### PR TITLE
fix(playground): fix the selectors non-displayed values in provider, router, and user forms

### DIFF
--- a/playground/app/features/providers/components/forms.py
+++ b/playground/app/features/providers/components/forms.py
@@ -11,12 +11,14 @@ def provider_create_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Router*",
             items=ProvidersState.routers_name_list,
+            value=ProvidersState.entity_to_create.router,
             on_change=lambda value: ProvidersState.set_new_entity_attribut("router", value),
             placeholder="Select router",
         ),
         entity_form_select_field(
             label="API type*",
             items=ProvidersState.provider_types_list,
+            value=ProvidersState.entity_to_create.type,
             on_change=lambda value: ProvidersState.set_new_entity_attribut("type", value),
             placeholder="Select type",
         ),
@@ -77,6 +79,7 @@ def provider_create_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Quality of service metric",
             items=ProvidersState.provider_qos_metric_list,
+            value=ProvidersState.entity_to_create.qos_metric,
             on_change=lambda value: ProvidersState.set_new_entity_attribut("qos_metric", value),
             tooltip="Metric to use for the quality of service policy. If not provided, no QoS policy is applied.",
             placeholder="Select metric (optional)",

--- a/playground/app/features/routers/components/forms.py
+++ b/playground/app/features/routers/components/forms.py
@@ -91,6 +91,7 @@ def router_create_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Type",
             items=RoutersState.router_types_list,
+            value=RoutersState.entity_to_create.type,
             on_change=lambda value: RoutersState.set_new_entity_attribut("type", value),
             tooltip="Router type (e.g., text-generation)",
             placeholder="Select type",
@@ -106,6 +107,7 @@ def router_create_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Load balancing strategy",
             items=RoutersState.router_load_balancing_strategies_list,
+            value=RoutersState.entity_to_create.load_balancing_strategy,
             on_change=lambda value: RoutersState.set_new_entity_attribut("load_balancing_strategy", value),
             tooltip="Strategy to use for load balancing between providers of the router",
             placeholder="Select strategy",

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -29,7 +29,7 @@ class RoutersState(EntityState):
     @rx.var
     def router_load_balancing_strategies_list(self) -> list[str]:
         """Get list of router load balancing strategies."""
-        return ["Shuffle", "Least busy"]
+        return ["Shuffle", "Least Busy"]
 
     ############################################################
     # Load entities

--- a/playground/app/features/users/components/forms.py
+++ b/playground/app/features/users/components/forms.py
@@ -104,12 +104,14 @@ def user_create_form_fields() -> rx.Component:
         entity_form_select_field(
             label="Role*",
             items=UsersState.roles_name_list,
+            value=UsersState.entity_to_create.role,
             on_change=lambda value: UsersState.set_new_entity_attribut("role", value),
             placeholder="Select role",
         ),
         entity_form_select_field(
             label="Organization",
             items=UsersState.organizations_name_list,
+            value=UsersState.entity_to_create.organization,
             on_change=lambda value: UsersState.set_new_entity_attribut("organization", value),
             placeholder="No organization",
         ),


### PR DESCRIPTION
## Description

When using the create forms for routers, providers, and users, selecting a value in a dropdown selector was not visually reflected in the component, the placeholder text would remain displayed even after a selection was made. The value was still correctly applied on form submission, but the UI gave no feedback that a selection had been made.                                             
                                                                                                                                                                                                     
Additionally, for routers using the "Least Busy" load balancing strategy, the selected value was not displayed in the settings form when trying to update an existing router.   

No issue has been created for this bug.

## Overview
This section provides a checklist to help categorize and describe the changes made in this PR.

### Area
Please select the area(s) that this PR affects:
- [ ] Core / Global project settings
- [ ] API
- [x] Playground / Web UI
- [ ] DevOps
- [ ] Docusaurus / Documentation
- [ ] Other (specify below)

### Type of change
Please select the type of change that this PR introduces:
- [ ] New feature
- [x] Bugfix
- [ ] Enhancement (improvement of an existing feature)
- [ ] Refactor (change that neither fixes a bug nor modifies behavior)
- [ ] Documentation
- [ ] Tests
- [ ] Performance improvement
- [ ] Chore / Maintenance (change to the build process or auxiliary tools, dependencies update, etc.)

## Definition of Done / Technical changes

Please provide the Definition of Done (DoD) criteria that apply to this PR.

- Select fields in the router create form display the selected value (type, load_balancing_strategy)                                                                                               
- Select fields in the provider create form display the selected value (router, type, qos_metric)                                                                                                  
- Select fields in the user create form display the selected value (role, organization)                                                                                                            
- The "Least Busy" load balancing strategy is correctly displayed in the router settings form for existing routers       

## Breaking changes
Please select one of the following options:
- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Quality assurance & Review readiness
Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed.

This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.

### Documentation
Please select one of the following options:
- [x] No documentation needed
- [ ] README / Markdown files updated
- [ ] API documentation updated (Swagger / Redoc)
- [ ] Docstrings updated
- [ ] Inline code comments added where needed

### Tests
Please select one or more of the following options:
- [x] No tests added (explain below)
- [ ] Unit tests added
- [ ] Integration tests added
- [ ] Functional tests added
- [ ] End-to-end tests added
- [ ] Performance tests added
- [ ] Existing tests updated

Only playground has been modified, no tests needed.

### Code Standards
- [x] Code follows project conventions and architecture
- [x] No unused imports, variables, functions, or classes
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project tools ([ruff](https://docs.astral.sh/uv/), etc.)

### Git & Process Standards
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR is correctly labeled
- [ ] PR is linked to relevant issue(s) / project(s)
- [x] Author is assigned to the PR
- [x] At least one reviewer has been requested

### Deployment Notes
- [x] No special deployment steps required
- [ ] Requires database migration (see "Database migration" section)
- [ ] Requires new or updated environment variables (explain below)
- [ ] Requires other special deployment steps (explain below)

### Database migration

Please select one of the following options:
- [x] No database migration required
- [ ] This PR requires a database migration (see checklist below)

Please confirm that the following steps have been completed for the database migration:
- [ ] Migration script added to `api/alembic/versions/` folder
- [ ] Migration upgrade tested locally
- [ ] Migration downgrade tested locally
- [ ] Migration documented (if applicable)
