### PR TITLE
refacto: rename GetModelUseCase and GetRoleUseCase to GetOne*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,18 +63,18 @@ Read existing code for the same resource (or the closest pattern above) before w
 
 | Kind | Pattern | Example |
 |------|---------|---------|
-| Use case file | `_<verb><noun>usecase.py` | `_getrolesusecase.py` |
-| Use case class | `<Verb><Noun>UseCase` | `GetRolesUseCase` |
-| Command | `<Verb><Noun>Command` | `GetRolesCommand` |
-| Success | `<Verb><Noun>UseCaseSuccess` | `GetRolesUseCaseSuccess` |
+| Use case file | `_<verb><noun>usecase.py` | `_getrolesusecase.py`, `_getoneroleusecase.py` |
+| Use case class | `<Verb><Noun>UseCase` | `GetRolesUseCase`, `GetOneRoleUseCase` |
+| Command | `<Verb><Noun>Command` | `GetRolesCommand`, `GetOneRoleCommand` |
+| Success | `<Verb><Noun>UseCaseSuccess` | `GetRolesUseCaseSuccess`, `GetOneRoleUseCaseSuccess` |
 | Domain error | `<Noun><Problem>Error` | `RoleNotFoundError` |
 | HTTP exception | `<Noun><Problem>HTTPException` | `RoleNotFoundHTTPException` |
 | Request body | `<Verb><Noun>Body` | `CreateRoleBody` |
 | Response | `<Noun>Response` / `<Noun>sResponse` | `RoleResponse`, `RolesResponse` |
-| DI factory | `<verb>_<noun>_use_case_factory` | `get_roles_use_case_factory` |
+| DI factory | `<verb>_<noun>_use_case_factory` | `get_roles_use_case_factory`, `get_one_role_use_case_factory` |
 | Entity unit tests | `api/tests/unit/domain/<domain>/test_<domain>entities.py` | `test_ocrentities.py`, `test_userentities.py` |
 
-Verbs: `Create`, `Update`, `Delete`, `Get` (single), `Get<Plural>` (list), `GetOne` (disambiguation).
+Verbs: `Create`, `Update`, `Delete`, `GetOne` (single / get-by-id), `Get<Plural>` (list). When a resource has both a list and a get-by-id use case, the single-resource name is `GetOne<Noun>` — never `Get<Noun>` (`GetRoleUseCase` → `GetOneRoleUseCase`, `GetModelUseCase` → `GetOneModelUseCase`). Pair them: `GetRolesUseCase` + `GetOneRoleUseCase`, `GetModelsUseCase` + `GetOneModelUseCase`.
 
 The domain and API term for an API credential is **key** (`Key`, `CreateKeyResponse`, `/admin/keys`). Do not introduce `token` for that resource.
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -49,14 +49,14 @@ from api.use_cases.admin.providers import (
     GetProvidersUseCase,
     UpdateProviderUseCase,
 )
-from api.use_cases.admin.roles import CreateRoleUseCase, DeleteRoleUseCase, GetRolesUseCase, GetRoleUseCase, UpdateRoleUseCase
+from api.use_cases.admin.roles import CreateRoleUseCase, DeleteRoleUseCase, GetOneRoleUseCase, GetRolesUseCase, UpdateRoleUseCase
 from api.use_cases.admin.routers import CreateRouterUseCase, DeleteRouterUseCase, GetOneRouterUseCase, GetRoutersUseCase, UpdateRouterUseCase
 from api.use_cases.admin.users import CreateUserUseCase, DeleteUserUseCase, GetOneUserUseCase, GetUsersUseCase, UpdateUserUseCase
 from api.use_cases.audio import CreateAudioTranscriptionsUseCase
 from api.use_cases.auth import AuthLoginUseCase, AuthSsoLoginUseCase
 from api.use_cases.embeddings import CreateEmbeddingsUseCase
 from api.use_cases.health import GetHealthModelsUseCase
-from api.use_cases.models import GetModelsUseCase, GetModelUseCase
+from api.use_cases.models import GetModelsUseCase, GetOneModelUseCase
 from api.use_cases.ocr import CreateOCRUseCase
 from api.use_cases.reranks import CreateRerankUseCase
 from api.use_cases.services import ProviderCapabilitiesProbe
@@ -299,8 +299,8 @@ def get_models_use_case_factory(postgres_session: AsyncSession = Depends(get_pos
     return GetModelsUseCase(router_repository=_router_repository(postgres_session))
 
 
-def get_model_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetModelUseCase:
-    return GetModelUseCase(router_repository=_router_repository(postgres_session))
+def get_one_model_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetOneModelUseCase:
+    return GetOneModelUseCase(router_repository=_router_repository(postgres_session))
 
 
 # ocr use cases
@@ -399,8 +399,8 @@ def get_roles_use_case_factory(postgres_session: AsyncSession = Depends(get_post
     )
 
 
-def get_role_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetRoleUseCase:
-    return GetRoleUseCase(
+def get_one_role_use_case_factory(postgres_session: AsyncSession = Depends(get_postgres_session)) -> GetOneRoleUseCase:
+    return GetOneRoleUseCase(
         role_repository=_role_repository(postgres_session),
     )
 

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -6,7 +6,7 @@ from fastapi import Body, Depends, Path, Query, Security
 from api.dependencies import (
     create_role_use_case_factory,
     delete_role_use_case_factory,
-    get_role_use_case_factory,
+    get_one_role_use_case_factory,
     get_roles_use_case_factory,
     update_role_use_case_factory,
 )
@@ -33,12 +33,12 @@ from api.use_cases.admin.roles import (
     DeleteRoleCommand,
     DeleteRoleUseCase,
     DeleteRoleUseCaseSuccess,
-    GetRoleCommand,
+    GetOneRoleCommand,
+    GetOneRoleUseCase,
+    GetOneRoleUseCaseSuccess,
     GetRolesCommand,
     GetRolesUseCase,
     GetRolesUseCaseSuccess,
-    GetRoleUseCase,
-    GetRoleUseCaseSuccess,
     UpdateRoleCommand,
     UpdateRoleUseCase,
     UpdateRoleUseCaseSuccess,
@@ -170,12 +170,12 @@ async def get_roles(
 )
 async def get_role(
     role_id: int = Path(description="The ID of the role to get."),
-    get_role_use_case: GetRoleUseCase = Depends(get_role_use_case_factory),
+    get_one_role_use_case: GetOneRoleUseCase = Depends(get_one_role_use_case_factory),
     request_context: ContextVar[RequestContext] = Depends(get_request_context),
 ) -> RoleResponse:
-    command = GetRoleCommand(role_id=role_id)
+    command = GetOneRoleCommand(role_id=role_id)
     try:
-        result = await get_role_use_case.execute(command)
+        result = await get_one_role_use_case.execute(command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing get_role use case",
@@ -188,7 +188,7 @@ async def get_role(
         raise InternalServerHTTPException()
 
     match result:
-        case GetRoleUseCaseSuccess(role=role):
+        case GetOneRoleUseCaseSuccess(role=role):
             return RoleResponse.model_validate(role, from_attributes=True)
         case RoleNotFoundError(id=role_id):
             raise RoleNotFoundHTTPException(role_id)

--- a/api/infrastructure/fastapi/endpoints/models.py
+++ b/api/infrastructure/fastapi/endpoints/models.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter, Depends, Path, Security
 from fastapi.responses import JSONResponse
 
-from api.dependencies import get_model_use_case_factory, get_models_use_case_factory
+from api.dependencies import get_models_use_case_factory, get_one_model_use_case_factory
 from api.domain.model.errors import ModelNotFoundError
 from api.infrastructure.fastapi import RequestContext
 from api.infrastructure.fastapi.accesscontroller import AccessController
@@ -11,7 +11,14 @@ from api.infrastructure.fastapi.dependencies import get_request_context
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.exceptions import InternalServerHTTPException, ModelNotFoundHTTPException
 from api.infrastructure.fastapi.schemas.models import Model, ModelsResponse
-from api.use_cases.models import GetModelCommand, GetModelsCommand, GetModelsUseCase, GetModelsUseCaseSucess, GetModelUseCase, GetModelUseCaseSucess
+from api.use_cases.models import (
+    GetModelsCommand,
+    GetModelsUseCase,
+    GetModelsUseCaseSucess,
+    GetOneModelCommand,
+    GetOneModelUseCase,
+    GetOneModelUseCaseSuccess,
+)
 from api.utils.variables import EndpointRoute, RouterName
 
 logger = logging.getLogger(__name__)
@@ -60,15 +67,15 @@ async def get_models(
 )
 async def get_model(
     model: str = Path(description="The name of the model to get."),
-    get_model_use_case: GetModelUseCase = Depends(get_model_use_case_factory),
+    get_one_model_use_case: GetOneModelUseCase = Depends(get_one_model_use_case_factory),
     request_context: RequestContext = Depends(get_request_context),
 ) -> JSONResponse:
     """
     Get a model by name and provide basic information.
     """
-    command = GetModelCommand(authenticated_user=request_context.get().user, name=model)
+    command = GetOneModelCommand(authenticated_user=request_context.get().user, name=model)
     try:
-        result = await get_model_use_case.execute(command=command)
+        result = await get_one_model_use_case.execute(command=command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing get_model use case",
@@ -81,7 +88,7 @@ async def get_model(
         raise InternalServerHTTPException()
 
     match result:
-        case GetModelUseCaseSucess(model):
+        case GetOneModelUseCaseSuccess(model):
             return JSONResponse(content=Model.model_validate(model, from_attributes=True).model_dump(), status_code=200)
         case ModelNotFoundError(name):
             raise ModelNotFoundHTTPException(name=name)

--- a/api/tests/integration/endpoints/admin/roles/test_get_role.py
+++ b/api/tests/integration/endpoints/admin/roles/test_get_role.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 import pytest
 import pytest_asyncio
 
-from api.dependencies import get_role_use_case_factory
+from api.dependencies import get_one_role_use_case_factory
 from api.domain.role.entities import LimitType, PermissionType
 from api.domain.role.errors import RoleNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
@@ -50,7 +50,7 @@ class TestGetRole:
     async def test_error_maps_to_correct_http_status(self, client: AsyncClient, app, use_case_result, expected_status, expected_detail):
         mock_use_case = AsyncMock()
         mock_use_case.execute.return_value = use_case_result
-        app.dependency_overrides[get_role_use_case_factory] = lambda: mock_use_case
+        app.dependency_overrides[get_one_role_use_case_factory] = lambda: mock_use_case
 
         response = await client.get(
             url=f"{URL}/999",

--- a/api/tests/integration/endpoints/test_models.py
+++ b/api/tests/integration/endpoints/test_models.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 import pytest
 import pytest_asyncio
 
-from api.dependencies import get_model_use_case_factory
+from api.dependencies import get_one_model_use_case_factory
 from api.domain.model.errors import ModelNotFoundError
 from api.schemas.models import ModelType
 from api.tests.helpers import INVALID_API_KEY, create_key
@@ -136,7 +136,7 @@ class TestGetModel:
     async def test_error_maps_to_correct_http_status(self, client: AsyncClient, app, use_case_result, expected_status, expected_detail):
         mock_use_case = AsyncMock()
         mock_use_case.execute.return_value = use_case_result
-        app.dependency_overrides[get_model_use_case_factory] = lambda: mock_use_case
+        app.dependency_overrides[get_one_model_use_case_factory] = lambda: mock_use_case
 
         response = await client.get(
             url=f"{URL}/non_existent_model",

--- a/api/tests/unit/use_case/admin/roles/test_getoneroleusecase.py
+++ b/api/tests/unit/use_case/admin/roles/test_getoneroleusecase.py
@@ -4,7 +4,7 @@ import pytest
 
 from api.domain.role.errors import RoleNotFoundError
 from api.tests.unit.use_case.factories import RoleFactory
-from api.use_cases.admin.roles import GetRoleCommand, GetRoleUseCase, GetRoleUseCaseSuccess
+from api.use_cases.admin.roles import GetOneRoleCommand, GetOneRoleUseCase, GetOneRoleUseCaseSuccess
 
 
 @pytest.fixture
@@ -14,22 +14,22 @@ def role_repository():
 
 @pytest.fixture
 def use_case(role_repository):
-    return GetRoleUseCase(role_repository=role_repository)
+    return GetOneRoleUseCase(role_repository=role_repository)
 
 
-class TestGetRoleUseCase:
+class TestGetOneRoleUseCase:
     @pytest.mark.asyncio
     async def test_should_return_role_when_user_is_admin_and_role_exists(self, use_case, role_repository):
         # Arrange
         role = RoleFactory(id=42)
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = role
-        command = GetRoleCommand(role_id=42)
+        command = GetOneRoleCommand(role_id=42)
 
         # Act
         result = await use_case.execute(command)
 
         # Assert
-        assert isinstance(result, GetRoleUseCaseSuccess)
+        assert isinstance(result, GetOneRoleUseCaseSuccess)
         assert result.role == role
         role_repository.get_role_with_permissions_and_limits_by_id.assert_awaited_once_with(role_id=42)
 
@@ -37,7 +37,7 @@ class TestGetRoleUseCase:
     async def test_should_return_role_not_found_error_when_role_does_not_exist(self, use_case, role_repository):
         # Arrange
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = RoleNotFoundError(id=99)
-        command = GetRoleCommand(role_id=99)
+        command = GetOneRoleCommand(role_id=99)
 
         # Act
         result = await use_case.execute(command)

--- a/api/tests/unit/use_case/models/test_getonemodelusecase.py
+++ b/api/tests/unit/use_case/models/test_getonemodelusecase.py
@@ -8,7 +8,7 @@ from api.domain.model.errors import ModelNotFoundError
 from api.domain.role.entities import Limit, LimitType
 from api.domain.router.errors import RouterNotFoundError
 from api.tests.unit.use_case.factories import AuthenticatedUserFactory, RouterFactory
-from api.use_cases.models import GetModelCommand, GetModelUseCase, GetModelUseCaseSucess
+from api.use_cases.models import GetOneModelCommand, GetOneModelUseCase, GetOneModelUseCaseSuccess
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def router_repository():
 
 @pytest.fixture
 def use_case(router_repository):
-    return GetModelUseCase(router_repository=router_repository)
+    return GetOneModelUseCase(router_repository=router_repository)
 
 
 @pytest.fixture
@@ -42,12 +42,12 @@ def router():
 
 @pytest.fixture
 def default_command():
-    return GetModelCommand(
+    return GetOneModelCommand(
         authenticated_user=AuthenticatedUserFactory(id=1, limits=[Limit(router_id=1, value=100, type=LimitType.RPM)]), name="gpt-4"
     )
 
 
-class TestGetModelUseCase:
+class TestGetOneModelUseCase:
     @pytest.mark.asyncio
     async def test_should_return_a_list_with_one_model_when_a_name_is_given(self, router_repository, router, use_case, default_command):
         # Arrange
@@ -58,7 +58,7 @@ class TestGetModelUseCase:
         result = await use_case.execute(command=default_command)
 
         # Assert
-        assert isinstance(result, GetModelUseCaseSucess)
+        assert isinstance(result, GetOneModelUseCaseSuccess)
         assert result.model.id == "gpt-4"
         router_repository.get_router_by_name_or_alias.assert_awaited_once_with(name_or_alias="gpt-4")
 
@@ -73,7 +73,7 @@ class TestGetModelUseCase:
         result = await use_case.execute(command=default_command)
 
         # Assert
-        assert isinstance(result, GetModelUseCaseSucess)
+        assert isinstance(result, GetOneModelUseCaseSuccess)
         assert result.model.id == "gpt-4"
         assert "gpt-4-turbo" in result.model.aliases
         router_repository.get_router_by_name_or_alias.assert_awaited_once_with(name_or_alias="gpt-4-turbo")
@@ -149,5 +149,5 @@ class TestGetModelUseCase:
         result = await use_case.execute(command=default_command)
 
         # Assert
-        assert isinstance(result, GetModelUseCaseSucess)
+        assert isinstance(result, GetOneModelUseCaseSuccess)
         assert result.model.id == "gpt-4"

--- a/api/use_cases/admin/roles/__init__.py
+++ b/api/use_cases/admin/roles/__init__.py
@@ -1,7 +1,7 @@
 from ._createroleusecase import CreateRoleCommand, CreateRoleUseCase, CreateRoleUseCaseSuccess
 from ._deleteroleusecase import DeleteRoleCommand, DeleteRoleUseCase, DeleteRoleUseCaseSuccess
+from ._getoneroleusecase import GetOneRoleCommand, GetOneRoleUseCase, GetOneRoleUseCaseSuccess
 from ._getrolesusecase import GetRolesCommand, GetRolesUseCase, GetRolesUseCaseSuccess
-from ._getroleusecase import GetRoleCommand, GetRoleUseCase, GetRoleUseCaseSuccess
 from ._updateroleusecase import UpdateRoleCommand, UpdateRoleUseCase, UpdateRoleUseCaseSuccess
 
 __all__ = [
@@ -11,12 +11,12 @@ __all__ = [
     "UpdateRoleCommand",
     "UpdateRoleUseCase",
     "UpdateRoleUseCaseSuccess",
+    "GetOneRoleCommand",
+    "GetOneRoleUseCase",
+    "GetOneRoleUseCaseSuccess",
     "GetRolesCommand",
     "GetRolesUseCase",
     "GetRolesUseCaseSuccess",
-    "GetRoleCommand",
-    "GetRoleUseCase",
-    "GetRoleUseCaseSuccess",
     "DeleteRoleCommand",
     "DeleteRoleUseCase",
     "DeleteRoleUseCaseSuccess",

--- a/api/use_cases/admin/roles/_getoneroleusecase.py
+++ b/api/use_cases/admin/roles/_getoneroleusecase.py
@@ -6,26 +6,26 @@ from api.domain.role.errors import RoleNotFoundError
 
 
 @dataclass
-class GetRoleCommand:
+class GetOneRoleCommand:
     role_id: int
 
 
 @dataclass
-class GetRoleUseCaseSuccess:
+class GetOneRoleUseCaseSuccess:
     role: Role
 
 
-type GetRoleUseCaseResult = GetRoleUseCaseSuccess | RoleNotFoundError
+type GetOneRoleUseCaseResult = GetOneRoleUseCaseSuccess | RoleNotFoundError
 
 
-class GetRoleUseCase:
+class GetOneRoleUseCase:
     def __init__(self, role_repository: RoleRepository):
         self.role_repository = role_repository
 
-    async def execute(self, command: GetRoleCommand) -> GetRoleUseCaseResult:
+    async def execute(self, command: GetOneRoleCommand) -> GetOneRoleUseCaseResult:
         result = await self.role_repository.get_role_with_permissions_and_limits_by_id(role_id=command.role_id)
         match result:
             case Role() as role:
-                return GetRoleUseCaseSuccess(role=role)
+                return GetOneRoleUseCaseSuccess(role=role)
             case RoleNotFoundError():
                 return RoleNotFoundError(id=command.role_id)

--- a/api/use_cases/models/__init__.py
+++ b/api/use_cases/models/__init__.py
@@ -1,6 +1,6 @@
 from ._bootstrapmodelsusecase import BootstrapModelsUseCase, BootstrapModelsUseCaseSkipped, BootstrapModelsUseCaseSuccess
 from ._getmodelsusecase import GetModelsCommand, GetModelsUseCase, GetModelsUseCaseSucess
-from ._getmodelusecase import GetModelCommand, GetModelUseCase, GetModelUseCaseSucess
+from ._getonemodelusecase import GetOneModelCommand, GetOneModelUseCase, GetOneModelUseCaseSuccess
 
 __all__ = [
     "BootstrapModelsUseCase",
@@ -9,7 +9,7 @@ __all__ = [
     "GetModelsCommand",
     "GetModelsUseCase",
     "GetModelsUseCaseSucess",
-    "GetModelCommand",
-    "GetModelUseCase",
-    "GetModelUseCaseSucess",
+    "GetOneModelCommand",
+    "GetOneModelUseCase",
+    "GetOneModelUseCaseSuccess",
 ]

--- a/api/use_cases/models/_getonemodelusecase.py
+++ b/api/use_cases/models/_getonemodelusecase.py
@@ -9,24 +9,24 @@ from api.domain.user.views import AuthenticatedUserView
 
 
 @dataclass
-class GetModelUseCaseSucess:
+class GetOneModelUseCaseSuccess:
     model: Model
 
 
 @dataclass
-class GetModelCommand:
+class GetOneModelCommand:
     authenticated_user: AuthenticatedUserView
     name: str
 
 
-type GetModelUseCaseResult = GetModelUseCaseSucess | ModelNotFoundError
+type GetOneModelUseCaseResult = GetOneModelUseCaseSuccess | ModelNotFoundError
 
 
-class GetModelUseCase:
+class GetOneModelUseCase:
     def __init__(self, router_repository: RouterRepository):
         self.router_repository = router_repository
 
-    async def execute(self, command: GetModelCommand) -> GetModelUseCaseResult:
+    async def execute(self, command: GetOneModelCommand) -> GetOneModelUseCaseResult:
         result = await self.router_repository.get_router_by_name_or_alias(name_or_alias=command.name)
         match result:
             case Router() as router:
@@ -48,4 +48,4 @@ class GetModelUseCase:
             costs=ModelCosts(prompt_tokens=router.cost_prompt_tokens, completion_tokens=router.cost_completion_tokens),
         )
 
-        return GetModelUseCaseSucess(model=model)
+        return GetOneModelUseCaseSuccess(model=model)


### PR DESCRIPTION
Closes #884

## Overview

Resolves #884. Rename the get-by-id model and role use cases to the `GetOne*` convention already used by routers, users, keys, and providers, and document that rule in `AGENTS.md`.

- `GetModelUseCase` → `GetOneModelUseCase` (command, success, factory, and files)
- `GetRoleUseCase` → `GetOneRoleUseCase` (command, success, factory, and files)
- `GetModelUseCaseSucess` renamed to `GetOneModelUseCaseSuccess` (typo fixed)

- [x] Get-by-id model use case is `GetOneModelUseCase`
- [x] Get-by-id role use case is `GetOneRoleUseCase`
- [x] Call sites, DI factories, and tests follow the new names
- [x] `AGENTS.md` states that get-by-id uses `GetOne<Noun>`, not `Get<Noun>`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [x] Updated or added documentation
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**

- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

> `api/sql/models.py` was not modified.

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified


Made with [Cursor](https://cursor.com)