### PR TITLE
fix(models): handle Mistral API non string content

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"56.26%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"56.18%","color":"red"}

--- a/api/schemas/chat.py
+++ b/api/schemas/chat.py
@@ -142,10 +142,17 @@ class ChatCompletion(ChatCompletion):
             choice = choices[0]
             message = choice.get("message") or {}
             content = message.get("content") or ""
-            reasoning_content = message.get("reasoning_content") or ""
 
-            result += f"{content.strip()}\n" if content else ""
-            result += f"{reasoning_content.strip()}\n" if reasoning_content else ""
+            if isinstance(content, list):  # for Mistral API
+                content_str = ""
+                for item in content:
+                    if item.get("type") == "text":
+                        content_str += item.get("text") or ""
+                content = content_str
+
+            reasoning_content = message.get("reasoning_content") or ""
+            result += f"{content.strip()}\n" if isinstance(content, str) else ""
+            result += f"{reasoning_content.strip()}\n" if isinstance(reasoning_content, str) else ""
 
         return result.strip()
 
@@ -186,9 +193,17 @@ class ChatCompletionChunk(ChatCompletionChunk):
         for choice in choices:
             delta = choice.get("delta") or {}
             content = delta.get("content") or ""
+
+            if isinstance(content, list):  # for Mistral API
+                content_str = ""
+                for item in content:
+                    if item.get("type") == "text":
+                        content_str += item.get("text") or ""
+                content = content_str
+
             reasoning_content = delta.get("reasoning_content") or ""
 
-            result += f"{content.strip()}\n" if content else ""
-            result += f"{reasoning_content.strip()}\n" if reasoning_content else ""
+            result += f"{content.strip()}\n" if isinstance(content, str) else ""
+            result += f"{reasoning_content.strip()}\n" if isinstance(reasoning_content, str) else ""
 
         return result.strip()


### PR DESCRIPTION
[//]: # (TODO - Add automatically the title, the PR number, the issue number, and the source and target branches)
[//]: # (TODO - Add automatically the number of commits / commit messages summary in this PR)
[//]: # (# Pull Request Title: [Please insert the PR title here])

## Overview

Regarding Mistral API reference, return of chat completions can be non string content : `string|array<TextChunk|ImageURLChunk|DocumentURLChunk|ReferenceChunk|FileChunk|ThinkChunk|AudioChunk>|null`

- [x] Handle non string response in content parsing 

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

*Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed. This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.*

- [ ] Updated or added documentation
- [ ] Updated or added unit tests 
- [ ] Updated or added integration tests -> LEGACY code 
- [ ] No debug logs or commented-out code left
- [ ] No secrets or environment variables committed in clear text
- [ ] Code is linted and formatted using the project pre-commit hooks


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

*If new or updated environment variables are required, please list them here, otherwise delete this part. If other special deployment steps are required, please describe them here, otherwise delete this part.*

