### PR TITLE
chore: enable limit pages can be none

### DIFF
--- a/api/domain/provider/_providerrepository.py
+++ b/api/domain/provider/_providerrepository.py
@@ -39,7 +39,7 @@ class ProviderRepository(ABC):
     async def get_providers_page(
         self,
         router_id: int | None,
-        limit: int,
+        limit: int | None,
         offset: int,
         sort_by: ProviderSortField = ProviderSortField.ID,
         sort_order: SortOrder = SortOrder.ASC,

--- a/api/domain/role/_rolerepository.py
+++ b/api/domain/role/_rolerepository.py
@@ -25,7 +25,7 @@ class RoleRepository(ABC):
     @abstractmethod
     async def get_roles_page(
         self,
-        limit: int,
+        limit: int | None,
         offset: int,
         sort_by: SortField,
         sort_order: SortOrder,

--- a/api/domain/router/_routerrepository.py
+++ b/api/domain/router/_routerrepository.py
@@ -18,7 +18,7 @@ class RouterRepository(ABC):
     @abstractmethod
     async def get_routers_page(
         self,
-        limit: int,
+        limit: int | None,
         offset: int,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,

--- a/api/domain/user/_userrepository.py
+++ b/api/domain/user/_userrepository.py
@@ -27,14 +27,14 @@ class UserRepository(ABC):
         pass
 
     @abstractmethod
-    async def get_users(
+    async def get_users(  # @TODO: remove this method after total clean archi migration
         self,
         email: str | None = None,
         user_id: int | None = None,
         role_id: int | None = None,
         organization_id: int | None = None,
         offset: int = 0,
-        limit: int = 10,
+        limit: int | None = 10,
         order_by: Literal["id", "email", "created", "updated"] = "id",
         order_direction: Literal["asc", "desc"] = "asc",
     ) -> list[User]:

--- a/api/infrastructure/postgres/_postgresproviderrepository.py
+++ b/api/infrastructure/postgres/_postgresproviderrepository.py
@@ -42,7 +42,12 @@ class PostgresProviderRepository(ProviderRepository):
             raise
 
     async def get_providers_page(
-        self, router_id: int | None, limit: int, offset: int, sort_by: ProviderSortField = ProviderSortField.ID, sort_order: SortOrder = SortOrder.ASC
+        self,
+        router_id: int | None,
+        limit: int | None,
+        offset: int,
+        sort_by: ProviderSortField = ProviderSortField.ID,
+        sort_order: SortOrder = SortOrder.ASC,
     ) -> ProviderPage:
         select_query = select(ProviderTable)
         count_query = select(func.count()).select_from(ProviderTable)

--- a/api/infrastructure/postgres/_postgresrolesrepository.py
+++ b/api/infrastructure/postgres/_postgresrolesrepository.py
@@ -32,7 +32,11 @@ class PostgresRolesRepository(RoleRepository):
         )
 
     async def get_roles_page(
-        self, limit: int = 10, offset: int = 0, sort_by: SortField = SortField.ID, sort_order: SortOrder = SortOrder.ASC
+        self,
+        limit: int | None,
+        offset: int,
+        sort_by: SortField = SortField.ID,
+        sort_order: SortOrder = SortOrder.ASC,
     ) -> RolePage:
         sort_column = {SortField.ID: RoleTable.id, SortField.NAME: RoleTable.name, SortField.CREATED: RoleTable.created}[sort_by]
         order_fn = asc if sort_order == SortOrder.ASC else desc

--- a/api/infrastructure/postgres/_postgresrouterrepository.py
+++ b/api/infrastructure/postgres/_postgresrouterrepository.py
@@ -89,7 +89,7 @@ class PostgresRouterRepository(RouterRepository):
 
     async def get_routers_page(
         self,
-        limit: int,
+        limit: int | None,
         offset: int,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -97,14 +97,14 @@ class PostgresUserRepository(UserRepository):
 
         return User(**row._mapping)
 
-    async def get_users(
+    async def get_users(  # @TODO: remove this method after total clean archi migration
         self,
         email: str | None = None,
         user_id: int | None = None,
         role_id: int | None = None,
         organization_id: int | None = None,
         offset: int = 0,
-        limit: int = 10,
+        limit: int | None = 10,
         order_by: Literal["id", "email", "created", "updated"] = "id",
         order_direction: Literal["asc", "desc"] = "asc",
     ) -> list[User]:

--- a/api/use_cases/admin/providers/_getprovidersusecase.py
+++ b/api/use_cases/admin/providers/_getprovidersusecase.py
@@ -12,7 +12,7 @@ class GetProvidersCommand:
     user_id: int
     router_id: int | None
     offset: int
-    limit: int
+    limit: int | None
     sort_by: ProviderSortField
     sort_order: SortOrder
 

--- a/api/use_cases/admin/roles/_getrolesusecase.py
+++ b/api/use_cases/admin/roles/_getrolesusecase.py
@@ -11,8 +11,8 @@ from api.domain.userinfo.errors import UserIsNotAdminError
 @dataclass
 class GetRolesCommand:
     user_id: int
-    offset: int = 0
-    limit: int = 10
+    offset: int
+    limit: int | None
     sort_by: SortField = SortField.ID
     sort_order: SortOrder = SortOrder.ASC
 
@@ -48,7 +48,10 @@ class GetRolesUseCase:
             return UserIsNotAdminError()
 
         role_page = await self.role_repository.get_roles_page(
-            limit=command.limit, offset=command.offset, sort_by=command.sort_by, sort_order=command.sort_order
+            limit=command.limit,
+            offset=command.offset,
+            sort_by=command.sort_by,
+            sort_order=command.sort_order,
         )
 
         if role_page.data:

--- a/api/use_cases/admin/routers/_getroutersusecase.py
+++ b/api/use_cases/admin/routers/_getroutersusecase.py
@@ -11,7 +11,7 @@ from api.domain.userinfo.errors import UserIsNotAdminError
 class GetRoutersCommand:
     user_id: int
     offset: int
-    limit: int
+    limit: int | None
     sort_by: SortField
     sort_order: SortOrder
 


### PR DESCRIPTION
## Description

Allow the `limit` pagination parameter to be `None` in admin list endpoints, which disables the row limit and returns all matching records.

Previously, `limit` was strictly typed as `int` across repositories and use cases, forcing callers to pass a concrete page size. This PR relaxes the type to `int | None` so that `None` can be used to signal "unlimited" pagination.

## Overview

### Area
- [ ] Core / Global project settings
- [x] API
- [ ] Playground / Web UI
- [ ] DevOps
- [ ] Docusaurus / Documentation
- [ ] Other (specify below)

### Type of change
- [ ] New feature
- [ ] Bugfix
- [x] Enhancement (improvement of an existing feature)
- [ ] Refactor (change that neither fixes a bug nor modifies behavior)
- [ ] Documentation
- [ ] Tests
- [ ] Performance improvement
- [ ] Chore / Maintenance (change to the build process or auxiliary tools, dependencies update, etc.)

## Definition of Done / Technical changes

- [x] `ProviderRepository.get_providers_page` accepts `limit: int | None`
- [x] `RoleRepository.get_roles_page` accepts `limit: int | None`
- [x] `RouterRepository.get_routers_page` accepts `limit: int | None`
- [x] `UserRepository.get_users` accepts `limit: int | None`
- [x] Postgres implementations (`PostgresProviderRepository`, `PostgresRolesRepository`, `PostgresRouterRepository`, `PostgresUserRepository`) updated accordingly
- [x] Use case commands `GetProvidersCommand`, `GetRolesCommand`, `GetRoutersCommand` propagate `limit: int | None`

## Breaking changes
- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

NB: A breaking change is a modification that is not backwards-compatible and/or changes current functionality.

## Quality assurance & Review readiness

### Documentation
- [x] No documentation needed
- [ ] README / Markdown files updated
- [ ] API documentation updated (Swagger / Redoc)
- [ ] Docstrings updated
- [ ] Inline code comments added where needed

### Tests
- [x] No tests added (explain below)
- [ ] Unit tests added
- [ ] Integration tests added
- [ ] Functional tests added
- [ ] End-to-end tests added
- [ ] Performance tests added
- [ ] Existing tests updated

Type signature change only; existing pagination tests continue to cover the `int` case and no new behavior is introduced at the call sites touched in this PR.

NB: For a concise overview of software testing types, see [this Atlassian's guide](https://www.atlassian.com/continuous-delivery/software-testing/types-of-software-testing).

### Code Standards
- [x] Code follows project conventions and architecture
- [x] No unused imports, variables, functions, or classes
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project tools ([ruff](https://docs.astral.sh/uv/), etc.)

### Git & Process Standards
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] PR is correctly labeled
- [ ] PR is linked to relevant issue(s) / project(s)
- [ ] Author is assigned to the PR
- [ ] At least one reviewer has been requested

### Deployment Notes
- [x] No special deployment steps required
- [ ] Requires database migration (see "Database migration" section)
- [ ] Requires new or updated environment variables (explain below)
- [ ] Requires other special deployment steps (explain below)

### Database migration
- [x] No database migration required
- [ ] This PR requires a database migration (see checklist below)

## Reviewer Focus

- Consistency of the `int | None` signature across domain interfaces, Postgres implementations, and use case commands.
- Ensure every downstream SQL builder correctly skips `.limit(...)` when `limit is None` (see `_postgresproviderrepository.py` and `_postgresrolesrepository.py` where default values were also reshuffled).
- `PostgresUserRepository.get_users` keeps `limit: int | None = 10` — confirm this default is intentional alongside the `@TODO: remove this method after total clean archi migration` note.

## Additional Notes

Unblocks admin list endpoints that need to fetch the full collection (e.g. for dropdowns) without making multiple paginated calls.