### PR TITLE
fix(keys): validation legacy keys post refacto

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"55.65%","color":"red"}
+{"schemaVersion":1,"label":"coverage","message":"55.64%","color":"red"}

--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ docs/.astro
 docs/node_modules
 node_modules/
 .astro/
+.vault
 
 # Coding assitants
 .kilo/

--- a/api/domain/key/entities.py
+++ b/api/domain/key/entities.py
@@ -13,14 +13,25 @@ class Key(BaseModel):
 
     @classmethod
     def build_from_claims(cls, claims: dict):
-        return cls(id=claims["token_id"], name="", value="", user_id=claims["user_id"], expires=claims["expires"], created=0)
+        return cls(
+            id=claims["token_id"],
+            name="",
+            value="",
+            user_id=claims["user_id"],
+            expires=claims.get("expires", claims.get("expires_at")),  # legacy support for expires_at: remove after 2027-08-10
+            created=0,
+        )
 
     def is_valid(self, expected_key: "Key") -> bool:
-        decoded_expires = self._expires_timestamp(self.expires)
-        if decoded_expires is not None and decoded_expires < int(datetime.now(tz=UTC).timestamp()):
+        now_ts = int(datetime.now(tz=UTC).timestamp())
+        expected_expires_ts = self._expires_timestamp(expected_key.expires)
+
+        if expected_expires_ts is not None and expected_expires_ts < now_ts:
             return False
 
-        return self.user_id == expected_key.user_id and decoded_expires == self._expires_timestamp(expected_key.expires)
+        # some legacy keys has expiration date unsync with database: after 2027-08-10, we can add a check to ensure the expiration date is sync with the database.
+        # decoded_expires == self._expires_timestamp(expected_key.expires)
+        return self.user_id == expected_key.user_id
 
     @staticmethod
     def _expires_timestamp(expires: datetime | None) -> int | None:

--- a/api/tests/integration/fastapi/test_accesscontroler.py
+++ b/api/tests/integration/fastapi/test_accesscontroler.py
@@ -1,5 +1,5 @@
 from contextvars import ContextVar, Token
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
 from fastapi.security import HTTPAuthorizationCredentials
@@ -326,6 +326,10 @@ class TestAccessController:
                 request_context=reset_request_context,
             )
 
+    @pytest.mark.skipif(
+        condition=datetime.now(tz=UTC) < datetime(2027, 8, 10, tzinfo=UTC),
+        reason="Ignore test until 2027-08-10 due to legacy key expiration date unsync with database",
+    )
     async def test_should_raise_invalid_api_key_when_expires_does_not_match_stored_expires(
         self,
         access_controller: AccessController,
@@ -476,3 +480,88 @@ class TestAccessController:
         assert context.user is not None
         assert context.user.id == user.id
         assert context.user.is_admin is True
+
+    async def test_should_validate_legacy_key_when_expires_is_in_expires_at(
+        self,
+        access_controller: AccessController,
+        request_obj: Mock,
+        key_repository: PostgresKeyRepository,
+        authenticated_user_query: PostgresAuthenticatedUserQuery,
+        reset_request_context: ContextVar[RequestContext],
+        secret_key: str,
+        db_session,
+    ):
+        """
+        Some legacy keys has expiration date unsync with database: after 2027-08-10, we can remove this test.
+        """
+        # Arrange
+        user = UserSQLFactory()
+        stored_expires = datetime.now(tz=UTC) + timedelta(days=1)
+        token = KeySQLFactory(user=user, expires=stored_expires)
+        await db_session.flush()
+
+        credentials = "sk-" + jwt.encode(
+            claims={"user_id": user.id, "token_id": token.id, "expires_at": int(stored_expires.timestamp())},
+            key=secret_key,
+            algorithm="HS256",
+        )
+        api_key = HTTPAuthorizationCredentials(scheme="Bearer", credentials=credentials)
+
+        # Act
+        await access_controller(
+            request=request_obj,
+            api_key=api_key,
+            key_repository=key_repository,
+            authenticated_user_query=authenticated_user_query,
+            request_context=reset_request_context,
+        )
+
+        # Assert
+        context = reset_request_context.get()
+        assert context.key is not None
+        assert context.key.id == token.id
+        assert context.key.user_id == user.id
+        assert int(context.key.expires.timestamp()) == int(stored_expires.timestamp())
+
+    async def test_should_validate_legacy_key_when_expiration_date_is_unsync_with_database(
+        self,
+        access_controller: AccessController,
+        request_obj: Mock,
+        key_repository: PostgresKeyRepository,
+        authenticated_user_query: PostgresAuthenticatedUserQuery,
+        reset_request_context: ContextVar[RequestContext],
+        secret_key: str,
+        db_session,
+    ):
+        """
+        Some legacy keys has expiration date unsync with database: after 2027-08-10, we can remove this test.
+        """
+        # Arrange
+        user = UserSQLFactory()
+        database_stored_expires = datetime.now() + timedelta(days=1)
+        token = KeySQLFactory(user=user, expires=database_stored_expires)
+        await db_session.flush()
+
+        key_stored_expires = int((datetime.now(tz=UTC) - timedelta(hours=1)).timestamp())
+        credentials = "sk-" + jwt.encode(
+            claims={"user_id": user.id, "token_id": token.id, "expires": key_stored_expires},
+            key=secret_key,
+            algorithm="HS256",
+        )
+        api_key = HTTPAuthorizationCredentials(scheme="Bearer", credentials=credentials)
+
+        # Act
+        await access_controller(
+            request=request_obj,
+            api_key=api_key,
+            key_repository=key_repository,
+            authenticated_user_query=authenticated_user_query,
+            request_context=reset_request_context,
+        )
+
+        # Assert
+        context = reset_request_context.get()
+        assert context.key is not None
+        assert context.key.id == token.id
+        assert context.key.user_id == user.id
+        assert int(context.key.expires.timestamp()) == key_stored_expires

--- a/api/use_cases/health/_gethealthmodelsusecase.py
+++ b/api/use_cases/health/_gethealthmodelsusecase.py
@@ -83,7 +83,6 @@ class GetHealthModelsUseCase:
                     case _:
                         # @TODO: if another provider is healthy, we should not set the health to red
                         # @TODO: connect load balancing strategy to the health status
-                        print(response)
                         health.status = HealthStatus.RED
                         continue
 


### PR DESCRIPTION
[//]: # (TODO - Add automatically the title, the PR number, the issue number, and the source and target branches)
[//]: # (TODO - Add automatically the number of commits / commit messages summary in this PR)
[//]: # (# Pull Request Title: [Please insert the PR title here])

## Overview

This PR fixes API key validation for existing keys that stopped working after the auth/keys refactor. Two issues were identified in the JWT expiration claim:

1. The expiration field was renamed during key creation and decoding, from `expires_at` to `expires`.
2. Some legacy keys contain an expiration date that does not match the one stored in the database. The refactor tightened key validation by adding a consistency check between the expiration date in the key and the one in the database. That check invalidated all affected legacy keys.

## Changes

This PR fixes both issues:

- [x] Key validation falls back to the `expires_at` claim when `expires` is not present
- [x] Removal of the consistency check between the database expiration date and the one in the key
- [x] Added comments to remove these fixes after **2027-08-10**, when all affected legacy keys will have expired
- [x] Added integration tests to verify legacy key support

---

**Title suggestion:** `fix: legacy API key validation after auth/keys refactor`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

*Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed. This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.*

- [ ] Updated or added documentation
- [ ] Updated or added unit tests
- [x] Updated or added integration tests
- [ ] No debug logs or commented-out code left
- [ ] No secrets or environment variables committed in clear text
- [ ] Code is linted and formatted using the project pre-commit hooks


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

*If new or updated environment variables are required, please list them here, otherwise delete this part. If other special deployment steps are required, please describe them here, otherwise delete this part.*

## Additional Notes

*Please provide any additional information or context that may be relevant to this PR, otherwise delete this part. This could be any specific areas you would like the reviewers to focus on during their review of this PR (complex logic, risky changes, performance-sensitive code, etc.)*