### PR TITLE
feat(playground): use API total field to display total pages in pagination

### DIFF
--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import math
 
 import httpx
 import reflex as rx
@@ -79,7 +80,7 @@ class KeysState(EntityState):
                     if key["name"] not in ["_system_playground_key", "_system_search_tool"]:
                         self.entities.append(self._format_key(key))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -222,18 +223,22 @@ class KeysState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created"]
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_order_by(self, value: str):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -243,7 +248,6 @@ class KeysState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -258,7 +262,7 @@ class KeysState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():

--- a/playground/app/features/organizations/state.py
+++ b/playground/app/features/organizations/state.py
@@ -1,3 +1,5 @@
+import math
+
 import httpx
 import reflex as rx
 
@@ -63,7 +65,7 @@ class OrganizationsState(EntityState):
                 for organization in data.get("data", []):
                     self.entities.append(self._format_organization(organization))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -229,18 +231,22 @@ class OrganizationsState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created", "updated"]
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_order_by(self, value: str):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -250,7 +256,6 @@ class OrganizationsState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -265,7 +270,7 @@ class OrganizationsState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -1,3 +1,5 @@
+import math
+
 import httpx
 import pycountry
 import reflex as rx
@@ -138,6 +140,7 @@ class ProvidersState(EntityState):
                 response.raise_for_status()
                 data = response.json()
                 self.entities = []
+                self.total = data.get("total", 0)
 
                 for provider in data.get("data", []):
                     if provider["user_id"] not in self.provider_owners:
@@ -171,7 +174,6 @@ class ProvidersState(EntityState):
 
                     self.entities.append(self._format_provider(provider))
 
-            self.has_more_page = len(self.entities) == self.per_page
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -370,18 +372,22 @@ class ProvidersState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "model_name", "created"]
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_order_by(self, value: str):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -391,7 +397,6 @@ class ProvidersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -406,7 +411,7 @@ class ProvidersState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():
@@ -418,7 +423,6 @@ class ProvidersState(EntityState):
     async def set_filter_router(self, value: str):
         self.filter_router_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import math
 
 import httpx
 import reflex as rx
@@ -126,7 +127,7 @@ class RolesState(EntityState):
                 for role in data.get("data", []):
                     self.entities.append(self._format_role(role))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -415,18 +416,22 @@ class RolesState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created", "updated"]
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_order_by(self, value: str):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -436,7 +441,6 @@ class RolesState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -451,7 +455,7 @@ class RolesState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -1,3 +1,5 @@
+import math
+
 import httpx
 import reflex as rx
 
@@ -90,6 +92,7 @@ class RoutersState(EntityState):
                 response.raise_for_status()
                 data = response.json()
                 self.entities = []
+                self.total = data.get("total", 0)
 
                 for router in data.get("data", []):
                     if router["user_id"] not in self.router_owners:
@@ -109,7 +112,6 @@ class RoutersState(EntityState):
 
                     self.entities.append(self._format_router(router))
 
-            self.has_more_page = len(self.entities) == self.per_page
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
         finally:
@@ -302,18 +304,22 @@ class RoutersState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created"]
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_order_by(self, value: str):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -323,7 +329,6 @@ class RoutersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -338,7 +343,7 @@ class RoutersState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -1,6 +1,7 @@
 """Usage state for fetching account usage with pagination and filters."""
 
 import datetime as dt
+import math
 from typing import Any
 
 import httpx
@@ -70,7 +71,7 @@ class UsageState(EntityState):
                 data = response.json()
                 self.entities = [self._format_usage(usage) for usage in data.get("data", [])]
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -100,10 +101,15 @@ class UsageState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
+
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
 
     @rx.event
     async def prev_page(self):
@@ -115,7 +121,7 @@ class UsageState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():
@@ -156,7 +162,6 @@ class UsageState(EntityState):
     @rx.event
     async def apply_filters(self):
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -1,3 +1,5 @@
+import math
+
 import httpx
 import reflex as rx
 
@@ -144,7 +146,7 @@ class UsersState(EntityState):
                 for user in data.get("data", []):
                     self.entities.append(self._format_user(user))
 
-            self.has_more_page = len(self.entities) == self.per_page
+            self.total = data.get("total", 0)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -357,6 +359,7 @@ class UsersState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    total: int = 0
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -364,11 +367,14 @@ class UsersState(EntityState):
     order_by_options: list[str] = ["id", "name", "created", "updated"]
     search_email_value: str = ""
 
+    @rx.var
+    def total_pages(self) -> int:
+        return max(1, math.ceil(self.total / self.per_page))
+
     @rx.event
     async def set_search_email(self, value: str):
         self.search_email_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -378,7 +384,6 @@ class UsersState(EntityState):
         """Set order by field and reload."""
         self.order_by_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -388,7 +393,6 @@ class UsersState(EntityState):
         """Set order direction and reload."""
         self.order_direction_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -403,7 +407,7 @@ class UsersState(EntityState):
 
     @rx.event
     async def next_page(self):
-        if self.has_more_page:
+        if self.page < self.total_pages:
             self.page += 1
             yield
             async for _ in self.load_entities():
@@ -416,7 +420,6 @@ class UsersState(EntityState):
     async def set_filter_role(self, value: str):
         self.filter_role_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield
@@ -425,7 +428,6 @@ class UsersState(EntityState):
     async def set_filter_organization(self, value: str):
         self.filter_organization_value = value
         self.page = 1
-        self.has_more_page = False
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/shared/components/lists.py
+++ b/playground/app/shared/components/lists.py
@@ -76,12 +76,12 @@ def entity_pagination(state: rx.State) -> rx.Component:
             disabled=state.page <= 1,
         ),
         rx.text(
-            state.page.to(str),
+            f"Page {state.page} / {state.total_pages}",
         ),
         rx.button(
             "Next",
             on_click=state.next_page,
-            disabled=~state.has_more_page,
+            disabled=state.page >= state.total_pages,
         ),
         spacing=SPACING_MEDIUM,
         align="center",

--- a/playground/app/shared/components/pagination.py
+++ b/playground/app/shared/components/pagination.py
@@ -14,12 +14,12 @@ def pagination(state: Any) -> rx.Component:
             disabled=state.page <= 1,
         ),
         rx.text(
-            state.page.to(str),
+            f"Page {state.page} / {state.total_pages}",
         ),
         rx.button(
             "Next",
             on_click=state.next_page,
-            disabled=~state.has_more_page,
+            disabled=state.page >= state.total_pages,
         ),
         spacing=SPACING_MEDIUM,
         align="center",

--- a/playground/app/shared/states/entity_state.py
+++ b/playground/app/shared/states/entity_state.py
@@ -93,7 +93,6 @@ class EntityState(AuthState):
     ############################################################
     # Pagination
     ############################################################
-    has_more_page: bool = False
 
     @abstractmethod
     async def set_order_by(self, value: str):


### PR DESCRIPTION
Closes [#758](https://github.com/etalab-ia/OpenGateLLM/issues/758#issue-4001430454)

## Overview

Pagination relied on `len(entities) == per_page` to guess whether another page existed, so the last page was only discovered by navigating into an empty one, and a list whose size was an exact multiple of per_page always offered a dead "Next".

Each entity state now reads the `total` field returned by the API and exposes a `total_pages` computed var. Pagination controls display "Page X / Y" and disable "Next" on the last known page.

*Please precise the issue that you are resolving and provide a summarized description of what was done in this PR. Then provide the Definition of Done (DoD) criteria that apply to this PR:*

//

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

*Before requesting a review, please take a moment to confirm that the following aspects have been considered and addressed. This section helps ensure the PR is ready for review, safe to merge, and deployable. If any items are left unchecked, please add a brief explanation for context.*

- [ ] Updated or added documentation
- [ ] Updated or added unit tests
- [ ] Updated or added integration tests
- [ ] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks


**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally


## Additional Notes

see comment below