### PR TITLE
refacto(user): POST /v1/admin/users endpoint clean archi refactoring

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"56.24%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"56.28%","color":"red"}

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"56.28%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"56.29%","color":"red"}

--- a/api/domain/user/_userrepository.py
+++ b/api/domain/user/_userrepository.py
@@ -25,6 +25,16 @@ class UserRepository(ABC):
         pass
 
     @abstractmethod
+    async def get_or_create_user(
+        self,
+        email: str,
+        password: str,
+        role_id: int,
+        name: str | None = None,
+    ) -> User:
+        pass
+
+    @abstractmethod
     async def get_first_admin_user(self) -> User | UserNotFoundError:
         pass
 

--- a/api/domain/user/_userrepository.py
+++ b/api/domain/user/_userrepository.py
@@ -25,16 +25,6 @@ class UserRepository(ABC):
         pass
 
     @abstractmethod
-    async def get_or_create_user(
-        self,
-        email: str,
-        password: str,
-        role_id: int,
-        name: str | None = None,
-    ) -> User:
-        pass
-
-    @abstractmethod
     async def get_first_admin_user(self) -> User | UserNotFoundError:
         pass
 

--- a/api/helpers/_usagetokenizer.py
+++ b/api/helpers/_usagetokenizer.py
@@ -10,7 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 class UsageTokenizer:
-    USAGE_ENDPOINTS = [EndpointRoute.AUDIO_TRANSCRIPTIONS, EndpointRoute.CHAT_COMPLETIONS, EndpointRoute.EMBEDDINGS, EndpointRoute.OCR, EndpointRoute.RERANK, EndpointRoute.SEARCH]
+    USAGE_ENDPOINTS = [
+        EndpointRoute.AUDIO_TRANSCRIPTIONS,
+        EndpointRoute.CHAT_COMPLETIONS,
+        EndpointRoute.EMBEDDINGS,
+        EndpointRoute.OCR,
+        EndpointRoute.RERANK,
+        EndpointRoute.SEARCH,
+    ]
 
     def __init__(self, tokenizer: Tokenizer):
         if tokenizer == Tokenizer.TIKTOKEN_O200K_BASE:

--- a/api/infrastructure/fastapi/endpoints/admin/providers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/providers.py
@@ -299,7 +299,7 @@ async def get_provider(
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
     response_model=ProvidersResponse,
-    responses=get_documentation_responses(),
+    responses=get_documentation_responses([]),
 )
 async def get_providers(
     router_id: int | None = Query(default=None, description="Filter providers by router ID."),

--- a/api/infrastructure/fastapi/endpoints/admin/providers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/providers.py
@@ -67,13 +67,14 @@ logger = logging.getLogger(__name__)
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
     responses=get_documentation_responses(
-        [
+        exceptions=[
             InconsistentModelMaxContextLengthHTTPException,
             InconsistentModelVectorSizeHTTPException,
             InvalidProviderTypeHTTPException,
             ProviderNotReachableHTTPException,
             ProviderAlreadyExistsHTTPException,
             RouterNotFoundHTTPException,
+            NotAdminUserHTTPException,
         ]
     ),
 )
@@ -144,7 +145,7 @@ async def create_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([ProviderNotFoundHTTPException]),
+    responses=get_documentation_responses([ProviderNotFoundHTTPException, NotAdminUserHTTPException]),
 )
 async def delete_provider(
     provider_id: int = Path(description="The ID of the provider to delete."),
@@ -194,6 +195,7 @@ async def delete_provider(
             ProviderAlreadyExistsHTTPException,
             RouterNotFoundHTTPException,
             ProviderNotFoundHTTPException,
+            NotAdminUserHTTPException,
         ]
     ),
 )
@@ -260,7 +262,7 @@ async def update_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([ProviderNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException]),
 )
 async def get_provider(
     provider_id: int = Path(description="The ID of the provider to get."),
@@ -299,7 +301,7 @@ async def get_provider(
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
     response_model=ProvidersResponse,
-    responses=get_documentation_responses([]),
+    responses=get_documentation_responses([NotAdminUserHTTPException]),
 )
 async def get_providers(
     router_id: int | None = Query(default=None, description="Filter providers by router ID."),

--- a/api/infrastructure/fastapi/endpoints/admin/providers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/providers.py
@@ -74,8 +74,6 @@ logger = logging.getLogger(__name__)
             ProviderNotReachableHTTPException,
             ProviderAlreadyExistsHTTPException,
             RouterNotFoundHTTPException,
-            NotAdminUserHTTPException,
-            AccountExpiredHTTPException,
         ]
     ),
 )
@@ -146,7 +144,7 @@ async def create_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses([ProviderNotFoundHTTPException]),
 )
 async def delete_provider(
     provider_id: int = Path(description="The ID of the provider to delete."),
@@ -196,8 +194,6 @@ async def delete_provider(
             ProviderAlreadyExistsHTTPException,
             RouterNotFoundHTTPException,
             ProviderNotFoundHTTPException,
-            NotAdminUserHTTPException,
-            AccountExpiredHTTPException,
         ]
     ),
 )
@@ -264,7 +260,7 @@ async def update_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses([ProviderNotFoundHTTPException]),
 )
 async def get_provider(
     provider_id: int = Path(description="The ID of the provider to get."),
@@ -303,7 +299,7 @@ async def get_provider(
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
     response_model=ProvidersResponse,
-    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses(),
 )
 async def get_providers(
     router_id: int | None = Query(default=None, description="Filter providers by router ID."),

--- a/api/infrastructure/fastapi/endpoints/admin/providers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/providers.py
@@ -66,15 +66,18 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_PROVIDERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([
-        InconsistentModelMaxContextLengthHTTPException,
-        InconsistentModelVectorSizeHTTPException,
-        InvalidProviderTypeHTTPException,
-        ProviderNotReachableHTTPException,
-        ProviderAlreadyExistsHTTPException,
-        RouterNotFoundHTTPException,
-        NotAdminUserHTTPException,
-    ]),
+    responses=get_documentation_responses(
+        [
+            InconsistentModelMaxContextLengthHTTPException,
+            InconsistentModelVectorSizeHTTPException,
+            InvalidProviderTypeHTTPException,
+            ProviderNotReachableHTTPException,
+            ProviderAlreadyExistsHTTPException,
+            RouterNotFoundHTTPException,
+            NotAdminUserHTTPException,
+            AccountExpiredHTTPException,
+        ]
+    ),
 )
 async def create_provider(
     body: CreateProviderBody,
@@ -143,7 +146,7 @@ async def create_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException, AccountExpiredHTTPException]),
 )
 async def delete_provider(
     provider_id: int = Path(description="The ID of the provider to delete."),
@@ -185,15 +188,18 @@ async def delete_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([
-        InconsistentModelMaxContextLengthHTTPException,
-        InconsistentModelVectorSizeHTTPException,
-        InvalidProviderTypeHTTPException,
-        ProviderAlreadyExistsHTTPException,
-        RouterNotFoundHTTPException,
-        ProviderNotFoundHTTPException,
-        NotAdminUserHTTPException,
-    ]),
+    responses=get_documentation_responses(
+        [
+            InconsistentModelMaxContextLengthHTTPException,
+            InconsistentModelVectorSizeHTTPException,
+            InvalidProviderTypeHTTPException,
+            ProviderAlreadyExistsHTTPException,
+            RouterNotFoundHTTPException,
+            ProviderNotFoundHTTPException,
+            NotAdminUserHTTPException,
+            AccountExpiredHTTPException,
+        ]
+    ),
 )
 async def update_provider(
     provider_id: int = Path(description="The ID of the provider to update."),
@@ -258,7 +264,7 @@ async def update_provider(
     path=EndpointRoute.ADMIN_PROVIDERS + "/{provider_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, ProviderNotFoundHTTPException, AccountExpiredHTTPException]),
 )
 async def get_provider(
     provider_id: int = Path(description="The ID of the provider to get."),
@@ -297,7 +303,7 @@ async def get_provider(
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
     response_model=ProvidersResponse,
-    responses=get_documentation_responses([NotAdminUserHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
 )
 async def get_providers(
     router_id: int | None = Query(default=None, description="Filter providers by router ID."),

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses(),
+    responses=get_documentation_responses([]),
 )
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),
@@ -142,7 +142,7 @@ async def update_role(
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses(),
+    responses=get_documentation_responses([]),
 )
 async def get_roles(
     offset: int = Query(default=0, ge=0, description="Number of roles to skip."),

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, AccountExpiredHTTPException]),
 )
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),
@@ -95,7 +95,9 @@ async def create_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException]),
+    responses=get_documentation_responses(
+        [NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException, AccountExpiredHTTPException]
+    ),
 )
 async def update_role(
     role_id: int = Path(description="The ID of the role to update."),
@@ -142,7 +144,7 @@ async def update_role(
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
 )
 async def get_roles(
     offset: int = Query(default=0, ge=0, description="Number of roles to skip."),
@@ -192,7 +194,7 @@ async def get_roles(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException, AccountExpiredHTTPException]),
 )
 async def get_role(
     role_id: int = Path(description="The ID of the role to get."),
@@ -231,7 +233,9 @@ async def get_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException, RoleHasUsersHTTPException]),
+    responses=get_documentation_responses(
+        [NotAdminUserHTTPException, RoleNotFoundHTTPException, RoleHasUsersHTTPException, AccountExpiredHTTPException]
+    ),
 )
 async def delete_role(
     role_id: int = Path(description="The ID of the role to delete."),

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses(),
 )
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),
@@ -95,9 +95,7 @@ async def create_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses(
-        [NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException, AccountExpiredHTTPException]
-    ),
+    responses=get_documentation_responses([RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException]),
 )
 async def update_role(
     role_id: int = Path(description="The ID of the role to update."),
@@ -144,7 +142,7 @@ async def update_role(
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses(),
 )
 async def get_roles(
     offset: int = Query(default=0, ge=0, description="Number of roles to skip."),
@@ -194,7 +192,7 @@ async def get_roles(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses([RoleNotFoundHTTPException]),
 )
 async def get_role(
     role_id: int = Path(description="The ID of the role to get."),
@@ -233,9 +231,7 @@ async def get_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses(
-        [NotAdminUserHTTPException, RoleNotFoundHTTPException, RoleHasUsersHTTPException, AccountExpiredHTTPException]
-    ),
+    responses=get_documentation_responses([RoleNotFoundHTTPException, RoleHasUsersHTTPException]),
 )
 async def delete_role(
     role_id: int = Path(description="The ID of the role to delete."),

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException]),
 )
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),
@@ -95,7 +95,7 @@ async def create_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleAlreadyExistsHTTPException, RoleNotFoundHTTPException]),
 )
 async def update_role(
     role_id: int = Path(description="The ID of the role to update."),
@@ -142,7 +142,7 @@ async def update_role(
     path=EndpointRoute.ADMIN_ROLES,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([]),
+    responses=get_documentation_responses([NotAdminUserHTTPException]),
 )
 async def get_roles(
     offset: int = Query(default=0, ge=0, description="Number of roles to skip."),
@@ -192,7 +192,7 @@ async def get_roles(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([RoleNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException]),
 )
 async def get_role(
     role_id: int = Path(description="The ID of the role to get."),
@@ -231,7 +231,7 @@ async def get_role(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([RoleNotFoundHTTPException, RoleHasUsersHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RoleNotFoundHTTPException, RoleHasUsersHTTPException]),
 )
 async def delete_role(
     role_id: int = Path(description="The ID of the role to delete."),

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -53,9 +53,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses(
-        [RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException, NotAdminUserHTTPException, AccountExpiredHTTPException]
-    ),
+    responses=get_documentation_responses([RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException]),
 )
 async def create_router(
     body: CreateRouterBody = Body(description="The router creation request."),
@@ -101,7 +99,7 @@ async def create_router(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses([RouterNotFoundHTTPException]),
 )
 async def get_router(
     router_id: int = Path(description="The router ID."),
@@ -139,7 +137,7 @@ async def get_router(
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses(),
 )
 async def get_routers(
     offset: int = Query(default=0, ge=0, description="Number of routers to skip."),
@@ -184,7 +182,7 @@ async def get_routers(
 @router.delete(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
-    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException, AccountExpiredHTTPException]),
+    responses=get_documentation_responses([RouterNotFoundHTTPException]),
     status_code=200,
 )
 async def delete_router(
@@ -226,10 +224,8 @@ async def delete_router(
     responses=get_documentation_responses(
         [
             RouterNotFoundHTTPException,
-            NotAdminUserHTTPException,
             RouterAliasAlreadyExistsHTTPException,
             RouterAlreadyExistsHTTPException,
-            AccountExpiredHTTPException,
         ]
     ),
     status_code=200,

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -53,11 +53,9 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([
-        RouterAliasAlreadyExistsHTTPException,
-        RouterAlreadyExistsHTTPException,
-        NotAdminUserHTTPException,
-    ]),
+    responses=get_documentation_responses(
+        [RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException, NotAdminUserHTTPException, AccountExpiredHTTPException]
+    ),
 )
 async def create_router(
     body: CreateRouterBody = Body(description="The router creation request."),
@@ -103,7 +101,7 @@ async def create_router(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException, AccountExpiredHTTPException]),
 )
 async def get_router(
     router_id: int = Path(description="The router ID."),
@@ -141,7 +139,7 @@ async def get_router(
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([NotAdminUserHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, AccountExpiredHTTPException]),
 )
 async def get_routers(
     offset: int = Query(default=0, ge=0, description="Number of routers to skip."),
@@ -186,7 +184,7 @@ async def get_routers(
 @router.delete(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
-    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException, AccountExpiredHTTPException]),
     status_code=200,
 )
 async def delete_router(
@@ -225,12 +223,15 @@ async def delete_router(
 @router.patch(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
-    responses=get_documentation_responses([
-        RouterNotFoundHTTPException,
-        NotAdminUserHTTPException,
-        RouterAliasAlreadyExistsHTTPException,
-        RouterAlreadyExistsHTTPException,
-    ]),
+    responses=get_documentation_responses(
+        [
+            RouterNotFoundHTTPException,
+            NotAdminUserHTTPException,
+            RouterAliasAlreadyExistsHTTPException,
+            RouterAlreadyExistsHTTPException,
+            AccountExpiredHTTPException,
+        ]
+    ),
     status_code=200,
 )
 async def update_router(

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException]),
+    responses=get_documentation_responses([RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException, NotAdminUserHTTPException]),
 )
 async def create_router(
     body: CreateRouterBody = Body(description="The router creation request."),
@@ -99,7 +99,7 @@ async def create_router(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([RouterNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException]),
 )
 async def get_router(
     router_id: int = Path(description="The router ID."),
@@ -137,7 +137,7 @@ async def get_router(
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses([]),
+    responses=get_documentation_responses([NotAdminUserHTTPException]),
 )
 async def get_routers(
     offset: int = Query(default=0, ge=0, description="Number of routers to skip."),
@@ -182,7 +182,7 @@ async def get_routers(
 @router.delete(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=get_current_key)],
-    responses=get_documentation_responses([RouterNotFoundHTTPException]),
+    responses=get_documentation_responses([NotAdminUserHTTPException, RouterNotFoundHTTPException]),
     status_code=200,
 )
 async def delete_router(
@@ -223,6 +223,7 @@ async def delete_router(
     dependencies=[Security(dependency=get_current_key)],
     responses=get_documentation_responses(
         [
+            NotAdminUserHTTPException,
             RouterNotFoundHTTPException,
             RouterAliasAlreadyExistsHTTPException,
             RouterAlreadyExistsHTTPException,

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -137,7 +137,7 @@ async def get_router(
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=200,
-    responses=get_documentation_responses(),
+    responses=get_documentation_responses([]),
 )
 async def get_routers(
     offset: int = Query(default=0, ge=0, description="Number of routers to skip."),

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -53,7 +53,11 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_ROUTERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([RouterAliasAlreadyExistsHTTPException, RouterAlreadyExistsHTTPException, NotAdminUserHTTPException]),
+    responses=get_documentation_responses([
+        RouterAliasAlreadyExistsHTTPException,
+        RouterAlreadyExistsHTTPException,
+        NotAdminUserHTTPException,
+    ]),
 )
 async def create_router(
     body: CreateRouterBody = Body(description="The router creation request."),

--- a/api/infrastructure/fastapi/endpoints/admin/users.py
+++ b/api/infrastructure/fastapi/endpoints/admin/users.py
@@ -30,12 +30,14 @@ logger = logging.getLogger(__name__)
     path=EndpointRoute.ADMIN_USERS,
     dependencies=[Security(dependency=get_current_key)],
     status_code=201,
-    responses=get_documentation_responses([
-        UserAlreadyExistsHTTPException,
-        RoleNotFoundHTTPException,
-        OrganizationNotFoundHTTPException,
-        NotAdminUserHTTPException,
-    ]),
+    responses=get_documentation_responses(
+        [
+            UserAlreadyExistsHTTPException,
+            RoleNotFoundHTTPException,
+            OrganizationNotFoundHTTPException,
+            NotAdminUserHTTPException,
+        ]
+    ),
 )
 async def create_user(
     body: CreateUserBody = Body(description="The user creation request."),

--- a/api/infrastructure/fastapi/endpoints/admin/users.py
+++ b/api/infrastructure/fastapi/endpoints/admin/users.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
             RoleNotFoundHTTPException,
             OrganizationNotFoundHTTPException,
             NotAdminUserHTTPException,
+            AccountExpiredHTTPException,
         ]
     ),
 )

--- a/api/infrastructure/fastapi/endpoints/admin/users.py
+++ b/api/infrastructure/fastapi/endpoints/admin/users.py
@@ -35,8 +35,6 @@ logger = logging.getLogger(__name__)
             UserAlreadyExistsHTTPException,
             RoleNotFoundHTTPException,
             OrganizationNotFoundHTTPException,
-            NotAdminUserHTTPException,
-            AccountExpiredHTTPException,
         ]
     ),
 )

--- a/api/infrastructure/fastapi/endpoints/admin/users.py
+++ b/api/infrastructure/fastapi/endpoints/admin/users.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
             UserAlreadyExistsHTTPException,
             RoleNotFoundHTTPException,
             OrganizationNotFoundHTTPException,
+            NotAdminUserHTTPException,
         ]
     ),
 )

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 import bcrypt
 from sqlalchemy import Integer, cast, func, insert, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,7 +45,6 @@ class PostgresUserRepository(UserRepository):
             updated=row.updated,
         )
 
-    @with_lock(namespace="user", key="email")
     async def create_user(
         self,
         email: str,
@@ -107,6 +107,33 @@ class PostgresUserRepository(UserRepository):
             return UserAlreadyExistsError(email=email)
 
         return self._row_to_user(row)
+
+    async def get_or_create_user(
+        self,
+        email: str,
+        password: str,
+        role_id: int,
+        name: str | None = None,
+    ) -> User:
+        hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        stmt = pg_insert(UserTable).values(email=email, name=name, password=hashed_password, role_id=role_id)
+        result = await self.postgres_session.execute(
+            stmt.on_conflict_do_update(index_elements=["email"], set_={"email": stmt.excluded.email}).returning(
+                UserTable.id,
+                UserTable.email,
+                UserTable.name,
+                UserTable.sub,
+                UserTable.iss,
+                UserTable.role_id.label("role"),
+                UserTable.organization_id.label("organization"),
+                UserTable.budget,
+                _unix_timestamp(UserTable.expires).label("expires"),
+                _unix_timestamp(UserTable.created).label("created"),
+                _unix_timestamp(UserTable.updated).label("updated"),
+                UserTable.priority,
+            )
+        )
+        return self._row_to_user(result.one())
 
     async def get_first_admin_user(self) -> User | UserNotFoundError:
         result = await self.postgres_session.execute(

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -42,6 +42,10 @@ class PostgresUserRepository(UserRepository):
             updated=row.updated,
         )
 
+    @staticmethod
+    def _hash_password(password: str) -> str:
+        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
     @with_lock(namespace="user", key="email")
     async def create_user(
         self,
@@ -56,7 +60,7 @@ class PostgresUserRepository(UserRepository):
         expires: int | None = None,
         priority: int = 0,
     ) -> User | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
-        hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        hashed_password = self._hash_password(password=password)
         expires_value = func.to_timestamp(expires) if expires is not None else None
 
         try:

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 import bcrypt
 from sqlalchemy import Integer, cast, func, insert, select, update
-from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.organization.errors import OrganizationNotFoundError
@@ -58,54 +58,51 @@ class PostgresUserRepository(UserRepository):
         expires: int | None = None,
         priority: int = 0,
     ) -> User | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
-        result = await self.postgres_session.execute(select(RoleTable.id).where(RoleTable.id == role_id))
-        try:
-            result.scalar_one()
-        except NoResultFound:
+        role_result = (await self.postgres_session.execute(select(RoleTable.id).where(RoleTable.id == role_id))).scalar_one_or_none()
+        if role_result is None:
             return RoleNotFoundError(id=role_id)
 
         if organization_id is not None:
-            result = await self.postgres_session.execute(select(OrganizationTable.id).where(OrganizationTable.id == organization_id))
-            try:
-                result.scalar_one()
-            except NoResultFound:
+            organisation_result = (
+                await self.postgres_session.execute(select(OrganizationTable.id).where(OrganizationTable.id == organization_id))
+            ).scalar_one_or_none()
+            if organisation_result is None:
                 return OrganizationNotFoundError(id=organization_id)
 
         hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
         expires_value = func.to_timestamp(expires) if expires is not None else None
 
         try:
-            async with self.postgres_session.begin_nested():
-                result = await self.postgres_session.execute(
-                    insert(UserTable)
-                    .values(
-                        email=email,
-                        name=name,
-                        password=hashed_password,
-                        sub=sub,
-                        iss=iss,
-                        role_id=role_id,
-                        organization_id=organization_id,
-                        budget=budget,
-                        expires=expires_value,
-                        priority=priority,
-                    )
-                    .returning(
-                        UserTable.id,
-                        UserTable.email,
-                        UserTable.name,
-                        UserTable.sub,
-                        UserTable.iss,
-                        UserTable.role_id.label("role"),
-                        UserTable.organization_id.label("organization"),
-                        UserTable.budget,
-                        _unix_timestamp(UserTable.expires).label("expires"),
-                        _unix_timestamp(UserTable.created).label("created"),
-                        _unix_timestamp(UserTable.updated).label("updated"),
-                        UserTable.priority,
-                    )
+            result = await self.postgres_session.execute(
+                insert(UserTable)
+                .values(
+                    email=email,
+                    name=name,
+                    password=hashed_password,
+                    sub=sub,
+                    iss=iss,
+                    role_id=role_id,
+                    organization_id=organization_id,
+                    budget=budget,
+                    expires=expires_value,
+                    priority=priority,
                 )
-                row = result.one()
+                .returning(
+                    UserTable.id,
+                    UserTable.email,
+                    UserTable.name,
+                    UserTable.sub,
+                    UserTable.iss,
+                    UserTable.role_id.label("role"),
+                    UserTable.organization_id.label("organization"),
+                    UserTable.budget,
+                    _unix_timestamp(UserTable.expires).label("expires"),
+                    _unix_timestamp(UserTable.created).label("created"),
+                    _unix_timestamp(UserTable.updated).label("updated"),
+                    UserTable.priority,
+                )
+            )
+            row = result.one()
         except IntegrityError:
             return UserAlreadyExistsError(email=email)
 

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -2,7 +2,6 @@ from typing import Literal
 
 import bcrypt
 from sqlalchemy import Integer, cast, func, insert, select, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,9 +12,7 @@ from api.domain.user import UserRepository
 from api.domain.user.entities import User
 from api.domain.user.errors import UserAlreadyExistsError, UserNotFoundError
 from api.infrastructure.postgres.decorators import with_lock
-from api.sql.models import Organization as OrganizationTable
 from api.sql.models import Permission as PermissionTable
-from api.sql.models import Role as RoleTable
 from api.sql.models import User as UserTable
 from api.utils.exceptions import UserNotFoundException
 
@@ -45,6 +42,7 @@ class PostgresUserRepository(UserRepository):
             updated=row.updated,
         )
 
+    @with_lock(namespace="user", key="email")
     async def create_user(
         self,
         email: str,
@@ -58,17 +56,6 @@ class PostgresUserRepository(UserRepository):
         expires: int | None = None,
         priority: int = 0,
     ) -> User | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
-        role_result = (await self.postgres_session.execute(select(RoleTable.id).where(RoleTable.id == role_id))).scalar_one_or_none()
-        if role_result is None:
-            return RoleNotFoundError(id=role_id)
-
-        if organization_id is not None:
-            organisation_result = (
-                await self.postgres_session.execute(select(OrganizationTable.id).where(OrganizationTable.id == organization_id))
-            ).scalar_one_or_none()
-            if organisation_result is None:
-                return OrganizationNotFoundError(id=organization_id)
-
         hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
         expires_value = func.to_timestamp(expires) if expires is not None else None
 
@@ -103,37 +90,14 @@ class PostgresUserRepository(UserRepository):
                 )
             )
             row = result.one()
-        except IntegrityError:
+        except IntegrityError as e:
+            if "user_organization_id_fkey" in str(e.orig):
+                return OrganizationNotFoundError(id=organization_id)
+            if "user_role_id_fkey" in str(e.orig):
+                return RoleNotFoundError(id=role_id)
             return UserAlreadyExistsError(email=email)
 
         return self._row_to_user(row)
-
-    async def get_or_create_user(
-        self,
-        email: str,
-        password: str,
-        role_id: int,
-        name: str | None = None,
-    ) -> User:
-        hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
-        stmt = pg_insert(UserTable).values(email=email, name=name, password=hashed_password, role_id=role_id)
-        result = await self.postgres_session.execute(
-            stmt.on_conflict_do_update(index_elements=["email"], set_={"email": stmt.excluded.email}).returning(
-                UserTable.id,
-                UserTable.email,
-                UserTable.name,
-                UserTable.sub,
-                UserTable.iss,
-                UserTable.role_id.label("role"),
-                UserTable.organization_id.label("organization"),
-                UserTable.budget,
-                _unix_timestamp(UserTable.expires).label("expires"),
-                _unix_timestamp(UserTable.created).label("created"),
-                _unix_timestamp(UserTable.updated).label("updated"),
-                UserTable.priority,
-            )
-        )
-        return self._row_to_user(result.one())
 
     async def get_first_admin_user(self) -> User | UserNotFoundError:
         result = await self.postgres_session.execute(

--- a/api/tests/integration/endpoints/admin/users/test_create_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_create_user.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock
+
+from httpx import AsyncClient
+import pytest
+import pytest_asyncio
+
+from api.dependencies import create_user_use_case_factory
+from api.domain.organization.errors import OrganizationNotFoundError
+from api.domain.role.errors import RoleNotFoundError
+from api.domain.user.errors import UserAlreadyExistsError
+from api.domain.userinfo.errors import UserIsNotAdminError
+from api.tests.helpers import create_token
+from api.tests.integration.factories.sql import RoleSQLFactory, UserSQLFactory
+from api.utils.variables import EndpointRoute
+
+URL = f"/v1{EndpointRoute.ADMIN_USERS}"
+
+
+def _valid_body(role_id: int, **overrides) -> dict:
+    body = {
+        "email": "newuser@test.com",
+        "password": "s3cr3t",
+        "role": role_id,
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestCreateUser:
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup(self, db_session):
+        self.admin_user = UserSQLFactory(admin_user=True)
+        self.token = await create_token(db_session, name="admin_token", user=self.admin_user)
+
+    async def test_happy_path(self, client: AsyncClient, db_session):
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(role_id=role.id),
+        )
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["email"] == "newuser@test.com"
+        assert isinstance(data["id"], int)
+        assert data["role"] == role.id
+
+    @pytest.mark.parametrize(
+        "use_case_result,expected_status,expected_detail",
+        [
+            (
+                UserAlreadyExistsError(email="existing@test.com"),
+                409,
+                "User existing@test.com already exists.",
+            ),
+            (
+                RoleNotFoundError(id=99),
+                404,
+                "Role 99 not found.",
+            ),
+            (
+                OrganizationNotFoundError(id=99),
+                404,
+                "Organization 99 not found.",
+            ),
+            (
+                UserIsNotAdminError(),
+                403,
+                "User has no admin rights.",
+            ),
+        ],
+    )
+    async def test_error_maps_to_correct_http_status(self, client: AsyncClient, app, use_case_result, expected_status, expected_detail):
+        mock_use_case = AsyncMock()
+        mock_use_case.execute.return_value = use_case_result
+        app.dependency_overrides[create_user_use_case_factory] = lambda: mock_use_case
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(role_id=1),
+        )
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail
+
+    @pytest.mark.parametrize(
+        "headers,expected_status,expected_detail",
+        [
+            ({}, 401, "Not authenticated"),
+            ({"Authorization": "Bearer invalid-token"}, 403, "Invalid API key."),
+        ],
+    )
+    async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
+        response = await client.post(url=URL, headers=headers, json=_valid_body(role_id=1))
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/endpoints/admin/users/test_create_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_create_user.py
@@ -7,9 +7,8 @@ import pytest_asyncio
 from api.dependencies import create_user_use_case_factory
 from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
-from api.domain.user.errors import UserAlreadyExistsError
-from api.domain.userinfo.errors import UserIsNotAdminError
-from api.tests.helpers import create_token
+from api.domain.user.errors import UserAlreadyExistsError, UserIsNotAdminError
+from api.tests.helpers import create_key
 from api.tests.integration.factories.sql import RoleSQLFactory, UserSQLFactory
 from api.utils.variables import EndpointRoute
 
@@ -31,7 +30,7 @@ class TestCreateUser:
     @pytest_asyncio.fixture(autouse=True)
     async def setup(self, db_session):
         self.admin_user = UserSQLFactory(admin_user=True)
-        self.token = await create_token(db_session, name="admin_token", user=self.admin_user)
+        self.token = await create_key(db_session, name="admin_token", user=self.admin_user)
 
     async def test_happy_path(self, client: AsyncClient, db_session):
         role = RoleSQLFactory()
@@ -92,7 +91,7 @@ class TestCreateUser:
         "headers,expected_status,expected_detail",
         [
             ({}, 401, "Not authenticated"),
-            ({"Authorization": "Bearer invalid-token"}, 403, "Invalid API key."),
+            ({"Authorization": "Bearer invalid-token"}, 401, "Invalid API key."),
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):

--- a/api/tests/integration/postgres/test_postgresproviderrepository.py
+++ b/api/tests/integration/postgres/test_postgresproviderrepository.py
@@ -298,8 +298,7 @@ class TestUpdateProvider:
 
         # Act
         result = await repository.update_provider(
-            domain_provider
-            .with_router_id(router_2.id)
+            domain_provider.with_router_id(router_2.id)
             .with_timeout(120)
             .with_model_hosting_zone(HostingZone.USA)
             .with_model_total_params(2_000_000)

--- a/api/tests/integration/postgres/user_repository/test_postgresusersrepository.py
+++ b/api/tests/integration/postgres/user_repository/test_postgresusersrepository.py
@@ -159,46 +159,6 @@ class TestCreateUser:
 
 
 @pytest.mark.asyncio(loop_scope="session")
-class TestGetOrCreateUser:
-    async def test_creates_user_when_email_does_not_exist(self, repository, db_session):
-        # Arrange
-        role = RoleSQLFactory()
-        await db_session.flush()
-
-        # Act
-        result = await repository.get_or_create_user(email="new@test.com", password="s3cr3t", role_id=role.id, name="New User")
-
-        # Assert
-        assert isinstance(result, User)
-        assert result.email == "new@test.com"
-        assert result.name == "New User"
-        assert result.role == role.id
-        assert isinstance(result.id, int)
-        row = (await db_session.execute(select(UserTable.password).where(UserTable.email == "new@test.com"))).scalar_one()
-        assert row != "s3cr3t"
-        assert bcrypt.checkpw(b"s3cr3t", row.encode("utf-8"))
-
-    async def test_returns_existing_user_when_email_already_exists(self, repository, db_session):
-        # Arrange
-        UserSQLFactory(email="existing@test.com")
-        await db_session.flush()
-        existing = await repository.get_user_by_email(email="existing@test.com")
-        assert isinstance(existing, User)
-        role = RoleSQLFactory()
-        await db_session.flush()
-
-        # Act
-        result = await repository.get_or_create_user(email="existing@test.com", password="newpassword", role_id=role.id)
-
-        # Assert
-        assert isinstance(result, User)
-        assert result.id == existing.id
-        assert result.email == "existing@test.com"
-        assert result.created == existing.created
-        assert result.updated == existing.updated
-
-
-@pytest.mark.asyncio(loop_scope="session")
 class TestGetUsers:
     async def test_returns_all_users_when_no_filter_given(self, repository, db_session):
         # Arrange

--- a/api/tests/integration/postgres/user_repository/test_postgresusersrepository.py
+++ b/api/tests/integration/postgres/user_repository/test_postgresusersrepository.py
@@ -159,6 +159,46 @@ class TestCreateUser:
 
 
 @pytest.mark.asyncio(loop_scope="session")
+class TestGetOrCreateUser:
+    async def test_creates_user_when_email_does_not_exist(self, repository, db_session):
+        # Arrange
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.get_or_create_user(email="new@test.com", password="s3cr3t", role_id=role.id, name="New User")
+
+        # Assert
+        assert isinstance(result, User)
+        assert result.email == "new@test.com"
+        assert result.name == "New User"
+        assert result.role == role.id
+        assert isinstance(result.id, int)
+        row = (await db_session.execute(select(UserTable.password).where(UserTable.email == "new@test.com"))).scalar_one()
+        assert row != "s3cr3t"
+        assert bcrypt.checkpw(b"s3cr3t", row.encode("utf-8"))
+
+    async def test_returns_existing_user_when_email_already_exists(self, repository, db_session):
+        # Arrange
+        UserSQLFactory(email="existing@test.com")
+        await db_session.flush()
+        existing = await repository.get_user_by_email(email="existing@test.com")
+        assert isinstance(existing, User)
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        # Act
+        result = await repository.get_or_create_user(email="existing@test.com", password="newpassword", role_id=role.id)
+
+        # Assert
+        assert isinstance(result, User)
+        assert result.id == existing.id
+        assert result.email == "existing@test.com"
+        assert result.created == existing.created
+        assert result.updated == existing.updated
+
+
+@pytest.mark.asyncio(loop_scope="session")
 class TestGetUsers:
     async def test_returns_all_users_when_no_filter_given(self, repository, db_session):
         # Arrange

--- a/api/tests/unit/infrastructure/fastapi/test_access.py
+++ b/api/tests/unit/infrastructure/fastapi/test_access.py
@@ -53,9 +53,7 @@ class TestGetCurrentKey:
         key_repository.get_key_expiration.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_should_raise_invalid_api_key_when_credentials_are_empty(
-        self, request_obj: Mock, key_repository: AsyncMock, request_context: Mock
-    ):
+    async def test_should_raise_invalid_api_key_when_credentials_are_empty(self, request_obj: Mock, key_repository: AsyncMock, request_context: Mock):
         # Arrange
         api_key = HTTPAuthorizationCredentials(scheme="Bearer", credentials="")
 

--- a/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
@@ -53,8 +53,7 @@ class TestUpdateRouterUseCase:
     ):
         # Arrange
         updated_router = (
-            sample_router
-            .with_name("new-name")
+            sample_router.with_name("new-name")
             .with_type(RouterType.TEXT_EMBEDDINGS_INFERENCE)
             .with_load_balancing_strategy(RouterLoadBalancingStrategy.LEAST_BUSY)
             .with_cost_prompt_tokens(0.005)

--- a/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
+++ b/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
@@ -56,7 +56,7 @@ class TestBootstrapAdminUserUseCase:
         )
         role_repository.create_role.return_value = role
         user_repository.get_user_by_email.return_value = UserNotFoundError(email=command.email)
-        user_repository.get_or_create_user.return_value = user
+        user_repository.create_user.return_value = user
 
         # Act
         result = await use_case.execute(command)
@@ -66,7 +66,7 @@ class TestBootstrapAdminUserUseCase:
 
         role_repository.create_role.assert_awaited_once_with(name=BootstrapAdminUseCase.BOOTSTRAP_ADMIN_ROLE_NAME)
         permission_repository.create_permissions.assert_awaited_once_with(role_id=42, permissions=[PermissionType.ADMIN])
-        user_repository.get_or_create_user.assert_awaited_once_with(
+        user_repository.create_user.assert_awaited_once_with(
             email=command.email,
             password=command.password,
             role_id=42,
@@ -86,7 +86,7 @@ class TestBootstrapAdminUserUseCase:
         assert result == BootstrapAdminUseCaseSkipped(user_id=7, email="admin@opengatellm.org", role_id=99)
         role_repository.get_role_with_permissions_and_limits_by_name.assert_not_awaited()
         role_repository.create_role.assert_not_awaited()
-        user_repository.get_or_create_user.assert_not_awaited()
+        user_repository.create_user.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_reuses_existing_role_when_role_name_conflicts(self, use_case, user_repository, role_repository, permission_repository, command):
@@ -100,7 +100,7 @@ class TestBootstrapAdminUserUseCase:
         user_repository.get_first_admin_user.return_value = UserNotFoundError()
         role_repository.get_role_with_permissions_and_limits_by_name.return_value = existing_role
         user_repository.get_user_by_email.return_value = UserNotFoundError(email=command.email)
-        user_repository.get_or_create_user.return_value = user
+        user_repository.create_user.return_value = user
 
         # Act
         result = await use_case.execute(command)
@@ -109,7 +109,7 @@ class TestBootstrapAdminUserUseCase:
         assert result == BootstrapAdminUseCaseSuccess(user_id=11, email="admin@opengatellm.org", role_id=5)
         role_repository.create_role.assert_not_awaited()
         permission_repository.create_permissions.assert_not_awaited()
-        user_repository.get_or_create_user.assert_awaited_once_with(
+        user_repository.create_user.assert_awaited_once_with(
             email=command.email,
             password=command.password,
             role_id=5,
@@ -134,6 +134,6 @@ class TestBootstrapAdminUserUseCase:
 
         # Assert
         assert result == BootstrapAdminUseCaseSuccess(user_id=20, email="admin@opengatellm.org", role_id=3)
-        user_repository.get_or_create_user.assert_not_awaited()
+        user_repository.create_user.assert_not_awaited()
         user_repository.update_user.assert_awaited_once()
         assert user_repository.update_user.await_args.kwargs["user"] == updated_user

--- a/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
+++ b/api/tests/unit/use_case/admin/test_bootstrapadminusecase.py
@@ -56,7 +56,7 @@ class TestBootstrapAdminUserUseCase:
         )
         role_repository.create_role.return_value = role
         user_repository.get_user_by_email.return_value = UserNotFoundError(email=command.email)
-        user_repository.create_user.return_value = user
+        user_repository.get_or_create_user.return_value = user
 
         # Act
         result = await use_case.execute(command)
@@ -66,7 +66,7 @@ class TestBootstrapAdminUserUseCase:
 
         role_repository.create_role.assert_awaited_once_with(name=BootstrapAdminUseCase.BOOTSTRAP_ADMIN_ROLE_NAME)
         permission_repository.create_permissions.assert_awaited_once_with(role_id=42, permissions=[PermissionType.ADMIN])
-        user_repository.create_user.assert_awaited_once_with(
+        user_repository.get_or_create_user.assert_awaited_once_with(
             email=command.email,
             password=command.password,
             role_id=42,
@@ -86,7 +86,7 @@ class TestBootstrapAdminUserUseCase:
         assert result == BootstrapAdminUseCaseSkipped(user_id=7, email="admin@opengatellm.org", role_id=99)
         role_repository.get_role_with_permissions_and_limits_by_name.assert_not_awaited()
         role_repository.create_role.assert_not_awaited()
-        user_repository.create_user.assert_not_awaited()
+        user_repository.get_or_create_user.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_reuses_existing_role_when_role_name_conflicts(self, use_case, user_repository, role_repository, permission_repository, command):
@@ -100,7 +100,7 @@ class TestBootstrapAdminUserUseCase:
         user_repository.get_first_admin_user.return_value = UserNotFoundError()
         role_repository.get_role_with_permissions_and_limits_by_name.return_value = existing_role
         user_repository.get_user_by_email.return_value = UserNotFoundError(email=command.email)
-        user_repository.create_user.return_value = user
+        user_repository.get_or_create_user.return_value = user
 
         # Act
         result = await use_case.execute(command)
@@ -109,7 +109,7 @@ class TestBootstrapAdminUserUseCase:
         assert result == BootstrapAdminUseCaseSuccess(user_id=11, email="admin@opengatellm.org", role_id=5)
         role_repository.create_role.assert_not_awaited()
         permission_repository.create_permissions.assert_not_awaited()
-        user_repository.create_user.assert_awaited_once_with(
+        user_repository.get_or_create_user.assert_awaited_once_with(
             email=command.email,
             password=command.password,
             role_id=5,
@@ -134,6 +134,6 @@ class TestBootstrapAdminUserUseCase:
 
         # Assert
         assert result == BootstrapAdminUseCaseSuccess(user_id=20, email="admin@opengatellm.org", role_id=3)
-        user_repository.create_user.assert_not_awaited()
+        user_repository.get_or_create_user.assert_not_awaited()
         user_repository.update_user.assert_awaited_once()
         assert user_repository.update_user.await_args.kwargs["user"] == updated_user

--- a/api/use_cases/admin/_bootstrapadminusecase.py
+++ b/api/use_cases/admin/_bootstrapadminusecase.py
@@ -71,7 +71,7 @@ class BootstrapAdminUseCase:
                 if user.role != role.id:
                     await self.user_repository.update_user(user=user.model_copy(update={"role": role.id}))
             case UserNotFoundError():
-                user = await self.user_repository.get_or_create_user(
+                user = await self.user_repository.create_user(
                     email=command.email,
                     password=command.password,
                     role_id=role.id,

--- a/api/use_cases/admin/_bootstrapadminusecase.py
+++ b/api/use_cases/admin/_bootstrapadminusecase.py
@@ -71,7 +71,7 @@ class BootstrapAdminUseCase:
                 if user.role != role.id:
                     await self.user_repository.update_user(user=user.model_copy(update={"role": role.id}))
             case UserNotFoundError():
-                user = await self.user_repository.create_user(
+                user = await self.user_repository.get_or_create_user(
                     email=command.email,
                     password=command.password,
                     role_id=role.id,

--- a/api/use_cases/admin/_bootstrapadminusecase.py
+++ b/api/use_cases/admin/_bootstrapadminusecase.py
@@ -51,7 +51,6 @@ class BootstrapAdminUseCase:
         self.user_repository = user_repository
 
     async def execute(self, command: BootstrapAdminCommand) -> BootstrapAdminUseCaseResult:
-
         result = await self.user_repository.get_first_admin_user()
         match result:
             case User() as user:

--- a/api/use_cases/admin/providers/_createproviderusecase.py
+++ b/api/use_cases/admin/providers/_createproviderusecase.py
@@ -59,7 +59,6 @@ class CreateProviderUseCase:
         self.user_with_role_query = user_with_role_query
 
     async def execute(self, command: CreateProviderCommand) -> CreateProviderUseCaseResult:
-
         user = await self.user_with_role_query.get_user_with_role_by_id(user_id=command.user_id)
 
         if user.expires is not None and user.expires < time.time():

--- a/api/use_cases/admin/routers/_getroutersusecase.py
+++ b/api/use_cases/admin/routers/_getroutersusecase.py
@@ -22,7 +22,7 @@ class GetRoutersUseCaseSuccess:
     router_page: RouterPage
 
 
-type GetRoutersUseCaseResult = GetRoutersUseCaseSuccess | UserIsNotAdminError
+type GetRoutersUseCaseResult = GetRoutersUseCaseSuccess | UserIsNotAdminError | UserExpiredError
 
 
 class GetRoutersUseCase:
@@ -30,10 +30,7 @@ class GetRoutersUseCase:
         self.router_repository = router_repository
         self.user_with_role_query = user_with_role_query
 
-    async def execute(
-        self,
-        command: GetRoutersCommand,
-    ) -> GetRoutersUseCaseResult:
+    async def execute(self, command: GetRoutersCommand) -> GetRoutersUseCaseResult:
         user = await self.user_with_role_query.get_user_with_role_by_id(user_id=command.user_id)
 
         if user.expires is not None and user.expires < time.time():

--- a/scripts/docs/generate_configuration_documentation.py
+++ b/scripts/docs/generate_configuration_documentation.py
@@ -11,9 +11,8 @@ sys.path.insert(0, PROJECT_ROOT)
 sys.path.insert(0, os.path.join(PROJECT_ROOT, "playground"))
 os.environ["CONFIG_FILE"] = os.path.join(PROJECT_ROOT, "config.example.yml")
 
-from app.core.configuration import ConfigFile as PlaygroundConfigFile  # noqa: E402 # type: ignore
-
 from api.schemas.core.configuration import ConfigFile as ApiConfigFile  # noqa: E402 # type: ignore
+from app.core.configuration import ConfigFile as PlaygroundConfigFile  # noqa: E402 # type: ignore
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--output", type=str, default=os.path.join("./docs/src/content/docs/configuration/configuration_file.md"))


### PR DESCRIPTION
[//]: # (Branch: 724-refacto-refacto-post-v1adminusers-endpoint-toward-clean-architecture ? main)
[//]: # (Commits: 3 ? refacto create_user repository method / refacto bootstrap admin user / add integration tests)
[//]: # (Issue: #724)

## Overview

Resolves #724 ? Refactors the `POST /v1/admin/users` endpoint and the user repository toward clean architecture.

The `create_user` repository method was relying on an advisory lock (`@with_lock`) to prevent duplicate email inserts. This lock was unnecessary on the REST endpoint path (requests are independent) and introduced accidental complexity. Separately, the bootstrap flow had a multi-worker race condition: if multiple Gunicorn workers started simultaneously, each would check for an existing admin user, find none, and then all attempt to insert ? causing crashes.

This PR splits the concern into two purpose-built methods:
- `create_user`: used by the REST endpoint. Returns typed errors (`UserAlreadyExistsError`, `RoleNotFoundError`, `OrganizationNotFoundError`) following railway-oriented error handling. No lock needed.
- `get_or_create_user`: used by the bootstrap. Uses PostgreSQL's `ON CONFLICT (email) DO UPDATE ? RETURNING` to atomically upsert and always return the user, eliminating the race condition without any application-level locking.

**Definition of Done:**

- [x] `create_user` no longer carries the `@with_lock` advisory lock decorator
- [x] `get_or_create_user` added to `UserRepository` (abstract) and `PostgresUserRepository` using `ON CONFLICT DO UPDATE`
- [x] `BootstrapAdminUseCase` simplified to use `get_or_create_user` directly
- [x] Integration tests added for `get_or_create_user` (repository level)
- [x] Integration tests added for `POST /v1/admin/users` (endpoint level)

**Breaking changes:**

- [x] No breaking changes

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- N/A ? `api/sql/models.py` was not modified

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

No migration, configuration, or environment variable changes are required for this PR.

## Additional Notes

**Why `ON CONFLICT DO UPDATE` instead of `ON CONFLICT DO NOTHING`**

`ON CONFLICT DO NOTHING` does not fire `RETURNING` when a conflict occurs, meaning the existing row cannot be retrieved in the same statement. `ON CONFLICT DO UPDATE SET email = EXCLUDED.email` is a deliberate no-op update (the value does not change) that forces `RETURNING` to always emit a row ? whether the user was just inserted or already existed. This makes `get_or_create_user` safe to call concurrently from multiple workers with a single round-trip to the database.

**Why password hashing stays in the repository**

Hashing is a storage invariant: the database must never store a plaintext password. It is not business logic ? no use case should need to decide whether to hash or not. Keeping it in the repository keeps the invariant close to the persistence layer and prevents accidental plaintext storage if a new caller forgets to hash upstream.