### PR TITLE
ci: run coverage and e2e only on ready PRs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,7 +2,7 @@ name: Testing
 
 # PR targeting main:
 #   draft  → unit (no coverage, no badge commit) + integration
-#   ready  → unit (coverage; badge commit only if % changed) + integration + e2e
+#   ready  → unit (coverage + badge commit) + integration + e2e
 # workflow_call / workflow_dispatch → all jobs; unit with coverage (badge commit only on a ready PR to main)
 
 on:
@@ -47,7 +47,6 @@ jobs:
           pytest -s api/tests/unit --config-file=pyproject.toml
 
       - name: Run unit tests with coverage and publish unit badge
-        id: coverage
         if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
         run: |
           . .venv/bin/activate
@@ -58,13 +57,11 @@ jobs:
           # Export coverage data to XML for badge computation
           python -m coverage xml -o coverage.xml
 
-          # Build unit coverage badge JSON only when the percentage changed
+          # Build unit coverage badge JSON
           mkdir -p .github/badges
           python - <<'PY'
           import json
-          import os
           import xml.etree.ElementTree as ET
-          from pathlib import Path
 
           coverage = float(ET.parse("coverage.xml").getroot().get("line-rate"))
           coverage_pct = f"{coverage * 100:.2f}"
@@ -75,39 +72,20 @@ jobs:
           else:
               color = "red"
 
-          message = f"{coverage_pct}%"
-          badge_path = Path(".github/badges/coverage.json")
-          existing_message = None
-          if badge_path.exists():
-              try:
-                  existing_message = json.loads(badge_path.read_text(encoding="utf-8")).get("message")
-              except (OSError, json.JSONDecodeError):
-                  existing_message = None
-
-          github_output = os.environ["GITHUB_OUTPUT"]
-          if existing_message == message:
-              print(f"Coverage unchanged at {message}; skipping badge update")
-              with open(github_output, "a", encoding="utf-8") as output:
-                  output.write("badge_changed=false\n")
-          else:
-              badge = {
-                  "schemaVersion": 1,
-                  "label": "coverage",
-                  "message": message,
-                  "color": color,
-              }
-              with badge_path.open("w", encoding="utf-8") as badge_file:
-                  json.dump(badge, badge_file)
-              print(f"Coverage badge updated: {existing_message} -> {message}")
-              with open(github_output, "a", encoding="utf-8") as output:
-                  output.write("badge_changed=true\n")
+          badge = {
+              "schemaVersion": 1,
+              "label": "coverage",
+              "message": f"{coverage_pct}%",
+              "color": color,
+          }
+          with open(".github/badges/coverage.json", "w", encoding="utf-8") as badge_file:
+              json.dump(badge, badge_file)
           PY
 
       - name: Commit unit coverage badge
         if: >-
           github.event.pull_request.draft == false &&
-          github.event.pull_request.base.ref == 'main' &&
-          steps.coverage.outputs.badge_changed == 'true'
+          github.event.pull_request.base.ref == 'main'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update unit coverage badge

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,10 +1,17 @@
 name: Testing
 
+# PR targeting main:
+#   draft  → unit (no coverage, no badge commit) + integration
+#   ready  → unit (coverage; badge commit only if % changed) + integration + e2e
+# workflow_call / workflow_dispatch → all jobs; unit with coverage (badge commit only on a ready PR to main)
+
 on:
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "api/**"
+      - ".github/workflows/run_tests.yml"
   workflow_call: # Add this to make the workflow reusable
   workflow_dispatch: # Add this to allow manual triggering
 
@@ -28,26 +35,36 @@ jobs:
         run: |
           cp config.example.yml config.yml
 
-      - name: Run unit tests with coverage and publish unit badge
+      - name: Install test dependencies
         run: |
-          # Create a local virtual environment and install dependencies
           uv venv
           uv pip install --quiet -p .venv/bin/python ".[api,dev,test]"
-          
-          # Activate venv for the test run
+
+      - name: Run unit tests
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft
+        run: |
           . .venv/bin/activate
-          
+          pytest -s api/tests/unit --config-file=pyproject.toml
+
+      - name: Run unit tests with coverage and publish unit badge
+        id: coverage
+        if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+        run: |
+          . .venv/bin/activate
+
           # Run unit tests with coverage
           pytest -s api/tests/unit --config-file=pyproject.toml --cov=./api --cov-report=html --cov-report=term-missing --cov-branch --cov-report=xml
 
           # Export coverage data to XML for badge computation
           python -m coverage xml -o coverage.xml
-          
-          # Build unit coverage badge JSON
+
+          # Build unit coverage badge JSON only when the percentage changed
           mkdir -p .github/badges
           python - <<'PY'
           import json
+          import os
           import xml.etree.ElementTree as ET
+          from pathlib import Path
 
           coverage = float(ET.parse("coverage.xml").getroot().get("line-rate"))
           coverage_pct = f"{coverage * 100:.2f}"
@@ -58,18 +75,39 @@ jobs:
           else:
               color = "red"
 
-          badge = {
-              "schemaVersion": 1,
-              "label": "coverage",
-              "message": f"{coverage_pct}%",
-              "color": color,
-          }
-          with open(".github/badges/coverage.json", "w", encoding="utf-8") as badge_file:
-              json.dump(badge, badge_file)
+          message = f"{coverage_pct}%"
+          badge_path = Path(".github/badges/coverage.json")
+          existing_message = None
+          if badge_path.exists():
+              try:
+                  existing_message = json.loads(badge_path.read_text(encoding="utf-8")).get("message")
+              except (OSError, json.JSONDecodeError):
+                  existing_message = None
+
+          github_output = os.environ["GITHUB_OUTPUT"]
+          if existing_message == message:
+              print(f"Coverage unchanged at {message}; skipping badge update")
+              with open(github_output, "a", encoding="utf-8") as output:
+                  output.write("badge_changed=false\n")
+          else:
+              badge = {
+                  "schemaVersion": 1,
+                  "label": "coverage",
+                  "message": message,
+                  "color": color,
+              }
+              with badge_path.open("w", encoding="utf-8") as badge_file:
+                  json.dump(badge, badge_file)
+              print(f"Coverage badge updated: {existing_message} -> {message}")
+              with open(github_output, "a", encoding="utf-8") as output:
+                  output.write("badge_changed=true\n")
           PY
 
       - name: Commit unit coverage badge
-        if: github.event.pull_request.base.ref == 'main'
+        if: >-
+          github.event.pull_request.draft == false &&
+          github.event.pull_request.base.ref == 'main' &&
+          steps.coverage.outputs.badge_changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update unit coverage badge
@@ -112,7 +150,10 @@ jobs:
     if: >-
       github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
-      github.actor != 'github-actions[bot]'
+      (
+        github.actor != 'github-actions[bot]' &&
+        github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Overview

Change the `Testing` workflow so draft PRs targeting `main` stay cheap, while ready PRs still get full checks and the coverage badge.

- [x] Draft PRs run unit tests without coverage (no badge commit) and integration tests
- [x] Ready PRs run unit tests with coverage and commit the badge when `git-auto-commit` sees a change
- [x] Integration tests run on draft and ready PRs
- [x] E2E tests run only on ready PRs
- [x] `ready_for_review` retriggers coverage and e2e when a draft is marked ready

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [ ] Updated or added unit tests
- [ ] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [ ] Code is linted and formatted using the project pre-commit hooks

N/A for documentation and tests: this is a GitHub Actions workflow change only.

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

## Additional Notes

`git-auto-commit-action` already skips the badge commit when `.github/badges/coverage.json` is unchanged, so the workflow does not compare coverage percentages in Python.

Made with [Cursor](https://cursor.com)