### PR TITLE
fix(audio): do not send default language to whisper model

### DIFF
--- a/api/endpoints/audio.py
+++ b/api/endpoints/audio.py
@@ -50,7 +50,7 @@ async def audio_transcriptions(
             model=data.model,
             endpoint=EndpointRoute.AUDIO_TRANSCRIPTIONS,
             files={"file": (data.file.filename, file_content, data.file.content_type)},
-            form=data.model_dump(mode="json", exclude="file"),
+            form=data.model_dump(mode="json", exclude_none=True, exclude={"file"}),
         ),
         redis_client=redis_client,
     )

--- a/api/schemas/audio.py
+++ b/api/schemas/audio.py
@@ -26,7 +26,7 @@ class AudioTranscriptionResponseFormat(StrEnum):
 class CreateAudioTranscription(BaseModel):
     file: UploadFile
     model: str
-    language: AudioTranscriptionLanguage
+    language: AudioTranscriptionLanguage | None
     prompt: str
     response_format: AudioTranscriptionResponseFormat
     temperature: float
@@ -37,7 +37,7 @@ class CreateAudioTranscription(BaseModel):
         cls,
         file: UploadFile = File(default=..., description="The audio file object (not file name) to transcribe, in one of these formats: mp3 or wav."),
         model: str = Form(default=..., description="ID of the model to use. Call `/v1/models` endpoint to get the list of available models, only `automatic-speech-recognition` model type is supported."),
-        language: AudioTranscriptionLanguage = Form(default=AudioTranscriptionLanguage.EN, description="The language of the output audio. If the output language is different than the audio language, the audio language will be translated into the output language. Supplying the output language in ISO-639-1 (e.g. en, fr) format will improve accuracy and latency."),
+        language: AudioTranscriptionLanguage | None = Form(default=None, description="The language of the output audio. If the output language is different than the audio language, the audio language will be translated into the output language. Output language must be supplied in ISO-639-1 format (e.g. en, fr) format."),
         prompt: str = Form(default="", description="An optional text to tell the model what to do with the input audio."),
         response_format: AudioTranscriptionResponseFormat = Form(default=AudioTranscriptionResponseFormat.JSON, description="The format of the transcript output, in one of these formats: `json` or `text`."),
         temperature: float = Form(default=0.0, ge=0.0, le=1.0, description="The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use log probability to automatically increase the temperature until certain thresholds are hit."),


### PR DESCRIPTION
Remove the "en" default for the language parameter in `/v1/audio/transcriptions`.

When the user does not provide a language, none is forwarded to the model so it can auto-detect it, and return the transcription in the original language
- model_dump uses exclude_none=True to avoid sending `language=null` to the model