### PR TITLE
feat(redis): implement redis keys reset

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "59.07%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "59.05%", "color": "red"}

--- a/api/helpers/_limiter.py
+++ b/api/helpers/_limiter.py
@@ -2,7 +2,7 @@ import logging
 
 from limits import RateLimitItemPerDay, RateLimitItemPerMinute
 from limits.aio import storage, strategies
-from redis.asyncio import ConnectionPool, Redis, RedisError
+from redis.asyncio import ConnectionPool, Redis
 
 from api.domain.role.entities import PermissionType
 from api.schemas.admin.roles import LimitType
@@ -26,15 +26,6 @@ class Limiter:
             self.strategy = strategies.FixedWindowRateLimiter(storage=self.redis_storage)
         else:  # SLIDING_WINDOW
             self.strategy = strategies.SlidingWindowCounterRateLimiter(storage=self.redis_storage)
-
-    async def reset(self) -> None:
-        """
-        Reset the limits when starting the API.
-        """
-        try:
-            await self.redis_storage.reset()
-        except RedisError:
-            logger.error(msg="Redis error during rate limit reset.", exc_info=True)
 
     async def _get_limit(self, type: LimitType, value: int | None = None) -> RateLimitItemPerMinute | RateLimitItemPerDay | None:
         if value is None:

--- a/api/tests/unit/test_helpers/test_limiter.py
+++ b/api/tests/unit/test_helpers/test_limiter.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 from limits.aio import strategies
 from limits.aio.storage import RedisStorage
 import pytest
-from redis.exceptions import RedisError
 
 from api.helpers._limiter import Limiter
 from api.schemas.admin.roles import Limit, LimitType, PermissionType
@@ -36,83 +35,6 @@ async def test_limiter_initialization_strategies(strategy, expected_class):
 
         limiter = Limiter(mock_redis_pool, strategy=strategy)
         assert isinstance(limiter.strategy, expected_class)
-
-
-# =========================== RESET METHOD ============================
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "strategy",
-    [
-        LimitingStrategy.MOVING_WINDOW,
-        LimitingStrategy.FIXED_WINDOW,
-        LimitingStrategy.SLIDING_WINDOW,
-    ],
-)
-async def test_limiter_reset_success(strategy):
-    """Test that reset successfully calls redis_client.reset()."""
-    # Mock the Redis pool instead of using global_context
-    mock_redis_pool = MagicMock()
-    mock_redis_pool.url = "redis://localhost:6379"
-
-    with patch("api.helpers._limiter.storage.RedisStorage") as MockStorage, patch("api.helpers._limiter.Redis") as MockRedis:
-        mock_storage_instance = AsyncMock(spec=RedisStorage)
-        MockStorage.return_value = mock_storage_instance
-
-        mock_internal_redis = AsyncMock()
-        MockRedis.return_value = mock_internal_redis
-
-        redis_state = ["LIMITS:key1", "LIMITS:key2"]
-        mock_internal_redis.keys.side_effect = lambda pattern: redis_state
-        # When storage.reset() is called, clear the state
-
-        async def simulate_reset():
-            redis_state.clear()
-
-        mock_storage_instance.reset.side_effect = simulate_reset
-
-        limiter = Limiter(mock_redis_pool, strategy=strategy)
-
-        # Verify keys exist before reset
-        initial_keys = await limiter.redis_client.keys("LIMITS*")
-        assert len(initial_keys) == 2
-
-        await limiter.reset()
-
-        mock_storage_instance.reset.assert_awaited_once()
-
-        final_keys = await limiter.redis_client.keys("LIMITS*")
-        assert len(final_keys) == 0
-
-
-@pytest.mark.asyncio
-async def test_limiter_reset_handles_redis_error():
-    """Test that reset handles RedisError gracefully."""
-    mock_redis_pool = MagicMock()
-    mock_redis_pool.url = "redis://localhost:6379"
-    strategy = LimitingStrategy.FIXED_WINDOW
-
-    with (
-        patch("api.helpers._limiter.storage.RedisStorage") as MockStorage,
-        patch("api.helpers._limiter.Redis") as MockRedis,
-        patch("api.helpers._limiter.logger") as mock_logger,
-    ):
-        mock_storage_instance = AsyncMock(spec=RedisStorage)
-        mock_storage_instance.reset.side_effect = RedisError("Test Error")
-        MockStorage.return_value = mock_storage_instance
-
-        mock_internal_redis = AsyncMock()
-        MockRedis.return_value = mock_internal_redis
-
-        limiter = Limiter(mock_redis_pool, strategy)
-
-        await limiter.reset()
-
-        mock_storage_instance.reset.assert_awaited_once()
-        mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[1]["msg"]
-        assert "Redis error during rate limit reset." in logged_msg
 
 
 # =========================== HIT METHOD ============================

--- a/api/utils/lifespan.py
+++ b/api/utils/lifespan.py
@@ -66,8 +66,6 @@ async def lifespan(_: FastAPI):
     global_context.tokenizer = create_tokenizer(configuration=configuration)
     global_context._tokenizer = initialize_tokenizer(configuration=configuration)
 
-    await global_context.limiter.reset()
-
     yield
 
     if global_context.redis_pool:

--- a/scripts/gunicorn.conf.py
+++ b/scripts/gunicorn.conf.py
@@ -1,4 +1,16 @@
 from prometheus_client import multiprocess
+from redis import Redis as SyncRedis
+
+from api.utils.configuration import get_configuration
+
+
+def on_starting(server):
+    client = SyncRedis.from_url(get_configuration().dependencies.redis.url)
+    try:
+        client.flushdb()
+        server.log.info("Redis keys flushed on API startup.")
+    finally:
+        client.close()
 
 
 def child_exit(server, worker):


### PR DESCRIPTION
## Overview

Resolves #704.

Redis keys were not cleared when the API started. The only startup-time reset was `Limiter.reset()`
(called in the lifespan), which delegates to the `limits` library's `redis_storage.reset()` — and that
only deletes keys prefixed with `LIMITS` (rate limiting). All the other keys written by the app
(`ogl_mg:*` inflight gauges, `ogl_ts:*` latency time-series) survived a restart.

This PR flushes the whole Redis logical DB on API startup, **once per process**, from the gunicorn
master (`on_starting` hook) before workers are forked. This placement is deliberate: with several
workers in production, doing the flush in the per-worker lifespan would mean that a single crashed
worker being respawned by gunicorn would wipe the Redis state (rate limits, inflight gauges, metrics)
still in use by its live sibling workers — including driving the `inflight` gauges negative. Running it
once in the master avoids that.

Changes:
- Add `reset_redis_keys(url)` in `api/utils/redis.py` — a synchronous `flushdb` (the gunicorn master
  runs outside the event loop).
- Call it from `on_starting(server)` in `scripts/gunicorn.conf.py`.
- Remove the now-redundant `Limiter.reset()` method and its lifespan call (superseded by the full flush),
  and drop the associated obsolete unit tests.

- [x] All Redis keys are flushed when the API starts
- [x] The flush runs once per process (gunicorn master), so a crashed-worker respawn does not wipe the
      shared Redis state of live workers
- [x] The obsolete `Limiter.reset()` (partial, LIMITS-only reset) is removed

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

> Note: behavior change (not an API break) — in local `make dev` the API runs under uvicorn (no gunicorn
> master), so the startup flush no longer happens in dev. Production runs under gunicorn (`startup_api.sh`),
> where the hook applies.

## Check lists

### Review checklist

- [ ] Updated or added documentation — n/a, internal startup behavior, no user-facing docs impacted.
- [ ] Updated or added unit tests — no unit test added for `reset_redis_keys`; the obsolete
      `Limiter.reset()` unit tests were removed along with the method.
- [ ] Updated or added integration tests — none added for the new startup flush behavior.
- [ ] No debug logs or commented-out code left — ⚠️ `api/utils/lifespan.py` still contains a commented-out
      `# await client.flushdb()` line to remove before merge.
- [x] No secrets or environment variables committed in clear text
- [ ] Code is linted and formatted using the project pre-commit hooks — to confirm by the author.


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

> `api/sql/models.py` was not modified — not applicable.

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

> None of the above apply: no schema change, no config change, no new/updated environment variables.
> The flush reuses the existing `dependencies.redis.url` configuration.

## Additional Notes

Points worth a reviewer's attention:

- **Placement rationale (main design point):** the flush is in the gunicorn master `on_starting` hook
  rather than the per-worker lifespan, specifically to avoid a respawned worker wiping the shared Redis
  state of live sibling workers (rate-limit counters, `ogl_mg:*` inflight gauges — `decrement_inflight`
  has no floor at 0, so a mid-life flush could push gauges negative and skew the "least busy" load
  balancer — and `ogl_ts:*` metrics).
- **Multi-replica / rolling deploy:** each new container still flushes the shared Redis on its own boot.
  A flush-on-start over a Redis shared across replicas is inherently in tension there; out of scope for
  this PR, which targets the frequent and dangerous case (worker respawn).
- **Celery:** when the (deprecated) Celery dependency is enabled, its broker/result-backend default to the
  same Redis URL/DB, so the startup flush also drops any queued Celery tasks/results.
- **Leftover to clean up:** remove the commented `# await client.flushdb()` in `api/utils/lifespan.py`.
- **Test coverage gap:** consider adding a test for `reset_redis_keys` (seed keys → call → assert
  `DBSIZE == 0`) since the previous startup-reset unit tests were removed.
