### PR TITLE
fix(langfuse): fix base_url for langfuse

### DIFF
--- a/api/schemas/core/configuration.py
+++ b/api/schemas/core/configuration.py
@@ -254,7 +254,7 @@ class LangfuseDependency(ConfigBaseModel):
 
     public_key: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(..., description="Langfuse public key.", examples=["pk-lf-..."])  # fmt: off
     secret_key: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(..., description="Langfuse secret key.", examples=["sk-lf-..."])  # fmt: off
-    url: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(default="http://localhost:3000", description="Langfuse server URL.", examples=["http://localhost:3000"])  # fmt: off
+    base_url: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(default="http://localhost:3000", description="Langfuse server URL.", examples=["http://localhost:3000"])  # fmt: off
 
 
 @custom_validation_error()

--- a/config.example.yml
+++ b/config.example.yml
@@ -34,7 +34,7 @@ dependencies:
   # langfuse:
   #   public_key: ${LANGFUSE_PUBLIC_KEY}
   #   secret_key: ${LANGFUSE_SECRET_KEY}
-  #   url: http://localhost:3000
+  #   base_url: http://localhost:3000
 
 # ---------------------------------- settings -----------------------------------
 settings:


### PR DESCRIPTION
## Overview

Fixes a misconfigured field name in the `LangfuseDependency` schema. The field was named `url` but the Langfuse SDK expects `base_url`, causing the dependency parameters to be passed incorrectly.

- [x] The `url` field in `LangfuseDependency` is renamed to `base_url` to match the Langfuse SDK parameter name.

**Breaking changes:**

- [ ] No breaking changes
- [x] This PR contains breaking changes (explain below)

> The `LangfuseDependency` configuration field `url` is renamed to `base_url`. Any existing configuration files or environment variable mappings referencing the `url` field must be updated to use `base_url`.

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- N/A ? `models.py` was not modified.

## Deployment checklist

- [ ] Alembic migration has been generated
- [x] Configuration file has been modified
- [ ] Environment variables have been modified

> Any deployment configuration or config file that sets the Langfuse `url` field must be updated to use `base_url` instead.

## Additional Notes

The only change is a one-line field rename in `api/schemas/core/configuration.py`: `url` ? `base_url` in `LangfuseDependency`. Reviewers should verify that all call sites constructing or consuming `LangfuseDependency` objects (e.g. in the Langfuse client initialization) are aligned with the new field name.