### PR TITLE
fix(postges): close session before calling LLMs in chat completion

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"55.66%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"55.65%","color":"red"}

--- a/api/endpoints/chat.py
+++ b/api/endpoints/chat.py
@@ -78,6 +78,8 @@ async def chat_completions(
         elasticsearch_client=elasticsearch_client,
     )
 
+    await postgres_session.close()
+
     if body.stream:
         stream_iter = model_provider.forward_stream(request_content=request_content, redis_client=redis_client)
         return StreamingResponseWithStatusCode(content=stream_iter, media_type="text/event-stream")


### PR DESCRIPTION
# fix(postges): close session before calling LLMs in chat completion

## Overview

Resolves #715.

The legacy `POST /v1/chat/completions` endpoint holds its request-scoped PostgreSQL session until the FastAPI dependency teardown, i.e. **after** the full response has been sent. Because the response is an SSE stream that can last tens of seconds, the connection stays checked out (`idle in transaction`) for the entire stream even though no database work happens during it. Under load this exhausts the API connection pool and the PostgreSQL server (`FATAL: sorry, too many clients already`).

This PR releases the connection back to the pool right after the upfront (read-only) DB work, authentication, model resolution and RAG search  and before the LLM call, in `api/endpoints/chat.py`:

```python
await postgres_session.close()  # before `if body.stream:`
```

This is safe because the request path is read-only, the legacy `get_postgres_session` teardown never commits, and the writes (usage logging, budget decrement) already run on their own short-lived sessions after the stream (`@hooks`).

**Definition of Done:**

- [ ] The PostgreSQL connection is returned to the pool **before** streaming starts (no request-bound `idle in transaction` connection visible in `pg_stat_activity` during a long `stream=true` call).
- [ ] Streaming and non-streaming responses remain functionally identical.
- [ ] Usage logging and budget decrement still work after the stream ends.
- [ ] Authentication, rate-limiting and RAG (`search=true`) remain unchanged.

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

*Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed. This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.*

- [ ] Updated or added documentation ? *N/A: behaviour is unchanged from the client's perspective; the fix is internal connection management.*
- [ ] Updated or added unit tests ? *N/A: the change is a one-line resource-lifecycle fix with no new branching logic to unit test.*
- [ ] Updated or added integration tests ? *Covered by the existing end-to-end suite `api/tests/integ/test_chat.py`; behaviour is unchanged. The connection-release effect is validated manually (see reproduction steps in the issue).*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated ? *N/A: `api/sql/models.py` is not modified.*
- [ ] Alembic migration upgrade has been tested locally ? *N/A*
- [ ] Alembic migration downgrade has been tested locally ? *N/A*

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated ? *N/A*
- [ ] Configuration file has been modified ? *N/A: no config change is required by this PR.*
- [ ] Environment variables have been modified ? *N/A*

## Additional Notes

Suggested review focus:

- **Correctness of the early close.** Confirm that nothing in the request path uses `postgres_session` after the `close()` (it does not: `forward_stream` / `forward_request` do not receive the session) and that the path is read-only (auth and model resolution are reads; rate-limiting is Redis-only).
- **Post-stream writes.** Usage logging (`log_usage`) and budget decrement (`update_budget`) run via `asyncio.create_task` in the `@hooks` streaming wrapper and open their own short-lived sessions, so they are unaffected by closing the request session early.

The same one-line fix applies to the other legacy endpoints (`embeddings`, `audio`, `ocr`, `search`, `parse`) and will be handled in follow-up PRs. Enabling `idle_in_transaction_session_timeout` and tuning `max_connections` / `pool_size` / `max_overflow` in production are tracked separately.
