### PR TITLE
refacto(endpoints): inject get_authenticated_user when only the user is needed

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "59.23%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "59.21%", "color": "red"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ async def get_roles(
     sort_by: SortField = Query(default=SortField.ID, ...),
     sort_order: SortOrder = Query(default=SortOrder.ASC, ...),
     get_roles_use_case: GetRolesUseCase = Depends(get_roles_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RolesResponse:
     command = GetRolesCommand(offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
     try:
@@ -321,6 +321,7 @@ async def get_roles(
 ```
 
 - Auth: `AccessController` from `api.infrastructure.fastapi` (`only_admin=True` for admin routes)
+- Auth user: `authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user)` when only the user is needed. Keep `get_request_context` only when the full `RequestContext` is required.
 - Sort query params: `sort_by` / `sort_order`
 - Document errors: `responses=get_documentation_responses([...])`
 - `case RoleNotFoundError(id=role_id, name=name)` **captures** `None`; it does not require an id. Pass both through to the HTTP exception (which already has a generic `"Role not found."` fallback). Map the fields the use case actually returns (`id=` from FK failures, not `name=` unless that path exists).
@@ -356,6 +357,7 @@ Mirror an existing test for the same verb (`test_get_roles.py`, `test_create_key
 
 - File names: entity tests **must** be `test_<domain>entities.py` (`test_ocrentities.py`, `test_userentities.py`) — not `test_<entity>.py`
 - Test names: unit `test_should_<behavior>` ; endpoint `test_happy_path`, `test_error_maps_to_correct_http_status`, `test_rejects_non_admin_user` ; postgres `test_returns_*` / `test_creates_*`
+- Mocks: every mock object and mock fixture is prefixed with `mock_` (`mock_use_case`, `mock_authenticated_user`)
 - Comments: `# Arrange` / `# Act` / `# Assert` (same as `test_createuserusecase.py`)
 - Async integration: `@pytest.mark.asyncio(loop_scope="session")` (including HTTP adapters)
 - Postgres: `repository` fixture from `db_session` — do not construct the repo inside each test
@@ -378,7 +380,7 @@ Entity helpers used by the use case belong in domain unit tests, not extra use-c
 
 ```python
 @pytest.fixture
-def model_tokenizer():
+def mock_model_tokenizer():
     tokenizer = MagicMock()
     tokenizer.compute_tokens.side_effect = lambda texts: len(texts)
     return tokenizer

--- a/api/infrastructure/fastapi/endpoints/admin/keys.py
+++ b/api/infrastructure/fastapi/endpoints/admin/keys.py
@@ -1,4 +1,3 @@
-from contextvars import ContextVar
 import logging
 
 from fastapi import Body, Depends, Path, Query, Security
@@ -7,8 +6,9 @@ from api.dependencies import create_key_use_case_factory, get_keys_use_case_fact
 from api.domain import SortField, SortOrder
 from api.domain.key.errors import KeyAlreadyExistsError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.admin import router
 from api.infrastructure.fastapi.endpoints.exceptions import (
@@ -30,7 +30,6 @@ from api.use_cases.admin.keys import (
     GetOneKeyUseCase,
     GetOneKeyUseCaseSuccess,
 )
-from api.utils.dependencies import get_request_context
 from api.utils.variables import EndpointRoute
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ logger = logging.getLogger(__name__)
 async def create_key(
     body: CreateKeyBody = Body(description="The key creation request."),
     create_key_use_case: CreateKeyUseCase = Depends(create_key_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeyResponse:
     """
     Create a new key for a user.
@@ -58,7 +57,7 @@ async def create_key(
         logger.exception(
             "Unexpected error while executing create_key use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "error_type": type(e).__name__,
             },
         )
@@ -82,7 +81,7 @@ async def create_key(
 async def get_key(
     key_id: int = Path(description="The ID of the key to get."),
     get_one_key_use_case: GetOneKeyUseCase = Depends(get_one_key_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeyResponse:
     command = GetOneKeyCommand(key_id=key_id)
     try:
@@ -91,7 +90,7 @@ async def get_key(
         logger.exception(
             "Unexpected error while executing get_key use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "key_id": key_id,
                 "error_type": type(e).__name__,
             },
@@ -118,7 +117,7 @@ async def get_keys(
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
     command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
     try:
@@ -127,7 +126,7 @@ async def get_keys(
         logger.exception(
             "Unexpected error while executing get_keys use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "offset": command.offset,
                 "limit": command.limit,
                 "sort_by": command.sort_by,

--- a/api/infrastructure/fastapi/endpoints/admin/providers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/providers.py
@@ -1,4 +1,3 @@
-from contextvars import ContextVar
 import logging
 
 from fastapi import Body, Depends, Path, Query, Security
@@ -21,9 +20,9 @@ from api.domain.provider.errors import (
     ProviderNotReachableError,
 )
 from api.domain.router.errors import RouterNotFoundError
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.admin import router
 from api.infrastructure.fastapi.endpoints.exceptions import (
@@ -89,11 +88,11 @@ logger = logging.getLogger(__name__)
 async def create_provider(
     body: CreateProviderBody,
     create_provider_use_case: CreateProviderUseCase = Depends(create_provider_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> CreateProviderResponse:
     try:
         command = CreateProviderCommand(
-            user_id=request_context.get().user.id,
+            user_id=authenticated_user.id,
             router_id=body.router_id,
             provider_type=body.type,
             url=body.url,
@@ -112,7 +111,7 @@ async def create_provider(
         logger.exception(
             "Unexpected error while executing create_provider use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "provider_router_id": body.router_id,
                 "provider_url": body.url,
                 "provider_model_name": body.model_name,
@@ -159,7 +158,7 @@ async def create_provider(
 async def delete_provider(
     provider_id: int = Path(description="The ID of the provider to delete."),
     delete_provider_use_case: DeleteProviderUseCase = Depends(delete_provider_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> ProviderResponse:
     command = DeleteProviderCommand(provider_id=provider_id)
     try:
@@ -168,7 +167,7 @@ async def delete_provider(
         logger.exception(
             "Unexpected error while executing delete_provider use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "provider_id": command.provider_id,
                 "error_type": type(e).__name__,
             },
@@ -203,7 +202,7 @@ async def update_provider(
     provider_id: int = Path(description="The ID of the provider to update."),
     body: UpdateProviderBody = Body(description="The provider update request."),
     update_provider_use_case: UpdateProviderUseCase = Depends(update_provider_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> ProviderResponse:
     command = UpdateProviderCommand(
         provider_id=provider_id,
@@ -221,7 +220,7 @@ async def update_provider(
         logger.exception(
             "Unexpected error while executing update_provider use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "provider_router_id": body.router_id,
                 "error_type": type(e).__name__,
             },
@@ -260,7 +259,7 @@ async def update_provider(
 async def get_provider(
     provider_id: int = Path(description="The ID of the provider to get."),
     get_one_provider_use_case: GetOneProviderUseCase = Depends(get_one_provider_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> ProviderResponse:
     command = GetOneProviderCommand(provider_id=provider_id)
     try:
@@ -269,7 +268,7 @@ async def get_provider(
         logger.exception(
             "Unexpected error while executing get_one_provider use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "provider_id": command.provider_id,
                 "error_type": type(e).__name__,
             },
@@ -296,7 +295,7 @@ async def get_providers(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of providers to return."),
     sort_by: ProviderSortField = Query(default=ProviderSortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
     get_providers_use_case: GetProvidersUseCase = Depends(get_providers_use_case_factory),
 ) -> ProvidersResponse:
     command = GetProvidersCommand(router_id=router_id, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
@@ -306,7 +305,7 @@ async def get_providers(
         logger.exception(
             "Unexpected error while executing get_providers use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "router_id": router_id,
                 "offset": command.offset,
                 "limit": command.limit,

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -1,4 +1,3 @@
-from contextvars import ContextVar
 import logging
 
 from fastapi import Body, Depends, Path, Query, Security
@@ -13,9 +12,9 @@ from api.dependencies import (
 from api.domain import SortField, SortOrder
 from api.domain.role.entities import Limit
 from api.domain.role.errors import RoleAlreadyExistsError, RoleHasUsersError, RoleNotFoundError
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.admin import router
 from api.infrastructure.fastapi.endpoints.exceptions import (
@@ -57,7 +56,7 @@ logger = logging.getLogger(__name__)
 async def create_role(
     body: CreateRoleBody = Body(description="The role creation request."),
     create_role_use_case: CreateRoleUseCase = Depends(create_role_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoleResponse:
     try:
         command = CreateRoleCommand(name=body.name, permissions=body.permissions, limits=body.limits)
@@ -66,7 +65,7 @@ async def create_role(
         logger.exception(
             "Unexpected error while executing create_role use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "role_name": body.name,
                 "error_type": type(e).__name__,
             },
@@ -90,7 +89,7 @@ async def update_role(
     role_id: int = Path(description="The ID of the role to update."),
     body: CreateRoleBody = Body(description="The role update request."),
     update_role_use_case: UpdateRoleUseCase = Depends(update_role_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoleResponse:
     command = UpdateRoleCommand(
         role_id=role_id,
@@ -106,7 +105,7 @@ async def update_role(
         logger.exception(
             "Unexpected error while executing update_role use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "role_name": body.name,
                 "error_type": type(e).__name__,
             },
@@ -134,7 +133,7 @@ async def get_roles(
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
     get_roles_use_case: GetRolesUseCase = Depends(get_roles_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RolesResponse:
     try:
         command = GetRolesCommand(offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
@@ -143,7 +142,7 @@ async def get_roles(
         logger.exception(
             "Unexpected error while executing get_roles use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "offset": command.offset,
                 "limit": command.limit,
                 "sort_by": command.sort_by,
@@ -171,7 +170,7 @@ async def get_roles(
 async def get_role(
     role_id: int = Path(description="The ID of the role to get."),
     get_role_use_case: GetRoleUseCase = Depends(get_role_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoleResponse:
     command = GetRoleCommand(role_id=role_id)
     try:
@@ -180,7 +179,7 @@ async def get_role(
         logger.exception(
             "Unexpected error while executing get_role use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "role_id": role_id,
                 "error_type": type(e).__name__,
             },
@@ -203,7 +202,7 @@ async def get_role(
 async def delete_role(
     role_id: int = Path(description="The ID of the role to delete."),
     delete_role_use_case: DeleteRoleUseCase = Depends(delete_role_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoleResponse:
     try:
         command = DeleteRoleCommand(role_id=role_id)
@@ -212,7 +211,7 @@ async def delete_role(
         logger.exception(
             "Unexpected error while executing delete_role use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "role_id": role_id,
                 "error_type": type(e).__name__,
             },

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -1,4 +1,3 @@
-from contextvars import ContextVar
 import logging
 
 from fastapi import Body, Depends, Path, Query, Security
@@ -12,9 +11,9 @@ from api.dependencies import (
 )
 from api.domain import SortField, SortOrder
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.admin import router
 from api.infrastructure.fastapi.endpoints.exceptions import (
@@ -56,10 +55,10 @@ logger = logging.getLogger(__name__)
 async def create_router(
     body: CreateRouterBody = Body(description="The router creation request."),
     create_router_use_case: CreateRouterUseCase = Depends(create_router_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RouterResponse:
     command = CreateRouterCommand(
-        user_id=request_context.get().user.id,
+        user_id=authenticated_user.id,
         name=body.name,
         router_type=body.router_type,
         aliases=body.aliases,
@@ -73,7 +72,7 @@ async def create_router(
         logger.exception(
             "Unexpected error while executing create_router use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "router_name": body.name,
                 "error_type": type(e).__name__,
             },
@@ -98,7 +97,7 @@ async def create_router(
 async def get_router(
     router_id: int = Path(description="The router ID."),
     get_one_router_use_case: GetOneRouterUseCase = Depends(get_one_router_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RouterResponse:
     command = GetOneRouterCommand(router_id=router_id)
     try:
@@ -107,7 +106,7 @@ async def get_router(
         logger.exception(
             "Unexpected error while executing get_router use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "router_id": command.router_id,
                 "error_type": type(e).__name__,
             },
@@ -132,7 +131,7 @@ async def get_routers(
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
     get_routers_use_case: GetRoutersUseCase = Depends(get_routers_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoutersResponse:
     command = GetRoutersCommand(
         offset=offset,
@@ -146,7 +145,7 @@ async def get_routers(
         logger.exception(
             "Unexpected error while executing get_routers use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "error_type": type(e).__name__,
             },
         )
@@ -170,7 +169,7 @@ async def get_routers(
 async def delete_router(
     router_id: int = Path(description="The ID of the router to delete (router ID, eg. 123)."),
     delete_router_use_case: DeleteRouterUseCase = Depends(delete_router_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RouterResponse:
     command = DeleteRouterCommand(router_id=router_id)
     try:
@@ -179,7 +178,7 @@ async def delete_router(
         logger.exception(
             "Unexpected error while executing delete_router use case",
             extra={
-                "user_id": command.user_id,
+                "authenticated_user_id": authenticated_user.id,
                 "router_id": command.router_id,
                 "error_type": type(e).__name__,
             },
@@ -209,7 +208,7 @@ async def delete_router(
 async def update_router(
     router_id: int = Path(description="The ID of the router to update (router ID, eg. 123)."),
     update_router_use_case: UpdateRouterUseCase = Depends(update_router_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
     body: UpdateRouterBody = Body(description="The router update request."),
 ) -> RouterResponse:
     command = UpdateRouterCommand(
@@ -227,7 +226,7 @@ async def update_router(
         logger.exception(
             "Unexpected error while executing update_router use case",
             extra={
-                "user_id": command.user_id,
+                "authenticated_user_id": authenticated_user.id,
                 "router_id": command.router_id,
                 "error_type": type(e).__name__,
             },

--- a/api/infrastructure/fastapi/endpoints/health.py
+++ b/api/infrastructure/fastapi/endpoints/health.py
@@ -4,9 +4,9 @@ from fastapi import APIRouter, Depends, Security
 from fastapi.responses import JSONResponse
 
 from api.dependencies import get_health_models_use_case_factory
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.exceptions import InternalServerHTTPException
 from api.infrastructure.fastapi.schemas.health import ModelHealthStatus, ModelsHealthResponse
@@ -34,20 +34,20 @@ def get_health() -> JSONResponse:
 )
 async def get_health_models(
     get_health_models_use_case: GetHealthModelsUseCase = Depends(get_health_models_use_case_factory),
-    request_context: RequestContext = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> JSONResponse:
     """
     Get the health of the models.
     """
 
-    command = GetHealthModelsCommand(authenticated_user=request_context.get().user)
+    command = GetHealthModelsCommand(authenticated_user=authenticated_user)
     try:
         result = await get_health_models_use_case.execute(command=command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing get_health_models use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/endpoints/models.py
+++ b/api/infrastructure/fastapi/endpoints/models.py
@@ -5,9 +5,9 @@ from fastapi.responses import JSONResponse
 
 from api.dependencies import get_model_use_case_factory, get_models_use_case_factory
 from api.domain.model.errors import ModelNotFoundError
-from api.infrastructure.fastapi import RequestContext
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.exceptions import InternalServerHTTPException, ModelNotFoundHTTPException
 from api.infrastructure.fastapi.schemas.models import Model, ModelsResponse
@@ -28,19 +28,19 @@ router = APIRouter(prefix="/v1", tags=[RouterName.MODELS.title()])
 )
 async def get_models(
     get_models_use_case: GetModelsUseCase = Depends(get_models_use_case_factory),
-    request_context: RequestContext = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> ModelNotFoundHTTPException | JSONResponse:
     """
     Lists the currently available models and provides basic information.
     """
-    command = GetModelsCommand(authenticated_user=request_context.get().user)
+    command = GetModelsCommand(authenticated_user=authenticated_user)
     try:
         result = await get_models_use_case.execute(command=command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing get_models use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "error_type": type(e).__name__,
             },
         )
@@ -61,19 +61,19 @@ async def get_models(
 async def get_model(
     model: str = Path(description="The name of the model to get."),
     get_model_use_case: GetModelUseCase = Depends(get_model_use_case_factory),
-    request_context: RequestContext = Depends(get_request_context),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> JSONResponse:
     """
     Get a model by name and provide basic information.
     """
-    command = GetModelCommand(authenticated_user=request_context.get().user, name=model)
+    command = GetModelCommand(authenticated_user=authenticated_user, name=model)
     try:
         result = await get_model_use_case.execute(command=command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing get_model use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user.id,
                 "model_name": model,
                 "error_type": type(e).__name__,
             },

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_key.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_key.py
@@ -12,15 +12,13 @@ from api.use_cases.admin.keys import GetOneKeyCommand, GetOneKeyUseCaseSuccess
 
 
 @pytest.fixture
-def mock_request_context():
-    mock_ctx = MagicMock()
-    mock_ctx.get.return_value = MagicMock(user=MagicMock(id=1))
-    return mock_ctx
+def mock_authenticated_user():
+    return MagicMock(id=1)
 
 
 class TestGetKeyEndpoint:
     @pytest.mark.asyncio
-    async def test_should_map_key_to_key_response(self, mock_request_context):
+    async def test_should_map_key_to_key_response(self, mock_authenticated_user):
         key = Key(
             id=1,
             name="my-key",
@@ -32,7 +30,7 @@ class TestGetKeyEndpoint:
         mock_use_case = MagicMock()
         mock_use_case.execute = AsyncMock(return_value=GetOneKeyUseCaseSuccess(key=key))
 
-        result = await get_key(key_id=1, get_one_key_use_case=mock_use_case, request_context=mock_request_context)
+        result = await get_key(key_id=1, get_one_key_use_case=mock_use_case, authenticated_user=mock_authenticated_user)
 
         assert isinstance(result, KeyResponse)
         assert result.id == 1
@@ -41,12 +39,12 @@ class TestGetKeyEndpoint:
         mock_use_case.execute.assert_awaited_once_with(GetOneKeyCommand(key_id=1))
 
     @pytest.mark.asyncio
-    async def test_should_raise_key_not_found_http_exception(self, mock_request_context):
+    async def test_should_raise_key_not_found_http_exception(self, mock_authenticated_user):
         mock_use_case = MagicMock()
         mock_use_case.execute = AsyncMock(return_value=KeyNotFoundError(id=99))
 
         with pytest.raises(KeyNotFoundHTTPException) as exc_info:
-            await get_key(key_id=99, get_one_key_use_case=mock_use_case, request_context=mock_request_context)
+            await get_key(key_id=99, get_one_key_use_case=mock_use_case, authenticated_user=mock_authenticated_user)
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Key 99 not found."

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
@@ -11,15 +11,13 @@ from api.use_cases.admin.keys import GetKeysCommand, GetKeysUseCaseSuccess
 
 
 @pytest.fixture
-def mock_request_context():
-    mock_ctx = MagicMock()
-    mock_ctx.get.return_value = MagicMock(user=MagicMock(id=1))
-    return mock_ctx
+def mock_authenticated_user():
+    return MagicMock(id=1)
 
 
 class TestGetKeysEndpoint:
     @pytest.mark.asyncio
-    async def test_should_map_key_page_to_keys_response(self, mock_request_context):
+    async def test_should_map_key_page_to_keys_response(self, mock_authenticated_user):
         key = Key(
             id=1,
             name="my-key",
@@ -38,7 +36,7 @@ class TestGetKeysEndpoint:
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
             get_keys_use_case=mock_use_case,
-            request_context=mock_request_context,
+            authenticated_user=mock_authenticated_user,
         )
 
         assert isinstance(result, KeysResponse)


### PR DESCRIPTION
## Overview

Resolves [#970](https://github.com/etalab-ia/OpenGateLLM/issues/970). Clean-architecture endpoints that only need the authenticated user now inject `get_authenticated_user` instead of `get_request_context`, matching `admin/users.py`. `get_request_context` is kept where the full `RequestContext` is required (e.g. `AccessController`).

- [x] Endpoints that only use the user inject `authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user)`
- [x] Commands and logs use `authenticated_user` / `authenticated_user.id`
- [x] `AGENTS.md` documents the auth-user dependency and `mock_` prefix for test mocks
- [x] Key endpoint unit tests pass `mock_authenticated_user`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [x] Updated or added documentation
- [x] Updated or added unit tests
- [ ] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

Integration tests still cover these routes over HTTP; only the key endpoint unit tests needed a signature update.

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified


Made with [Cursor](https://cursor.com)