### PR TITLE
fix(playground): prevent role row action buttons from toggling the rate-limits accordion

### DIFF
--- a/playground/app/shared/components/lists.py
+++ b/playground/app/shared/components/lists.py
@@ -40,7 +40,7 @@ def entity_row(
                     with_settings,
                     rx.button(
                         rx.icon("settings", size=ICON_SIZE_MEDIUM),
-                        on_click=lambda: state.set_entity_settings(entity=entity),
+                        on_click=lambda: state.set_entity_settings(entity=entity).stop_propagation,
                         variant="soft",
                         color_scheme="blue",
                         size=TEXT_SIZE_LABEL,
@@ -48,7 +48,7 @@ def entity_row(
                 ),
                 rx.button(
                     rx.icon("trash-2", size=ICON_SIZE_MEDIUM),
-                    on_click=lambda: state.set_entity_to_delete(entity=entity),
+                    on_click=lambda: state.set_entity_to_delete(entity=entity).stop_propagation,
                     variant="soft",
                     color_scheme="red",
                     size=TEXT_SIZE_LABEL,


### PR DESCRIPTION
## Overview

Resolves #942.

On the Roles page, each role is rendered as an `rx.accordion.item` whose **header** contains the shared `entity_row` component (settings + delete buttons). Because those buttons live inside the accordion header — which is itself the clickable toggle — their click events bubbled up to the accordion, so clicking **Settings** or **Delete** performed the intended action *and* expanded/collapsed the rate-limits accordion.

This PR adds `.stop_propagation` to the `on_click` event specs of the settings and delete buttons in `entity_row` (`playground/app/shared/components/lists.py`). The click no longer bubbles to the accordion header, so each button performs only its own action, while clicking the row body still toggles the accordion.

The change lives in the shared `entity_row` used by other lists (organizations, routers, providers, users, keys). Those are non-accordion lists with no parent click handler, so `stop_propagation` is a harmless no-op there — no regression.

Definition of Done:

- [x] Clicking the **Settings** button opens the role settings modal only, without toggling the rate-limits accordion
- [x] Clicking the **Delete** button starts the delete flow only, without toggling the rate-limits accordion
- [x] Clicking the role row body still expands/collapses the rate-limits accordion as before
- [x] No regression for other consumers of the shared `entity_row` component

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation — *N/A: UI behavior fix, no documented behavior changes*
- [ ] Updated or added unit tests — *N/A: front-end event-propagation fix; not covered by the current test suite*
- [ ] Updated or added integration tests — *N/A: same as above; verified manually in the playground*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated — *N/A: `models.py` not modified*
- [ ] Alembic migration upgrade has been tested locally — *N/A*
- [ ] Alembic migration downgrade has been tested locally — *N/A*

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

## Additional Notes

The fix uses Reflex's `.stop_propagation` event-spec modifier, which emits `event.stopPropagation()` before running the handler — sufficient for the `on_click` bubbling that caused this issue. If a future Radix accordion version also reacts to `pointerdown`/`keydown` on the trigger, `.prevent_default` could be added as well, but it is not needed for the current behavior.

Suggested area to focus review: confirm the `.stop_propagation` change in `entity_row` does not alter expected click behavior on the other lists that reuse this component.

<img width="1402" height="399" alt="Screenshot 2026-06-29 at 14 29 33" src="https://github.com/user-attachments/assets/5c061345-bdbe-4048-b2c9-9c874cf202b0" />
