### PR TITLE
feat(playground): add copy button when creating an API key

### DIFF
--- a/playground/app/features/keys/components/dialogs.py
+++ b/playground/app/features/keys/components/dialogs.py
@@ -26,11 +26,26 @@ def keys_created_dialog() -> rx.Component:
             ),
             rx.vstack(
                 rx.vstack(
-                    rx.text(
-                        "Your API Key:",
-                        size=TEXT_SIZE_LABEL,
-                        weight="bold",
-                        color=rx.color("mauve", 11),
+                    rx.hstack(
+                        rx.text(
+                            "Your API Key:",
+                            size=TEXT_SIZE_LABEL,
+                            weight="bold",
+                            color=rx.color("mauve", 11),
+                        ),
+                        rx.spacer(),
+                        rx.button(
+                            rx.icon("copy", size=ICON_SIZE_MEDIUM),
+                            "Copy",
+                            on_click=[
+                                rx.set_clipboard(KeysState.created_key),
+                                rx.toast.success("API key copied to clipboard", position="bottom-right"),
+                            ],
+                            variant="soft",
+                            size=SIZE_MEDIUM,
+                        ),
+                        width="100%",
+                        align="center",
                     ),
                     rx.text_area(
                         value=KeysState.created_key,

--- a/playground/app/features/keys/components/dialogs.py
+++ b/playground/app/features/keys/components/dialogs.py
@@ -13,30 +13,9 @@ from app.core.variables import (
     SPACING_SMALL,
     SPACING_TINY,
     TEXT_SIZE_LABEL,
-    TEXT_SIZE_MEDIUM,
 )
 from app.features.keys.state import KeysState
 from app.shared.components.dialogs import entity_delete_dialog
-
-
-def _api_key_panel() -> rx.Component:
-    """Tinted, bordered panel displaying the key on a single, horizontally-scrollable line."""
-    return rx.scroll_area(
-        rx.text(
-            KeysState.created_key,
-            font_family="monospace",
-            size=TEXT_SIZE_MEDIUM,
-            white_space="nowrap",
-            user_select="none",
-        ),
-        scrollbars="horizontal",
-        type="auto",
-        width="100%",
-        padding=PADDING_MEDIUM,
-        background_color=rx.color("mauve", 2),
-        border=f"1px solid {rx.color('mauve', 6)}",
-        border_radius="0.5rem",
-    )
 
 
 def keys_created_dialog() -> rx.Component:
@@ -49,11 +28,6 @@ def keys_created_dialog() -> rx.Component:
                     rx.icon("circle_check", size=ICON_SIZE_XL, color=rx.color("green", 9)),
                     rx.vstack(
                         rx.dialog.title("API key created", margin="0"),
-                        rx.dialog.description(
-                            "Your new API key is ready to use.",
-                            color=rx.color("mauve", 11),
-                            size=TEXT_SIZE_LABEL,
-                        ),
                         spacing=SPACING_TINY,
                         align="start",
                     ),
@@ -78,7 +52,13 @@ def keys_created_dialog() -> rx.Component:
                         weight="bold",
                         color=rx.color("mauve", 11),
                     ),
-                    _api_key_panel(),
+                    rx.text_area(
+                        value=KeysState.created_key,
+                        read_only=True,
+                        width="100%",
+                        min_height="120px",
+                        size=SIZE_MEDIUM,
+                    ),
                     spacing=SPACING_SMALL,
                     width="100%",
                 ),

--- a/playground/app/features/keys/components/dialogs.py
+++ b/playground/app/features/keys/components/dialogs.py
@@ -2,74 +2,115 @@
 
 import reflex as rx
 
-from app.core.variables import ICON_SIZE_MEDIUM, ICON_SIZE_XL, MAX_DIALOG_WIDTH, SIZE_MEDIUM, SPACING_LARGE, SPACING_SMALL, TEXT_SIZE_LABEL
+from app.core.variables import (
+    ICON_SIZE_MEDIUM,
+    ICON_SIZE_XL,
+    MAX_DIALOG_WIDTH,
+    PADDING_MEDIUM,
+    SIZE_MEDIUM,
+    SPACING_LARGE,
+    SPACING_MEDIUM,
+    SPACING_SMALL,
+    SPACING_TINY,
+    TEXT_SIZE_LABEL,
+    TEXT_SIZE_MEDIUM,
+)
 from app.features.keys.state import KeysState
 from app.shared.components.dialogs import entity_delete_dialog
+
+
+def _api_key_panel() -> rx.Component:
+    """Tinted, bordered panel displaying the key on a single, horizontally-scrollable line."""
+    return rx.scroll_area(
+        rx.text(
+            KeysState.created_key,
+            font_family="monospace",
+            size=TEXT_SIZE_MEDIUM,
+            white_space="nowrap",
+            user_select="none",
+        ),
+        scrollbars="horizontal",
+        type="auto",
+        width="100%",
+        padding=PADDING_MEDIUM,
+        background_color=rx.color("mauve", 2),
+        border=f"1px solid {rx.color('mauve', 6)}",
+        border_radius="0.5rem",
+    )
 
 
 def keys_created_dialog() -> rx.Component:
     """Dialog to display the newly created API key."""
     return rx.dialog.root(
         rx.dialog.content(
-            rx.dialog.title(
-                rx.hstack(
-                    rx.icon("check_check", size=ICON_SIZE_XL, color=rx.color("green", 11)),
-                    "API Key created successfully!",
-                    spacing=SPACING_SMALL,
-                    align="center",
-                )
-            ),
-            rx.dialog.description(
-                "Copy your API key now. You won't be able to see it again!",
-                color=rx.color("red", 11),
-                weight="bold",
-            ),
             rx.vstack(
-                rx.vstack(
-                    rx.hstack(
-                        rx.text(
-                            "Your API Key:",
-                            size=TEXT_SIZE_LABEL,
-                            weight="bold",
+                # Header
+                rx.hstack(
+                    rx.icon("circle_check", size=ICON_SIZE_XL, color=rx.color("green", 9)),
+                    rx.vstack(
+                        rx.dialog.title("API key created", margin="0"),
+                        rx.dialog.description(
+                            "Your new API key is ready to use.",
                             color=rx.color("mauve", 11),
+                            size=TEXT_SIZE_LABEL,
                         ),
-                        rx.spacer(),
-                        rx.button(
-                            rx.icon("copy", size=ICON_SIZE_MEDIUM),
-                            "Copy",
-                            on_click=[
-                                rx.set_clipboard(KeysState.created_key),
-                                rx.toast.success("API key copied to clipboard", position="bottom-right"),
-                            ],
-                            variant="soft",
-                            size=SIZE_MEDIUM,
-                        ),
-                        width="100%",
-                        align="center",
+                        spacing=SPACING_TINY,
+                        align="start",
                     ),
-                    rx.text_area(
-                        value=KeysState.created_key,
-                        read_only=True,
-                        width="100%",
-                        min_height="120px",
-                        size=SIZE_MEDIUM,
+                    spacing=SPACING_MEDIUM,
+                    align="center",
+                    width="100%",
+                ),
+                # Warning
+                rx.callout(
+                    "Copy your key now, for security reasons you won't be able to see it again.",
+                    icon="triangle_alert",
+                    color_scheme="amber",
+                    variant="surface",
+                    size="1",
+                    width="100%",
+                ),
+                # Key
+                rx.vstack(
+                    rx.text(
+                        "Your API key",
+                        size=TEXT_SIZE_LABEL,
+                        weight="bold",
+                        color=rx.color("mauve", 11),
                     ),
+                    _api_key_panel(),
                     spacing=SPACING_SMALL,
                     width="100%",
                 ),
-                rx.dialog.close(
-                    rx.button(
-                        rx.icon("check", size=ICON_SIZE_MEDIUM),
-                        "I've copied the key",
-                        on_click=KeysState.clear_created_key,
-                        size=SIZE_MEDIUM,
-                        width="100%",
+                # Footer
+                rx.hstack(
+                    rx.dialog.close(
+                        rx.button(
+                            "Done",
+                            on_click=KeysState.clear_created_key,
+                            variant="soft",
+                            color_scheme="gray",
+                            size=SIZE_MEDIUM,
+                        ),
                     ),
+                    rx.button(
+                        rx.icon("copy", size=ICON_SIZE_MEDIUM),
+                        "Copy API key",
+                        on_click=[
+                            rx.set_clipboard(KeysState.created_key),
+                            rx.toast.success("API key copied to clipboard", position="bottom-right"),
+                        ],
+                        size=SIZE_MEDIUM,
+                    ),
+                    spacing=SPACING_MEDIUM,
+                    justify="end",
+                    width="100%",
                 ),
                 spacing=SPACING_LARGE,
                 width="100%",
             ),
             max_width=MAX_DIALOG_WIDTH,
+            padding=PADDING_MEDIUM,
         ),
         open=KeysState.is_created_dialog_open,
         on_open_change=KeysState.handle_created_dialog_change,

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -33,11 +33,22 @@ class KeysState(EntityState):
         """Get keys list with correct typing for Reflex."""
         return self.entities
 
+    def _default_expiry_date(self) -> str:
+        """Default expiry date: today + 1 year, capped at the configured maximum if any."""
+        default = dt.datetime.now() + dt.timedelta(days=365)
+        if configuration.settings.auth_key_max_expiration_days is not None:
+            max_date = dt.datetime.now() + dt.timedelta(days=configuration.settings.auth_key_max_expiration_days - 1)
+            default = min(default, max_date)
+        return default.strftime("%Y-%m-%d")
+
     @rx.event
     async def load_entities(self):
         """Load entities."""
         if not self.is_authenticated or not self.api_key:
             return
+
+        if not self.entity_to_create.expires:
+            self.entity_to_create.expires = self._default_expiry_date()
 
         self.entities_loading = True
         yield
@@ -192,6 +203,9 @@ class KeysState(EntityState):
                 # Store the created key to display in dialog
                 self.created_key = data.get("key", "")
                 self.is_created_dialog_open = True
+
+                # Reset the create form, keeping the default 1-year expiry
+                self.entity_to_create = Key(expires=self._default_expiry_date())
 
                 yield rx.toast.success("Key created successfully", position="bottom-right")
                 async for _ in self.load_entities():


### PR DESCRIPTION
## Overview

This PR improves the user experience around API key creation in the playground.

When a new API key is created, the value is shown only once and cannot be retrieved again. The previous dialog displayed the key in a read-only text area and only offered an "I've copied the key" button that the user had to act on manually, which was error-prone (the key could easily be lost if not copied correctly).

What was done:
- Redesigned the "API key created" dialog with a clearer layout (header with icon + title/description, an amber warning callout, the key in a tinted bordered panel, and a footer with actions).
- Added a **"Copy API key"** button that copies the key to the clipboard and shows a success toast, removing the manual copy/paste step.
- Replaced the manual "I've copied the key" action with a simple **"Done"** button to close the dialog.
- Added a default expiration date of **one year** for newly created keys, capped at the configured maximum (`auth_key_max_expiration_days`) when one is set.
- Reset the creation form after a key is created, keeping the default 1-year expiry pre-filled for the next key.

- [x] Users can copy the newly created API key in one click (with confirmation feedback).
- [x] The new key value remains visible/copyable until the dialog is dismissed.
- [x] New keys default to a 1-year expiration, capped at the configured maximum.

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

*Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed. This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.*

- [ ] Updated or added documentation — N/A, UI-only change in the playground.
- [ ] Updated or added unit tests — N/A, presentational/UI logic only.
- [ ] Updated or added integration tests — N/A, presentational/UI logic only.
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated — N/A
- [ ] Configuration file has been modified — N/A
- [ ] Environment variables have been modified — N/A

## Additional Notes

The expiry default reuses the existing `auth_key_max_expiration_days` setting to make sure the proposed 1-year default never exceeds the configured maximum.

Changes are scoped to two files in the playground:
- `playground/app/features/keys/components/dialogs.py` — redesigned dialog + copy button.
- `playground/app/features/keys/state.py` — default 1-year expiry and form reset after creation.
- Don't take into account the difference in theme

Before redesign:
<img width="1680" height="1050" alt="Screenshot 2026-06-04 at 15 10 43" src="https://github.com/user-attachments/assets/e83a91af-f2dd-4ec8-bd53-5c58a7d7df12" />

After redesign:
<img width="1728" height="1084" alt="Screenshot 2026-05-29 at 14 42 49" src="https://github.com/user-attachments/assets/34296c3b-192b-4952-9c2d-c306023d633c" />
