### PR TITLE
refacto(me): POST /v1/me/keys endpoint toward clean architecture

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "59.31%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "59.30%", "color": "red"}

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -289,6 +289,13 @@ def create_key_use_case_factory(key_repository: KeyRepository = Depends(_key_rep
     )
 
 
+def create_me_key_use_case_factory(key_repository: KeyRepository = Depends(_key_repository)) -> CreateKeyUseCase:
+    return CreateKeyUseCase(
+        key_repository=key_repository,
+        key_max_expiration_days=configuration.settings.auth_key_max_expiration_days,
+    )
+
+
 def get_keys_use_case_factory(key_repository: KeyRepository = Depends(_key_repository)) -> GetKeysUseCase:
     return GetKeysUseCase(key_repository=key_repository)
 

--- a/api/endpoints/me/keys.py
+++ b/api/endpoints/me/keys.py
@@ -1,33 +1,13 @@
-from fastapi import Body, Depends, Path, Request, Response, Security
+from fastapi import Depends, Path, Request, Response, Security
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.endpoints.me import router
 from api.helpers._accesscontroller import AccessController
-from api.schemas.me.keys import CreateKey, CreateKeyResponse, Key
+from api.schemas.me.keys import Key
 from api.utils.context import global_context, request_context
 from api.utils.dependencies import get_postgres_session
 from api.utils.variables import EndpointRoute
-
-
-@router.post(path=EndpointRoute.ME_KEYS, dependencies=[Security(dependency=AccessController())], status_code=201, response_model=CreateKeyResponse)
-async def create_key(
-    request: Request,
-    body: CreateKey = Body(description="The token creation request."),
-    postgres_session: AsyncSession = Depends(get_postgres_session),
-) -> JSONResponse:
-    """
-    Create a new API key.
-    """
-
-    token_id, token = await global_context.identity_access_manager.create_token(
-        postgres_session=postgres_session,
-        user_id=request_context.get().user_info.id,
-        name=body.name,
-        expires=body.expires,
-    )
-
-    return JSONResponse(status_code=201, content={"id": token_id, "key": token})
 
 
 @router.delete(path=EndpointRoute.ME_KEYS + "/{key}", dependencies=[Security(dependency=AccessController())], status_code=204)

--- a/api/infrastructure/fastapi/endpoints/me/keys.py
+++ b/api/infrastructure/fastapi/endpoints/me/keys.py
@@ -6,7 +6,9 @@ from api.dependencies import create_me_key_use_case_factory, get_keys_use_case_f
 from api.domain import SortField, SortOrder
 from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError
 from api.domain.user.errors import UserNotFoundError
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
+from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.exceptions import (
     InternalServerHTTPException,
@@ -25,7 +27,6 @@ from api.use_cases.admin.keys import (
     GetKeysUseCase,
     GetKeysUseCaseSuccess,
 )
-from api.utils.dependencies import get_authenticated_user_id
 from api.utils.variables import EndpointRoute
 
 logger = logging.getLogger(__name__)
@@ -40,20 +41,21 @@ logger = logging.getLogger(__name__)
 async def create_key(
     body: CreateKeyBody = Body(description="The key creation request."),
     create_me_key_use_case: CreateKeyUseCase = Depends(create_me_key_use_case_factory),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeyResponse:
     """
     Create a new API key for the authenticated user.
     """
 
-    command = CreateKeyCommand(user_id=authenticated_user_id, name=body.name, expire=body.expires)
+    command = CreateKeyCommand(user_id=authenticated_user.id, name=body.name, expire=body.expires)
     try:
         result = await create_me_key_use_case.execute(command)
     except Exception as e:
         logger.exception(
             "Unexpected error while executing create_me_key use case",
             extra={
-                "authenticated_user_id": authenticated_user_id,
+                "authenticated_user_id": authenticated_user.id,
+                "name": body.name,
                 "error_type": type(e).__name__,
             },
         )
@@ -82,14 +84,14 @@ async def get_keys(
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
     """
     Get all your keys.
     """
 
     command = GetKeysCommand(
-        user_id=authenticated_user_id,
+        user_id=authenticated_user.id,
         offset=offset,
         limit=limit,
         sort_by=sort_by,
@@ -101,7 +103,7 @@ async def get_keys(
         logger.exception(
             "Unexpected error while executing get_keys use case",
             extra={
-                "authenticated_user_id": authenticated_user_id,
+                "authenticated_user_id": authenticated_user.id,
                 "offset": command.offset,
                 "limit": command.limit,
                 "sort_by": command.sort_by,

--- a/api/infrastructure/fastapi/endpoints/me/keys.py
+++ b/api/infrastructure/fastapi/endpoints/me/keys.py
@@ -1,21 +1,73 @@
-from contextvars import ContextVar
 import logging
 
-from fastapi import Depends, Query, Security
+from fastapi import Body, Depends, Query, Security
 
-from api.dependencies import get_keys_use_case_factory
+from api.dependencies import create_me_key_use_case_factory, get_keys_use_case_factory
 from api.domain import SortField, SortOrder
-from api.infrastructure.fastapi import RequestContext
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError
+from api.domain.user.errors import UserNotFoundError
 from api.infrastructure.fastapi.accesscontroller import AccessController
-from api.infrastructure.fastapi.dependencies import get_request_context
 from api.infrastructure.fastapi.documentation import get_documentation_responses
-from api.infrastructure.fastapi.endpoints.exceptions import InternalServerHTTPException
+from api.infrastructure.fastapi.endpoints.exceptions import (
+    InternalServerHTTPException,
+    KeyAlreadyExistsHTTPException,
+    KeyExpirationInvalidHTTPException,
+    UserNotFoundHTTPException,
+)
 from api.infrastructure.fastapi.endpoints.me import router
 from api.infrastructure.fastapi.schemas.admin.keys import KeyResponse, KeysResponse
-from api.use_cases.admin.keys import GetKeysCommand, GetKeysUseCase, GetKeysUseCaseSuccess
+from api.infrastructure.fastapi.schemas.me.keys import CreateKeyBody
+from api.use_cases.admin.keys import (
+    CreateKeyCommand,
+    CreateKeyUseCase,
+    CreateKeyUseCaseSuccess,
+    GetKeysCommand,
+    GetKeysUseCase,
+    GetKeysUseCaseSuccess,
+)
+from api.utils.dependencies import get_authenticated_user_id
 from api.utils.variables import EndpointRoute
 
 logger = logging.getLogger(__name__)
+
+
+@router.post(
+    path=EndpointRoute.ME_KEYS,
+    dependencies=[Security(dependency=AccessController())],
+    status_code=201,
+    responses=get_documentation_responses([KeyAlreadyExistsHTTPException, KeyExpirationInvalidHTTPException, UserNotFoundHTTPException]),
+)
+async def create_key(
+    body: CreateKeyBody = Body(description="The key creation request."),
+    create_me_key_use_case: CreateKeyUseCase = Depends(create_me_key_use_case_factory),
+    authenticated_user_id: int = Depends(get_authenticated_user_id),
+) -> KeyResponse:
+    """
+    Create a new API key for the authenticated user.
+    """
+
+    command = CreateKeyCommand(user_id=authenticated_user_id, name=body.name, expire=body.expires)
+    try:
+        result = await create_me_key_use_case.execute(command)
+    except Exception as e:
+        logger.exception(
+            "Unexpected error while executing create_me_key use case",
+            extra={
+                "authenticated_user_id": authenticated_user_id,
+                "error_type": type(e).__name__,
+            },
+        )
+        raise InternalServerHTTPException()
+
+    match result:
+        case CreateKeyUseCaseSuccess(key=key):
+            return KeyResponse.model_validate(key, from_attributes=True)
+        case KeyAlreadyExistsError(name=name):
+            raise KeyAlreadyExistsHTTPException(name)
+        case KeyExpirationInvalidError(max_expiration_days=max_expiration_days):
+            raise KeyExpirationInvalidHTTPException(max_expiration_days)
+        case UserNotFoundError(id=user_id):
+            raise UserNotFoundHTTPException(user_id)
 
 
 @router.get(
@@ -30,14 +82,14 @@ async def get_keys(
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
-    request_context: ContextVar[RequestContext] = Depends(get_request_context),
+    authenticated_user_id: int = Depends(get_authenticated_user_id),
 ) -> KeysResponse:
     """
     Get all your keys.
     """
 
     command = GetKeysCommand(
-        user_id=request_context.get().user.id,
+        user_id=authenticated_user_id,
         offset=offset,
         limit=limit,
         sort_by=sort_by,
@@ -49,7 +101,7 @@ async def get_keys(
         logger.exception(
             "Unexpected error while executing get_keys use case",
             extra={
-                "authenticated_user_id": request_context.get().user.id,
+                "authenticated_user_id": authenticated_user_id,
                 "offset": command.offset,
                 "limit": command.limit,
                 "sort_by": command.sort_by,

--- a/api/infrastructure/fastapi/schemas/me/keys.py
+++ b/api/infrastructure/fastapi/schemas/me/keys.py
@@ -1,0 +1,29 @@
+from datetime import UTC, datetime
+from typing import Annotated
+
+from pydantic import Field, StringConstraints, field_validator
+
+from api.domain import BaseModel
+
+
+class CreateKeyBody(BaseModel):
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1), Field(description="Name of the key.", examples=["key-1"])]  # fmt: off
+    expires: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Expiration time, as Unix timestamp. If None, uses the configured maximum key lifetime when set, otherwise the key never expires.",
+        ),
+    ]
+
+    @field_validator("expires", mode="after")
+    def must_be_future_and_convert_to_datetime(cls, expires) -> None | datetime:
+        if expires is None:
+            return expires
+
+        if expires <= int(datetime.now(tz=UTC).timestamp()):
+            raise ValueError("Expiration time must be in the future.")
+
+        expires = datetime.fromtimestamp(timestamp=expires, tz=UTC)
+
+        return expires

--- a/api/schemas/me/keys.py
+++ b/api/schemas/me/keys.py
@@ -1,27 +1,6 @@
-import datetime as dt
-from typing import Annotated, Literal
-
-from pydantic import Field, constr, field_validator
+from typing import Literal
 
 from api.schemas import BaseModel
-
-
-class CreateKeyResponse(BaseModel):
-    id: int
-    token: str
-
-
-class CreateKey(BaseModel):
-    name: Annotated[str, constr(strip_whitespace=True, min_length=1)]
-    expires: int | None = Field(None, description="Timestamp in seconds")
-
-    @field_validator("expires", mode="before")
-    def must_be_future(cls, expires):
-        if isinstance(expires, int):
-            if expires <= int(dt.datetime.now(tz=dt.UTC).timestamp()):
-                raise ValueError("Wrong timestamp, must be in the future.")
-
-        return expires
 
 
 class Key(BaseModel):

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from api.helpers.models import ModelRegistry
 from api.schemas.core.configuration import Configuration, Dependencies, Settings
 from api.sql.models import Base
 from api.tests.integration import factories
+from api.utils.configuration import configuration as global_configuration
 from api.utils.context import global_context
 from api.utils.dependencies import get_model_registry
 from api.utils.dependencies import get_postgres_session as get_postgres_session_utils
@@ -44,9 +45,12 @@ def test_configuration():
             disabled_routers=[],
             hidden_routers=[],
             monitoring_prometheus_enabled=False,
+            auth_secret_key="test-secret-key",
+            auth_key_max_expiration_days=None,
         ),
         dependencies=Dependencies.model_construct(sentry=None),
     )
+    global_configuration.settings = configuration.settings
     return configuration
 
 

--- a/api/tests/integration/endpoints/me/keys/test_create_key.py
+++ b/api/tests/integration/endpoints/me/keys/test_create_key.py
@@ -1,0 +1,92 @@
+from unittest.mock import AsyncMock
+
+from httpx import AsyncClient
+import pytest
+import pytest_asyncio
+
+from api.dependencies import create_me_key_use_case_factory
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError
+from api.domain.user.errors import UserNotFoundError
+from api.tests.helpers import create_key
+from api.tests.integration.factories.sql import UserSQLFactory
+from api.utils.variables import EndpointRoute
+
+URL = f"/v1{EndpointRoute.ME_KEYS}"
+
+
+def _valid_body(**overrides) -> dict:
+    body = {"name": "new-key"}
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestCreateMeKey:
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup(self, db_session):
+        self.user = UserSQLFactory(regular_user=True)
+        self.token = await create_key(db_session, name="user_token", user=self.user)
+
+    async def test_happy_path(self, client: AsyncClient):
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(),
+        )
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["object"] == "key"
+        assert data["name"] == "new-key"
+        assert data["user"] == self.user.id
+        assert isinstance(data["id"], int)
+        assert data["value"].startswith("sk-")
+        assert data["expires"] is None
+        assert isinstance(data["created"], int)
+
+    @pytest.mark.parametrize(
+        "use_case_result,expected_status,expected_detail",
+        [
+            (
+                KeyAlreadyExistsError(name="new-key"),
+                409,
+                "Key new-key already exists.",
+            ),
+            (
+                KeyExpirationInvalidError(max_expiration_days=365),
+                400,
+                "Key expiration timestamp cannot be greater than 365 days from now.",
+            ),
+            (
+                UserNotFoundError(id=99),
+                404,
+                "User 99 not found.",
+            ),
+        ],
+    )
+    async def test_error_maps_to_correct_http_status(self, client: AsyncClient, app, use_case_result, expected_status, expected_detail):
+        mock_use_case = AsyncMock()
+        mock_use_case.execute.return_value = use_case_result
+        app.dependency_overrides[create_me_key_use_case_factory] = lambda: mock_use_case
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(),
+        )
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail
+
+    @pytest.mark.parametrize(
+        "headers,expected_status,expected_detail",
+        [
+            ({}, 401, "Not authenticated"),
+            ({"Authorization": "Bearer invalid-token"}, 401, "Invalid API key."),
+        ],
+    )
+    async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
+        response = await client.post(url=URL, headers=headers, json=_valid_body())
+
+        assert response.status_code == expected_status
+        assert response.json().get("detail") == expected_detail

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -201,7 +201,7 @@ class KeysState(EntityState):
                 data = response.json()
 
                 # Store the created key to display in dialog
-                self.created_key = data.get("key", "")
+                self.created_key = data.get("value", "")
                 self.is_created_dialog_open = True
 
                 # Reset the create form, keeping the default 1-year expiry

--- a/scripts/create_api_key.py
+++ b/scripts/create_api_key.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         },
     )
     assert response.status_code == 201, response.text
-    api_key = response.json()["key"]
+    api_key = response.json()["value"]
 
     console.print(f"✔ API key created successfully for user {args.email}", style="bold green")
     console.print(api_key)


### PR DESCRIPTION
## Summary
- Move `POST /v1/me/keys` off `IdentityAccessManager` onto a thin FastAPI endpoint that reuses `CreateKeyUseCase`, domain errors, and `KeyResponse`.
- Preserve `auth_key_max_expiration_days` (default lifetime + reject expirations past the max) and keep GET/DELETE `/v1/me/keys` on the legacy router until those issues are migrated.
- Align playground and `scripts/create_api_key.py` with the create response `value` field (same contract as admin keys).

## Test plan
- [x] `pytest api/tests/unit/use_case/admin/keys/test_createkeyusecase.py`
- [x] `pytest api/tests/integration/endpoints/me/keys/test_create_key.py`
- [x] `pytest api/tests/integration/endpoints/admin/keys/test_create_key.py` (no admin regression)
- [ ] Create a key as a non-admin user via `POST /v1/me/keys` and confirm the secret is returned in `value`
- [ ] With `auth_key_max_expiration_days` set, omit `expires` (gets the max lifetime) and send an expiration past the max (400)

Fixes #734

Made with [Cursor](https://cursor.com)