### PR TITLE
chore: add npm minimum release age

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary

- Add `docs/.npmrc` with `min-release-age=7`
- Enforce a 7-day package release-age gate for npm installs in the `docs/` package root

## Why

This helps mitigate supply-chain attacks where a malicious or compromised package version is published and consumed immediately after release.

Closes #906

## Verification

- [x] `npm config get min-release-age --prefix docs` returns `7`
- [x] `npm ci --ignore-scripts --prefix docs`

Note: `npm ci` reports existing audit/deprecation warnings, but the install succeeds and this PR does not change dependencies or the lockfile.