### PR TITLE
feat(playground): show total pages in pagination

### DIFF
--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -78,7 +78,7 @@ class KeysState(EntityState):
                     if key["name"] not in ["playground", "_system_search_tool"]:
                         self.entities.append(self._format_key(key))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -220,8 +220,6 @@ class KeysState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -233,7 +231,7 @@ class KeysState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
+
         yield
         async for _ in self.load_entities():
             yield
@@ -243,23 +241,6 @@ class KeysState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield

--- a/playground/app/features/organizations/state.py
+++ b/playground/app/features/organizations/state.py
@@ -65,7 +65,7 @@ class OrganizationsState(EntityState):
                 for organization in data.get("data", []):
                     self.entities.append(self._format_organization(organization))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -229,8 +229,6 @@ class OrganizationsState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -242,7 +240,6 @@ class OrganizationsState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -252,23 +249,6 @@ class OrganizationsState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -171,7 +171,7 @@ class ProvidersState(EntityState):
 
                     self.entities.append(self._format_provider(provider))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -368,8 +368,6 @@ class ProvidersState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -381,7 +379,6 @@ class ProvidersState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -391,26 +388,9 @@ class ProvidersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield
 
     filter_router_value: str = "All routers"
 
@@ -418,7 +398,6 @@ class ProvidersState(EntityState):
     async def set_filter_router(self, value: str):
         self.filter_router_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -118,7 +118,7 @@ class RolesState(EntityState):
                 for role in data.get("data", []):
                     self.entities.append(self._format_role(role))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -434,8 +434,6 @@ class RolesState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -447,7 +445,6 @@ class RolesState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -457,23 +454,6 @@ class RolesState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -99,7 +99,7 @@ class RoutersState(EntityState):
                     if router["user_id"] not in self.router_owners:
                         async with httpx.AsyncClient() as client:
                             response = await client.get(
-                                url=f"{self.opengatellm_url}/v1/admin/users/{router["user_id"]}",
+                                url=f"{self.opengatellm_url}/v1/admin/users/{router['user_id']}",
                                 headers={"Authorization": f"Bearer {self.api_key}"},
                                 timeout=configuration.settings.playground_opengatellm_timeout,
                             )
@@ -113,7 +113,7 @@ class RoutersState(EntityState):
 
                     self.entities.append(self._format_router(router))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -304,8 +304,6 @@ class RoutersState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -317,7 +315,6 @@ class RoutersState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -327,23 +324,6 @@ class RoutersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -70,7 +70,7 @@ class UsageState(EntityState):
                 data = response.json()
                 self.entities = [self._format_usage(usage) for usage in data.get("data", [])]
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -98,28 +98,10 @@ class UsageState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield
 
     filter_date_from_value: str | None = None
     filter_date_to_value: str | None = None
@@ -156,7 +138,6 @@ class UsageState(EntityState):
     @rx.event
     async def apply_filters(self):
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -146,7 +146,7 @@ class UsersState(EntityState):
                 for user in data.get("data", []):
                     self.entities.append(self._format_user(user))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -365,8 +365,6 @@ class UsersState(EntityState):
     ############################################################
     # Pagination & filters
     ############################################################
-    page: int = 1
-    per_page: int = 20
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -378,7 +376,6 @@ class UsersState(EntityState):
     async def set_search_email(self, value: str):
         self.search_email_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -388,7 +385,6 @@ class UsersState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -398,26 +394,9 @@ class UsersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
-
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
-
-    @rx.event
-    async def next_page(self):
-        if self.has_more_page:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield
 
     filter_role_value: str = "All roles"
     filter_organization_value: str = "All organizations"
@@ -426,7 +405,6 @@ class UsersState(EntityState):
     async def set_filter_role(self, value: str):
         self.filter_role_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -435,7 +413,6 @@ class UsersState(EntityState):
     async def set_filter_organization(self, value: str):
         self.filter_organization_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/shared/components/lists.py
+++ b/playground/app/shared/components/lists.py
@@ -76,7 +76,10 @@ def entity_pagination(state: rx.State) -> rx.Component:
             disabled=state.page <= 1,
         ),
         rx.text(
+            "Page ",
             state.page.to(str),
+            " / ",
+            state.total_pages.to(str),
         ),
         rx.button(
             "Next",

--- a/playground/app/shared/components/pagination.py
+++ b/playground/app/shared/components/pagination.py
@@ -14,7 +14,10 @@ def pagination(state: Any) -> rx.Component:
             disabled=state.page <= 1,
         ),
         rx.text(
+            "Page ",
             state.page.to(str),
+            " / ",
+            state.total_pages.to(str),
         ),
         rx.button(
             "Next",

--- a/playground/app/shared/states/entity_state.py
+++ b/playground/app/shared/states/entity_state.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod
+import math
+
+import reflex as rx
 
 from app.features.auth.state import AuthState
 from app.shared.models.entities import Entity
@@ -93,7 +96,9 @@ class EntityState(AuthState):
     ############################################################
     # Pagination
     ############################################################
-    has_more_page: bool = False
+    total: int = 0
+    page: int = 1
+    per_page: int = 20
 
     @abstractmethod
     async def set_order_by(self, value: str):
@@ -105,12 +110,28 @@ class EntityState(AuthState):
         """Set order direction and reload."""
         pass
 
-    @abstractmethod
+    @rx.event
     async def prev_page(self):
         """Go to previous page."""
-        pass
+        if self.page > 1:
+            self.page -= 1
+            yield
+            async for _ in self.load_entities():
+                yield
 
-    @abstractmethod
+    @rx.event
     async def next_page(self):
         """Go to next page."""
-        pass
+        if self.has_more_page:
+            self.page += 1
+            yield
+            async for _ in self.load_entities():
+                yield
+
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
+    @rx.var
+    def has_more_page(self) -> bool:
+        return self.page < self.total_pages


### PR DESCRIPTION
## Overview

Resolves #758.

The playground pagination only displayed the current page number, with a `Next` button enabled from a `has_more_page` boolean guessed client-side (`len(entities) == per_page`). This PR uses the `total` count returned by the API to display `Page X / Y` and to drive the `Next` button state.

The pagination logic was also duplicated across every feature state (`keys`, `organizations`, `providers`, `roles`, `routers`, `usage`, `users`) — each redefining `page`, `per_page`, `prev_page` and `next_page`. It now lives once in the shared `EntityState`:

- `total`, `page`, `per_page` are declared in `EntityState`
- `total_pages` and `has_more_page` become computed `rx.var`s
- `prev_page` / `next_page` become concrete implementations instead of abstract methods
- each feature state now only sets `self.total = data.get("total", 0)` after loading

Net result: -156 / +41 lines.

- [x] Total number of pages is displayed in the playground pagination (`Page X / Y`)
- [x] `Next` is disabled on the last page, based on the API `total` rather than a heuristic
- [x] Pagination logic is factored into the shared `EntityState`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation — *not applicable, UI-only change*
- [ ] Updated or added unit tests — *playground has no test suite*
- [ ] Updated or added integration tests — *idem*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

`api/sql/models.py` is not modified.

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

No specific deployment step required.

## Additional Notes

Points worth a look during review:

- `total_pages` uses `max(1, ceil(total / per_page))` so an empty list still shows `Page 1 / 1` rather than `1 / 0`.
- The change assumes every paginated playground endpoint returns a `total` field; `data.get("total", 0)` falls back to `0` (and therefore `1` page) if one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
