### PR TITLE
refacto(provider): move HTTP request details off the ProviderClient port (#993)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,35 @@ The domain and API term for an API credential is **key** (`Key`, `CreateKeyRespo
 
 ---
 
+## Imports
+
+| Importing module | Style | Example |
+|------------------|-------|---------|
+| `__init__.py` re-export | relative, single dot | `from ._httpproviderclient import HttpProviderClient` |
+| Module importing a sibling in the **same** directory | relative, single dot | `from ._httpproviderrequest import HttpProviderRequest` |
+| Anything else — other directory, other package, tests | absolute | `from api.infrastructure.http.adapters import HttpProviderAdapter` |
+
+Never write a multi-dot relative import (`from ..x import`, `from ...x import`); use the absolute path instead. Reference siblings: `_requestcontextusagerecorder.py`, `_albertmodelprovider.py`.
+
+**A module inside a package must not import from its own package root.** The package `__init__.py` is still running when it pulls the submodule in, so the name it needs may not be bound yet and the import fails against a partially initialized module.
+
+```python
+# api/infrastructure/http/adapters/models/_modelsadapter.py
+
+# bad — http/__init__.py imports the adapter builder (and so this module) before it
+# binds HttpProviderRequest, so this raises ImportError and the app cannot start
+from api.infrastructure.http import HttpProviderRequest
+
+# good — the defining module, independent of __init__ ordering
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
+```
+
+Do not reorder `__init__.py` to break such a cycle: ruff sorts those imports alphabetically on commit and silently undoes the fix.
+
+Code **outside** the package keeps importing the public root (`from api.infrastructure.http import HttpProviderRequest`) — DI factories, `lifespan.py`, tests.
+
+---
+
 ## Schemas
 
 Location: `api/infrastructure/fastapi/schemas/`.

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -124,8 +124,8 @@ def _provider_adapter_builder() -> ProviderAdapterBuilder:
     return HttpProviderAdapterBuilder()
 
 
-def _provider_client() -> ProviderClient:
-    return HttpProviderClient()
+def _provider_client(provider_adapter_builder: ProviderAdapterBuilder = Depends(_provider_adapter_builder)) -> ProviderClient:
+    return HttpProviderClient(adapter_builder=provider_adapter_builder)
 
 
 def _provider_load_balancer(redis_client: Redis = Depends(get_redis_client)) -> ProviderLoadBalancer:

--- a/api/domain/provider/_provideradapter.py
+++ b/api/domain/provider/_provideradapter.py
@@ -1,26 +1,16 @@
 from abc import ABC, abstractmethod
 
-from api.domain.provider.entities import (
-    Provider,
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
-    ProviderOriginalRequest,
-    ProviderOriginalResponse,
-)
-from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
+from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest, ProviderResponse
+from api.domain.provider.errors import ProviderAdapterValidationResponseError
 
 
 class ProviderAdapter(ABC):
     provider: Provider
 
     @abstractmethod
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest | ProviderAdapterValidationRequestError:
-        pass
-
-    @abstractmethod
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
         pass

--- a/api/domain/provider/_providerclient.py
+++ b/api/domain/provider/_providerclient.py
@@ -3,16 +3,24 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
-from api.domain.provider.entities import Provider, ProviderFormattedRequest, ProviderOriginalResponse
+from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest
+from api.domain.provider.errors import ProviderAdapterValidationRequestError, UnsupportedProviderEndpointError
 
-type ProviderClientResponse = ProviderOriginalResponse | TooBusyModelError | UnknownModelError | StatusCodeModelError
+type ProviderClientResponse = (
+    ProviderRawResponse
+    | TooBusyModelError
+    | UnknownModelError
+    | StatusCodeModelError
+    | ProviderAdapterValidationRequestError
+    | UnsupportedProviderEndpointError
+)
 
 
 class ProviderClient(ABC):
     @abstractmethod
-    async def forward_request(self, provider: Provider, formatted_request: ProviderFormattedRequest) -> ProviderClientResponse:
+    async def forward(self, provider: Provider, request: ProviderRequest) -> ProviderClientResponse:
         pass
 
     @abstractmethod
-    async def forward_stream(self, provider: Provider, formatted_request: ProviderFormattedRequest) -> AsyncGenerator[Any]:
+    async def forward_stream(self, provider: Provider, request: ProviderRequest) -> AsyncGenerator[Any]:
         pass

--- a/api/domain/provider/entities.py
+++ b/api/domain/provider/entities.py
@@ -1,5 +1,4 @@
 from enum import StrEnum
-from http import HTTPMethod
 from typing import Annotated, Literal
 
 import pycountry
@@ -146,7 +145,7 @@ class ProviderCapabilities(BaseModel):
     vector_size: int | None = None
 
 
-class ProviderOriginalRequest(BaseModel):
+class ProviderRequest(BaseModel):
     endpoint: Annotated[EndpointRoute, Field(description="The source endpoint (at the user side) of the request.")]
     payload: Annotated[ForwardablePayload | None, Field(default=None, description="The payload to use for the request.")]
 
@@ -156,16 +155,7 @@ class ResponseMetrics(BaseModel):
     ttft: Annotated[int | None, Field(default=None, description="The time to first byte of the response.")]
 
 
-class ProviderFormattedRequest(BaseModel):
-    method: Annotated[HTTPMethod, Field(description="The HTTP method to build the request.")]
-    url: Annotated[str, Field(description="The model API URL to build the request.")]
-    auth: Annotated[BasicAuth | None, Field(default=None, description="The authentication to use for the request.")]
-    body: Annotated[dict, Field(default={}, description="The JSON body to use for the request.")]
-    form: Annotated[dict, Field(default={}, description="The form-encoded data to use for the request.")]
-    files: Annotated[dict, Field(default={}, description="The files to use for the request.")]
-
-
-class ProviderOriginalResponse(BaseModel):
+class ProviderRawResponse(BaseModel):
     data: Annotated[dict | list | None, Field(default=None, description="The JSON data to use for the response.")]
     text: Annotated[str | None, Field(default=None, description="The text data to use for the response.")]
 
@@ -176,13 +166,13 @@ class ProviderMetrics(ModelJsonResponse):
     running_requests: float
 
 
-class ProviderFormattedResponse(BaseModel):
+class ProviderResponse(BaseModel):
     id: Annotated[str, Field(description="The request identifier.")]
     data: Annotated[ModelJsonResponse | None, Field(default=None, description="The JSON data to use for the response.")]
     text: Annotated[str | None, Field(default=None, description="The text data to use for the response.")]
 
     @model_validator(mode="after")
-    def validate_data_and_text(self) -> "ProviderFormattedResponse":
+    def validate_data_and_text(self) -> "ProviderResponse":
         if self.data is not None and self.text is not None:
             raise ValueError("data and text cannot be set at the same time")
 

--- a/api/infrastructure/http/__init__.py
+++ b/api/infrastructure/http/__init__.py
@@ -1,5 +1,6 @@
 from ._httpauthssosessionvalidator import HttpAuthSsoSessionValidator
 from ._httpprovideradapterbuilder import HttpProviderAdapterBuilder
 from ._httpproviderclient import HttpProviderClient
+from ._httpproviderrequest import HttpProviderRequest
 
-__all__ = ["HttpAuthSsoSessionValidator", "HttpProviderAdapterBuilder", "HttpProviderClient"]
+__all__ = ["HttpAuthSsoSessionValidator", "HttpProviderAdapterBuilder", "HttpProviderClient", "HttpProviderRequest"]

--- a/api/infrastructure/http/_httpproviderclient.py
+++ b/api/infrastructure/http/_httpproviderclient.py
@@ -9,8 +9,9 @@ from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, Unk
 from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderClientResponse
 from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, UnsupportedProviderEndpointError
-from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters import HttpProviderAdapter
+
+from ._httpproviderrequest import HttpProviderRequest
 
 logger = logging.getLogger(__name__)
 

--- a/api/infrastructure/http/_httpproviderclient.py
+++ b/api/infrastructure/http/_httpproviderclient.py
@@ -6,27 +6,50 @@ import httpx
 from httpx import BasicAuth
 
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
-from api.domain.provider import ProviderClient, ProviderClientResponse
-from api.domain.provider.entities import Provider, ProviderFormattedRequest, ProviderOriginalResponse
+from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderClientResponse
+from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest
+from api.domain.provider.errors import ProviderAdapterValidationRequestError, UnsupportedProviderEndpointError
+from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http.adapters import HttpProviderAdapter
 
 logger = logging.getLogger(__name__)
 
 
 class HttpProviderClient(ProviderClient):
-    async def forward_request(self, provider: Provider, formatted_request: ProviderFormattedRequest) -> ProviderClientResponse:
+    def __init__(self, adapter_builder: ProviderAdapterBuilder):
+        self.adapter_builder = adapter_builder
+
+    async def forward(self, provider: Provider, request: ProviderRequest) -> ProviderClientResponse:
+        adapter = self.adapter_builder.build(endpoint=request.endpoint, provider=provider)
+        match adapter:
+            case UnsupportedProviderEndpointError() as error:
+                return error
+            case HttpProviderAdapter() as adapter:
+                pass
+
+        http_request = adapter.to_http_request(request)
+        match http_request:
+            case ProviderAdapterValidationRequestError() as error:
+                return error
+            case HttpProviderRequest() as http_request:
+                pass
+
+        return await self._send(provider=provider, http_request=http_request)
+
+    async def _send(self, provider: Provider, http_request: HttpProviderRequest) -> ProviderClientResponse:
         # TEMPORARY PATCH FOR MISTRAL METRICS ENDPOINT
-        auth = BasicAuth(username=formatted_request.auth.username, password=formatted_request.auth.password) if formatted_request.auth else None
+        auth = BasicAuth(username=http_request.auth.username, password=http_request.auth.password) if http_request.auth else None
 
         async with httpx.AsyncClient(timeout=provider.timeout) as async_client:
             try:
                 response = await async_client.request(
                     headers={"Authorization": f"Bearer {provider.key}"} if provider.key else {},
                     auth=auth,
-                    method=formatted_request.method,
-                    url=formatted_request.url,
-                    json=formatted_request.body,
-                    files=formatted_request.files,
-                    data=formatted_request.form,
+                    method=http_request.method,
+                    url=http_request.url,
+                    json=http_request.body,
+                    files=http_request.files,
+                    data=http_request.form,
                 )
             except (
                 httpx.TimeoutException,
@@ -61,7 +84,7 @@ class HttpProviderClient(ProviderClient):
         else:
             data, text = None, response.text
 
-        return ProviderOriginalResponse(data=data, text=text)
+        return ProviderRawResponse(data=data, text=text)
 
-    async def forward_stream(self, provider: Provider, formatted_request: ProviderFormattedRequest):
+    async def forward_stream(self, provider: Provider, request: ProviderRequest):
         raise NotImplementedError()

--- a/api/infrastructure/http/_httpproviderrequest.py
+++ b/api/infrastructure/http/_httpproviderrequest.py
@@ -1,0 +1,16 @@
+from http import HTTPMethod
+from typing import Annotated
+
+from pydantic import Field
+
+from api.domain import BaseModel
+from api.domain.provider.entities import BasicAuth
+
+
+class HttpProviderRequest(BaseModel):
+    method: Annotated[HTTPMethod, Field(description="The HTTP method to build the request.")]
+    url: Annotated[str, Field(description="The model API URL to build the request.")]
+    auth: Annotated[BasicAuth | None, Field(default=None, description="The authentication to use for the request.")]
+    body: Annotated[dict, Field(default={}, description="The JSON body to use for the request.")]
+    form: Annotated[dict, Field(default={}, description="The form-encoded data to use for the request.")]
+    files: Annotated[dict, Field(default={}, description="The files to use for the request.")]

--- a/api/infrastructure/http/adapters/_httpprovideradapter.py
+++ b/api/infrastructure/http/adapters/_httpprovideradapter.py
@@ -6,14 +6,9 @@ from uuid import uuid4
 from pydantic import StringConstraints, ValidationError
 
 from api.domain.provider import ProviderAdapter
-from api.domain.provider.entities import (
-    Provider,
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
-    ProviderOriginalRequest,
-    ProviderOriginalResponse,
-)
+from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
+from api.infrastructure.http import HttpProviderRequest
 from api.utils.variables import EndpointRoute
 
 
@@ -26,31 +21,31 @@ class HttpProviderAdapter(ProviderAdapter):
     def __init__(self, provider: Provider):
         self.provider = provider
 
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest | ProviderAdapterValidationRequestError:
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest | ProviderAdapterValidationRequestError:
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
-        formatted_request = ProviderFormattedRequest(
+        http_request = HttpProviderRequest(
             method=self.TARGET_ENDPOINT_METHOD,
             url=target_url,
-            body=original_request.payload.model_dump(exclude_none=True) if original_request.payload else {},
+            body=request.payload.model_dump(exclude_none=True) if request.payload else {},
         )
 
-        if "model" in formatted_request.body:
-            formatted_request.body["model"] = self.provider.model_name
+        if "model" in http_request.body:
+            http_request.body["model"] = self.provider.model_name
 
-        return formatted_request
+        return http_request
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
-        request_id = self._extract_request_id(original_response=original_response)
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
+        request_id = self._extract_request_id(raw_response=raw_response)
         try:
-            data = self.RESPONSE_TYPE(**{**original_response.data, "id": request_id, "model": original_request.payload.model})
+            data = self.RESPONSE_TYPE(**{**raw_response.data, "id": request_id, "model": request.payload.model})
         except ValidationError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=e.errors())
 
-        return ProviderFormattedResponse(id=request_id, data=data)
+        return ProviderResponse(id=request_id, data=data)
 
     @staticmethod
     def _build_target_url(base_url: str, target_endpoint_route: str | None) -> str:
@@ -59,10 +54,10 @@ class HttpProviderAdapter(ProviderAdapter):
         return url
 
     @staticmethod
-    def _extract_request_id(original_response: ProviderOriginalResponse) -> str:
+    def _extract_request_id(raw_response: ProviderRawResponse) -> str:
         default_request_id = f"request-{str(uuid4()).replace('-', '')}"
 
-        if isinstance(original_response.data, dict):
-            return original_response.data.get("id", default_request_id)
+        if isinstance(raw_response.data, dict):
+            return raw_response.data.get("id", default_request_id)
 
         return default_request_id

--- a/api/infrastructure/http/adapters/_httpprovideradapter.py
+++ b/api/infrastructure/http/adapters/_httpprovideradapter.py
@@ -8,7 +8,7 @@ from pydantic import StringConstraints, ValidationError
 from api.domain.provider import ProviderAdapter
 from api.domain.provider.entities import Provider, ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.utils.variables import EndpointRoute
 
 

--- a/api/infrastructure/http/adapters/audio/_audiotranscriptionsadapter.py
+++ b/api/infrastructure/http/adapters/audio/_audiotranscriptionsadapter.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 from api.domain.audio.entities import AudioTranscriptions
 from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
 

--- a/api/infrastructure/http/adapters/audio/_audiotranscriptionsadapter.py
+++ b/api/infrastructure/http/adapters/audio/_audiotranscriptionsadapter.py
@@ -3,13 +3,9 @@ from http import HTTPMethod
 from pydantic import ValidationError
 
 from api.domain.audio.entities import AudioTranscriptions
-from api.domain.provider.entities import (
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
-    ProviderOriginalRequest,
-    ProviderOriginalResponse,
-)
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
 
@@ -20,30 +16,30 @@ class AudioTranscriptionsAdapter(HttpProviderAdapter):
     TARGET_ENDPOINT_METHOD = HTTPMethod.POST
     RESPONSE_TYPE = AudioTranscriptions
 
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest | ProviderAdapterValidationRequestError:
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest | ProviderAdapterValidationRequestError:
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
-        formatted_request = ProviderFormattedRequest(
+        http_request = HttpProviderRequest(
             method=self.TARGET_ENDPOINT_METHOD,
             url=target_url,
-            form=original_request.payload.model_dump(exclude_none=True, exclude={"file"}),
-            files={"file": (original_request.payload.file.name, original_request.payload.file.file, original_request.payload.file.content_type)},
+            form=request.payload.model_dump(exclude_none=True, exclude={"file"}),
+            files={"file": (request.payload.file.name, request.payload.file.file, request.payload.file.content_type)},
         )
-        formatted_request.form["model"] = self.provider.model_name
+        http_request.form["model"] = self.provider.model_name
 
-        return formatted_request
+        return http_request
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
-        request_id = self._extract_request_id(original_response=original_response)
-        if original_response.text is not None:
-            return ProviderFormattedResponse(id=request_id, text=original_response.text)
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
+        request_id = self._extract_request_id(raw_response=raw_response)
+        if raw_response.text is not None:
+            return ProviderResponse(id=request_id, text=raw_response.text)
 
         try:
-            data = self.RESPONSE_TYPE.model_validate({"id": request_id, "model": original_request.payload.model, **original_response.data})
+            data = self.RESPONSE_TYPE.model_validate({"id": request_id, "model": request.payload.model, **raw_response.data})
         except ValidationError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=e.errors())
 
-        return ProviderFormattedResponse(id=request_id, data=data)
+        return ProviderResponse(id=request_id, data=data)

--- a/api/infrastructure/http/adapters/audio/mistral/_mistralaudiotranscriptionsadapter.py
+++ b/api/infrastructure/http/adapters/audio/mistral/_mistralaudiotranscriptionsadapter.py
@@ -6,8 +6,9 @@ from pydantic import ValidationError
 
 from api.domain import BaseModel
 from api.domain.audio.entities import AudioTranscriptions, AudioTranscriptionsResponseFormat
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.audio import AudioTranscriptionsAdapter
 from api.schemas.audio import AudioTranscriptionLanguage
 
@@ -23,17 +24,17 @@ class MistralCreateAudioTranscriptionsBody(BaseModel):
 class MistralAudioTranscriptionsAdapter(AudioTranscriptionsAdapter):
     TARGET_ENDPOINT_ROUTE = "/v1/chat/completions"
 
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest | ProviderAdapterValidationRequestError:
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest | ProviderAdapterValidationRequestError:
         try:
-            body = MistralCreateAudioTranscriptionsBody.model_validate(original_request.payload.model_dump(mode="json", exclude={"file"}))
+            body = MistralCreateAudioTranscriptionsBody.model_validate(request.payload.model_dump(mode="json", exclude={"file"}))
         except ValidationError as e:
             return ProviderAdapterValidationRequestError(provider_type=self.provider.type, errors=e.errors())
 
         text = body.prompt or f"Transcribe this audio in this language : {body.language or 'en'}"  # fmt: off
-        file = original_request.payload.file.file.read()
+        file = request.payload.file.file.read()
         input_audio = base64.b64encode(file).decode("utf-8")
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
-        return ProviderFormattedRequest(
+        return HttpProviderRequest(
             method=self.TARGET_ENDPOINT_METHOD,
             url=target_url,
             body=ChatCompletionRequest(
@@ -48,15 +49,15 @@ class MistralAudioTranscriptionsAdapter(AudioTranscriptionsAdapter):
             ).model_dump(),
         )
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse:
-        text = original_response.data["choices"][0]["message"]["content"]
-        request_id = self._extract_request_id(original_response=original_response)
-        if original_request.payload.response_format == AudioTranscriptionsResponseFormat.TEXT:
-            return ProviderFormattedResponse(id=request_id, text=text)
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        text = raw_response.data["choices"][0]["message"]["content"]
+        request_id = self._extract_request_id(raw_response=raw_response)
+        if request.payload.response_format == AudioTranscriptionsResponseFormat.TEXT:
+            return ProviderResponse(id=request_id, text=text)
 
-        data = AudioTranscriptions(id=request_id, text=text, model=original_request.payload.model)
-        return ProviderFormattedResponse(id=request_id, data=data)
+        data = AudioTranscriptions(id=request_id, text=text, model=request.payload.model)
+        return ProviderResponse(id=request_id, data=data)

--- a/api/infrastructure/http/adapters/audio/mistral/_mistralaudiotranscriptionsadapter.py
+++ b/api/infrastructure/http/adapters/audio/mistral/_mistralaudiotranscriptionsadapter.py
@@ -8,7 +8,7 @@ from api.domain import BaseModel
 from api.domain.audio.entities import AudioTranscriptions, AudioTranscriptionsResponseFormat
 from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters.audio import AudioTranscriptionsAdapter
 from api.schemas.audio import AudioTranscriptionLanguage
 

--- a/api/infrastructure/http/adapters/chat/mistral/_mistralchatcompletionsadapter.py
+++ b/api/infrastructure/http/adapters/chat/mistral/_mistralchatcompletionsadapter.py
@@ -1,5 +1,5 @@
 from api.domain.provider.entities import ProviderRequest
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters.chat import ChatCompletionsAdapter
 
 

--- a/api/infrastructure/http/adapters/chat/mistral/_mistralchatcompletionsadapter.py
+++ b/api/infrastructure/http/adapters/chat/mistral/_mistralchatcompletionsadapter.py
@@ -1,10 +1,11 @@
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderOriginalRequest
+from api.domain.provider.entities import ProviderRequest
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.chat import ChatCompletionsAdapter
 
 
 class MistralChatCompletionsAdapter(ChatCompletionsAdapter):
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest:
-        body = original_request.payload.model_dump(exclude_none=True)
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest:
+        body = request.payload.model_dump(exclude_none=True)
         body["random_seed"] = body["random_seed"] or body["seed"]
         supported_fields = [
             "frequency_penalty",
@@ -30,4 +31,4 @@ class MistralChatCompletionsAdapter(ChatCompletionsAdapter):
         body = {key: value for key, value in body.items() if key in supported_fields}
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
 
-        return ProviderFormattedRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, body=body)
+        return HttpProviderRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, body=body)

--- a/api/infrastructure/http/adapters/embeddings/_embeddingsadapter.py
+++ b/api/infrastructure/http/adapters/embeddings/_embeddingsadapter.py
@@ -3,7 +3,7 @@ from http import HTTPMethod
 from pydantic import ValidationError
 
 from api.domain.embeddings.entities import Embeddings
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
@@ -15,21 +15,21 @@ class EmbeddingsAdapter(HttpProviderAdapter):
     TARGET_ENDPOINT_METHOD = HTTPMethod.POST
     RESPONSE_TYPE = Embeddings
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
-        request_id = self._extract_request_id(original_response=original_response)
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
+        request_id = self._extract_request_id(raw_response=raw_response)
         try:
-            encoding_format = original_request.payload.encoding_format
+            encoding_format = request.payload.encoding_format
             data = self.RESPONSE_TYPE._from_provider_response(
-                original_response.data,
+                raw_response.data,
                 encoding_format=encoding_format,
                 id=request_id,
-                model=original_request.payload.model,
+                model=request.payload.model,
             )
         except ValidationError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=e.errors())
 
-        return ProviderFormattedResponse(id=request_id, data=data)
+        return ProviderResponse(id=request_id, data=data)

--- a/api/infrastructure/http/adapters/metrics/mistral/_mistralmetricsadapter.py
+++ b/api/infrastructure/http/adapters/metrics/mistral/_mistralmetricsadapter.py
@@ -2,7 +2,7 @@ from prometheus_client.parser import text_string_to_metric_families
 
 from api.domain.provider.entities import ProviderMetrics, ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters.metrics import MetricsAdapter
 
 

--- a/api/infrastructure/http/adapters/metrics/mistral/_mistralmetricsadapter.py
+++ b/api/infrastructure/http/adapters/metrics/mistral/_mistralmetricsadapter.py
@@ -1,31 +1,24 @@
 from prometheus_client.parser import text_string_to_metric_families
 
-from api.domain.provider.entities import (
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
-    ProviderMetrics,
-    ProviderOriginalRequest,
-    ProviderOriginalResponse,
-)
+from api.domain.provider.entities import ProviderMetrics, ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.metrics import MetricsAdapter
 
 
 class MistralMetricsAdapter(MetricsAdapter):
     # TEMPORARY PATCH FOR MISTRAL METRICS ENDPOINT
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest:
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest:
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
-        formatted_request = ProviderFormattedRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, auth=self.provider.basic_auth)
+        return HttpProviderRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, auth=self.provider.basic_auth)
 
-        return formatted_request
-
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
         try:
-            families = list(text_string_to_metric_families(text=original_response.text))
+            families = list(text_string_to_metric_families(text=raw_response.text))
         except ValueError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=[{"msg": str(e)}])
 
@@ -37,6 +30,6 @@ class MistralMetricsAdapter(MetricsAdapter):
                 elif sample.name == "vllm:num_requests_waiting" and sample.labels.get("model_name") == self.provider.model_name:
                     waiting_requests += sample.value
 
-        request_id = self._extract_request_id(original_response=original_response)
+        request_id = self._extract_request_id(raw_response=raw_response)
 
-        return ProviderFormattedResponse(id=request_id, data=ProviderMetrics(waiting_requests=waiting_requests, running_requests=running_requests))
+        return ProviderResponse(id=request_id, data=ProviderMetrics(waiting_requests=waiting_requests, running_requests=running_requests))

--- a/api/infrastructure/http/adapters/metrics/vllm/_vllmmetricsadapter.py
+++ b/api/infrastructure/http/adapters/metrics/vllm/_vllmmetricsadapter.py
@@ -1,18 +1,18 @@
 from prometheus_client.parser import text_string_to_metric_families
 
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderMetrics, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderMetrics, ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
 from api.infrastructure.http.adapters.metrics import MetricsAdapter
 
 
 class VllmMetricsAdapter(MetricsAdapter):
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
         try:
-            families = list(text_string_to_metric_families(text=original_response.text))
+            families = list(text_string_to_metric_families(text=raw_response.text))
         except ValueError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=[{"msg": str(e)}])
 
@@ -24,6 +24,6 @@ class VllmMetricsAdapter(MetricsAdapter):
                 elif sample.name == "vllm:num_requests_waiting" and sample.labels.get("model_name") == self.provider.model_name:
                     waiting_requests += sample.value
 
-        request_id = self._extract_request_id(original_response=original_response)
+        request_id = self._extract_request_id(raw_response=raw_response)
 
-        return ProviderFormattedResponse(id=request_id, data=ProviderMetrics(waiting_requests=waiting_requests, running_requests=running_requests))
+        return ProviderResponse(id=request_id, data=ProviderMetrics(waiting_requests=waiting_requests, running_requests=running_requests))

--- a/api/infrastructure/http/adapters/models/_modelsadapter.py
+++ b/api/infrastructure/http/adapters/models/_modelsadapter.py
@@ -1,7 +1,8 @@
 from http import HTTPMethod
 
 from api.domain.model.entities import Model, Models, ModelType
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
 
@@ -12,19 +13,19 @@ class ModelsAdapter(HttpProviderAdapter):
     TARGET_ENDPOINT_METHOD = HTTPMethod.GET
     RESPONSE_TYPE = Model
 
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest:
-        return ProviderFormattedRequest(
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest:
+        return HttpProviderRequest(
             method=self.TARGET_ENDPOINT_METHOD,
             url=self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE),
         )
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse:
-        request_id = self._extract_request_id(original_response=original_response)
-        return ProviderFormattedResponse(
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        request_id = self._extract_request_id(raw_response=raw_response)
+        return ProviderResponse(
             id=request_id,
             data=Models(
                 data=[
@@ -36,7 +37,7 @@ class ModelsAdapter(HttpProviderAdapter):
                         max_context_length=model.get("max_context_length", None),
                         type=ModelType.TEXT_GENERATION,  # dummy value, not used
                     )
-                    for model in original_response.data["data"]
+                    for model in raw_response.data["data"]
                 ]
             ),
         )

--- a/api/infrastructure/http/adapters/models/_modelsadapter.py
+++ b/api/infrastructure/http/adapters/models/_modelsadapter.py
@@ -2,7 +2,7 @@ from http import HTTPMethod
 
 from api.domain.model.entities import Model, Models, ModelType
 from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
 

--- a/api/infrastructure/http/adapters/models/mistral/_mistralmodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/mistral/_mistralmodelsadapter.py
@@ -1,18 +1,16 @@
 from api.domain.model.entities import Model, Models, ModelType
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
 class MistralModelsAdapter(ModelsAdapter):
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-        prompt_tokens: int = 0,
-        latency: int = 0,
-    ) -> ProviderFormattedResponse:
-        request_id = self._extract_request_id(original_response=original_response)
-        return ProviderFormattedResponse(
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        request_id = self._extract_request_id(raw_response=raw_response)
+        return ProviderResponse(
             id=request_id,
             data=Models(
                 data=[
@@ -23,7 +21,7 @@ class MistralModelsAdapter(ModelsAdapter):
                         max_context_length=model["max_context_length"],
                         type=ModelType.TEXT_GENERATION,  # dummy value, not used
                     )
-                    for model in original_response.data.get("data", [])
+                    for model in raw_response.data.get("data", [])
                 ]
             ),
         )

--- a/api/infrastructure/http/adapters/models/tei/_teimodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/tei/_teimodelsadapter.py
@@ -1,28 +1,26 @@
 from api.domain.model.entities import Model, Models, ModelType
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
 class TeiModelsAdapter(ModelsAdapter):
     TARGET_ENDPOINT_ROUTE = "/info"
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-        prompt_tokens: int = 0,
-        latency: int = 0,
-    ) -> ProviderFormattedResponse:
-        request_id = self._extract_request_id(original_response=original_response)
-        return ProviderFormattedResponse(
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        request_id = self._extract_request_id(raw_response=raw_response)
+        return ProviderResponse(
             id=request_id,
             data=Models(
                 data=[
                     Model(
-                        id=original_response.data["model_id"],
+                        id=raw_response.data["model_id"],
                         created=0,
                         owned_by="tei",
-                        max_context_length=original_response.data["max_input_length"],
+                        max_context_length=raw_response.data["max_input_length"],
                         type=ModelType.TEXT_GENERATION,  # dummy value, not used
                     )
                 ]

--- a/api/infrastructure/http/adapters/models/vllm/_vllmmodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/vllm/_vllmmodelsadapter.py
@@ -1,18 +1,16 @@
 from api.domain.model.entities import Model, Models, ModelType
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
 class VllmModelsAdapter(ModelsAdapter):
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-        prompt_tokens: int = 0,
-        latency: int = 0,
-    ) -> ProviderFormattedResponse:
-        request_id = self._extract_request_id(original_response=original_response)
-        return ProviderFormattedResponse(
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        request_id = self._extract_request_id(raw_response=raw_response)
+        return ProviderResponse(
             id=request_id,
             data=Models(
                 data=[
@@ -23,7 +21,7 @@ class VllmModelsAdapter(ModelsAdapter):
                         max_context_length=model["max_model_len"],
                         type=ModelType.TEXT_GENERATION,  # dummy value, not used
                     )
-                    for model in original_response.data.get("data", [])
+                    for model in raw_response.data.get("data", [])
                 ]
             ),
         )

--- a/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
+++ b/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
@@ -3,9 +3,10 @@ from typing import Literal
 from pydantic import Field, ValidationError
 
 from api.domain import BaseModel
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.rerank.entities import Rerank, RerankResult
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.rerank import RerankAdapter
 
 
@@ -21,13 +22,13 @@ class TeiCreateRerankBody(BaseModel):
 class TeiRerankAdapter(RerankAdapter):
     TARGET_ENDPOINT_ROUTE = "/rerank"
 
-    def format_request(self, original_request: ProviderOriginalRequest) -> ProviderFormattedRequest | ProviderAdapterValidationRequestError:
+    def to_http_request(self, request: ProviderRequest) -> HttpProviderRequest | ProviderAdapterValidationRequestError:
         try:
             body = TeiCreateRerankBody.model_validate(
                 {
-                    "query": original_request.payload.query,
-                    "texts": original_request.payload.documents,
-                    **original_request.payload.model_dump(exclude_none=True),
+                    "query": request.payload.query,
+                    "texts": request.payload.documents,
+                    **request.payload.model_dump(exclude_none=True),
                 }
             ).model_dump()
         except ValidationError as e:
@@ -35,24 +36,24 @@ class TeiRerankAdapter(RerankAdapter):
 
         target_url = self._build_target_url(base_url=self.provider.url, target_endpoint_route=self.TARGET_ENDPOINT_ROUTE)
 
-        return ProviderFormattedRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, body=body)
+        return HttpProviderRequest(method=self.TARGET_ENDPOINT_METHOD, url=target_url, body=body)
 
-    def format_response(
+    def to_domain_response(
         self,
-        original_response: ProviderOriginalResponse,
-        original_request: ProviderOriginalRequest,
-    ) -> ProviderFormattedResponse | ProviderAdapterValidationResponseError:
-        results = sorted(original_response.data, key=lambda x: x["score"], reverse=True)[: original_request.payload.top_n]
+        raw_response: ProviderRawResponse,
+        request: ProviderRequest,
+    ) -> ProviderResponse | ProviderAdapterValidationResponseError:
+        results = sorted(raw_response.data, key=lambda x: x["score"], reverse=True)[: request.payload.top_n]
         for result in results:
             result["relevance_score"] = result.pop("score")
 
         results = [RerankResult(**result) for result in results]
-        request_id = self._extract_request_id(original_response=original_response)
-        data = Rerank(id=request_id, model=original_request.payload.model, results=results)
+        request_id = self._extract_request_id(raw_response=raw_response)
+        data = Rerank(id=request_id, model=request.payload.model, results=results)
 
         try:
             data = self.RESPONSE_TYPE.model_validate(data)
         except ValidationError as e:
             return ProviderAdapterValidationResponseError(provider_type=self.provider.type, errors=e.errors())
 
-        return ProviderFormattedResponse(id=request_id, data=data)
+        return ProviderResponse(id=request_id, data=data)

--- a/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
+++ b/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
@@ -6,7 +6,7 @@ from api.domain import BaseModel
 from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.rerank.entities import Rerank, RerankResult
-from api.infrastructure.http import HttpProviderRequest
+from api.infrastructure.http._httpproviderrequest import HttpProviderRequest
 from api.infrastructure.http.adapters.rerank import RerankAdapter
 
 

--- a/api/tests/integration/factories/tei.py
+++ b/api/tests/integration/factories/tei.py
@@ -4,7 +4,7 @@ import random
 import factory
 from faker import Faker
 
-from api.domain.provider.entities import ProviderFormattedRequest
+from api.infrastructure.http import HttpProviderRequest
 
 fake = Faker()
 
@@ -12,7 +12,7 @@ fake = Faker()
 # Formatted request factories
 class TeiFormattedModelRequestFactory(factory.DictFactory):
     class Meta:
-        model = ProviderFormattedRequest
+        model = HttpProviderRequest
 
     method = factory.Faker("random_element", elements=list(HTTPMethod))
     url = factory.Faker("url")

--- a/api/tests/integration/factories/vllm.py
+++ b/api/tests/integration/factories/vllm.py
@@ -4,7 +4,7 @@ import random
 import factory
 from faker import Faker
 
-from api.domain.provider.entities import ProviderFormattedRequest
+from api.infrastructure.http import HttpProviderRequest
 
 fake = Faker()
 
@@ -12,7 +12,7 @@ fake = Faker()
 # Formatted request factories
 class VllmFormattedModelRequestFactory(factory.DictFactory):
     class Meta:
-        model = ProviderFormattedRequest
+        model = HttpProviderRequest
 
     method = factory.Faker("random_element", elements=list(HTTPMethod))
     url = factory.Faker("url")

--- a/api/tests/integration/http/test_httpproviderclient.py
+++ b/api/tests/integration/http/test_httpproviderclient.py
@@ -1,38 +1,48 @@
 import base64
+from unittest.mock import patch
 from urllib.parse import urljoin
 
 import httpx
 import pytest
 import respx
 
+from api.domain.embeddings.entities import CreateEmbeddingsBody
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
-from api.domain.provider.entities import ProviderOriginalResponse, ProviderType
-from api.infrastructure.http import HttpProviderClient
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderType
+from api.domain.provider.errors import ProviderAdapterValidationRequestError, UnsupportedProviderEndpointError
+from api.infrastructure.http import HttpProviderAdapterBuilder, HttpProviderClient
+from api.infrastructure.http.adapters.models.vllm import VllmModelsAdapter
 from api.tests.integration.factories.mistral import MistralMetricsResponseFactory
 from api.tests.integration.factories.vllm import VllmEmbeddingsResponseFactory, VllmMetricsResponseFactory, VllmModelsResponseFactory
-from api.tests.unit.infrastructure.factories import ProviderFormattedRequestFactory
 from api.tests.unit.use_case.factories import ProviderFactory
+from api.utils.variables import EndpointRoute
 
 DEFAULT_PROVIDER_URL = "http://my-test-provider/"
 DEFAULT_MODEL_ID = "test/my-model"
 
 
-def provider_factory():
-    return ProviderFactory(
+def provider_factory(**overrides):
+    values = dict(
         type=ProviderType.VLLM,
         url=DEFAULT_PROVIDER_URL,
         key="test-key",
         timeout=1,
         model_name=DEFAULT_MODEL_ID,
     )
+    values.update(overrides)
+    return ProviderFactory(**values)
+
+
+def http_provider_client() -> HttpProviderClient:
+    return HttpProviderClient(adapter_builder=HttpProviderAdapterBuilder())
 
 
 @pytest.mark.asyncio(loop_scope="session")
 class TestHttpProviderClient:
     @respx.mock
-    async def test_forward_request_models(self):
+    async def test_forward_models(self):
         provider = provider_factory()
-        formatted_request = ProviderFormattedRequestFactory(vllm_models=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
 
         body = VllmModelsResponseFactory(model_id=DEFAULT_MODEL_ID)
         url = urljoin(DEFAULT_PROVIDER_URL, "/v1/models")
@@ -44,24 +54,21 @@ class TestHttpProviderClient:
             )
         )
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
-        assert isinstance(result, ProviderOriginalResponse)
+        assert isinstance(result, ProviderRawResponse)
         assert result.data == body
         assert result.text is None
         assert route.called is True
         assert route.calls[0].request.headers.get("Authorization") == "Bearer test-key"
 
     @respx.mock
-    async def test_forward_request_embeddings(self):
-        provider = ProviderFactory(
-            type=ProviderType.VLLM,
-            url=DEFAULT_PROVIDER_URL,
-            key=None,
-            timeout=1,
-            model_name=DEFAULT_MODEL_ID,
+    async def test_forward_embeddings(self):
+        provider = provider_factory(key=None)
+        request = ProviderRequest(
+            endpoint=EndpointRoute.EMBEDDINGS,
+            payload=CreateEmbeddingsBody(model="openweight-embeddings", input=["hello world"]),
         )
-        formatted_request = ProviderFormattedRequestFactory(vllm_embeddings=True, base_url=provider.url)
 
         body = VllmEmbeddingsResponseFactory(model_id=DEFAULT_MODEL_ID, dimensions=8)
         url = urljoin(DEFAULT_PROVIDER_URL, "/v1/embeddings")
@@ -73,18 +80,18 @@ class TestHttpProviderClient:
             )
         )
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
-        assert isinstance(result, ProviderOriginalResponse)
+        assert isinstance(result, ProviderRawResponse)
         assert result.data == body
         assert result.text is None
         assert route.called is True
         assert route.calls[0].request.headers.get("Authorization") is None
 
     @respx.mock
-    async def test_forward_request_metrics_text_response(self):
+    async def test_forward_metrics_text_response(self):
         provider = provider_factory()
-        formatted_request = ProviderFormattedRequestFactory(vllm_metrics=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.METRICS)
 
         body = VllmMetricsResponseFactory(model_name=DEFAULT_MODEL_ID, running=2.0, waiting=1.0)
         url = urljoin(DEFAULT_PROVIDER_URL, "/metrics")
@@ -96,24 +103,25 @@ class TestHttpProviderClient:
             )
         )
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
-        assert isinstance(result, ProviderOriginalResponse)
+        assert isinstance(result, ProviderRawResponse)
         assert result.data is None
         assert result.text == body["text"]
         assert route.called is True
         assert route.calls[0].request.headers.get("Authorization") == "Bearer test-key"
 
     @respx.mock
-    async def test_forward_request_uses_basic_auth_when_formatted_request_has_auth(self):
+    async def test_forward_uses_basic_auth_when_provider_has_basic_auth(self):
         provider = ProviderFactory(
             type=ProviderType.MISTRAL,
             url=DEFAULT_PROVIDER_URL,
             key=None,
             timeout=1,
             model_name=DEFAULT_MODEL_ID,
+            basic_auth={"username": "metrics", "password": "secret"},
         )
-        formatted_request = ProviderFormattedRequestFactory(mistral_metrics=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.METRICS)
 
         body = MistralMetricsResponseFactory(model_name=DEFAULT_MODEL_ID)
         url = urljoin(DEFAULT_PROVIDER_URL, "/metrics")
@@ -125,9 +133,9 @@ class TestHttpProviderClient:
             )
         )
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
-        assert isinstance(result, ProviderOriginalResponse)
+        assert isinstance(result, ProviderRawResponse)
         assert result.text == body["text"]
         assert route.called is True
         expected_auth = "Basic " + base64.b64encode(b"metrics:secret").decode()
@@ -146,27 +154,27 @@ class TestHttpProviderClient:
         ],
     )
     @respx.mock
-    async def test_forward_request_returns_too_busy_error_when_provider_request_fails(self, exception, expected_detail):
+    async def test_forward_returns_too_busy_error_when_provider_request_fails(self, exception, expected_detail):
         provider = provider_factory()
-        formatted_request = ProviderFormattedRequestFactory(vllm_models=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
 
         url = urljoin(DEFAULT_PROVIDER_URL, "/v1/models")
         route = respx.get(url=url).mock(side_effect=exception)
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
         assert result == TooBusyModelError(status_code=500, detail=expected_detail)
         assert route.called is True
 
     @respx.mock
-    async def test_forward_request_returns_unknown_error_when_provider_request_raises_unexpected_exception(self):
+    async def test_forward_returns_unknown_error_when_provider_request_raises_unexpected_exception(self):
         provider = provider_factory()
-        formatted_request = ProviderFormattedRequestFactory(vllm_models=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
 
         url = urljoin(DEFAULT_PROVIDER_URL, "/v1/models")
         route = respx.get(url=url).mock(side_effect=ValueError("invalid provider response"))
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
         assert result == UnknownModelError(status_code=500, detail="invalid provider response")
         assert route.called is True
@@ -201,14 +209,32 @@ class TestHttpProviderClient:
         ],
     )
     @respx.mock
-    async def test_forward_request_returns_status_code_error_when_provider_returns_error_response(self, response, expected_detail):
+    async def test_forward_returns_status_code_error_when_provider_returns_error_response(self, response, expected_detail):
         provider = provider_factory()
-        formatted_request = ProviderFormattedRequestFactory(vllm_models=True, base_url=provider.url)
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
 
         url = urljoin(DEFAULT_PROVIDER_URL, "/v1/models")
         route = respx.get(url=url).mock(return_value=response)
 
-        result = await HttpProviderClient().forward_request(provider=provider, formatted_request=formatted_request)
+        result = await http_provider_client().forward(provider=provider, request=request)
 
         assert result == StatusCodeModelError(status_code=response.status_code, detail=expected_detail)
         assert route.called is True
+
+    async def test_forward_returns_unsupported_provider_endpoint_error_when_adapter_is_missing(self):
+        provider = provider_factory(type=ProviderType.ALBERT)
+        request = ProviderRequest(endpoint=EndpointRoute.METRICS)
+
+        result = await http_provider_client().forward(provider=provider, request=request)
+
+        assert result == UnsupportedProviderEndpointError(endpoint=EndpointRoute.METRICS, provider_type=ProviderType.ALBERT)
+
+    async def test_forward_returns_request_validation_error_when_adapter_rejects_request(self):
+        provider = provider_factory()
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
+        validation_error = ProviderAdapterValidationRequestError(provider_type=provider.type, errors=[{"msg": "invalid"}])
+
+        with patch.object(VllmModelsAdapter, "to_http_request", return_value=validation_error):
+            result = await http_provider_client().forward(provider=provider, request=request)
+
+        assert result is validation_error

--- a/api/tests/integration/use_case/test_providercapabilitiesprobe.py
+++ b/api/tests/integration/use_case/test_providercapabilitiesprobe.py
@@ -32,7 +32,10 @@ def _mock_embeddings_response(respx_mock, body: dict, status_code: int) -> None:
 
 @pytest.fixture
 def probe() -> ProviderCapabilitiesProbe:
-    return ProviderCapabilitiesProbe(provider_client=HttpProviderClient(), provider_adapter_builder=HttpProviderAdapterBuilder())
+    return ProviderCapabilitiesProbe(
+        provider_client=HttpProviderClient(adapter_builder=HttpProviderAdapterBuilder()),
+        provider_adapter_builder=HttpProviderAdapterBuilder(),
+    )
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/api/tests/unit/infrastructure/factories.py
+++ b/api/tests/unit/infrastructure/factories.py
@@ -8,8 +8,9 @@ from openai.types import Embedding
 
 from api.domain.embeddings.entities import CreateEmbeddingsBody, Embeddings
 from api.domain.model.entities import Model, Models, ModelType
-from api.domain.provider.entities import BasicAuth, ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest
+from api.domain.provider.entities import BasicAuth, ProviderRequest, ProviderResponse
 from api.domain.rerank.entities import CreateRerankBody, Rerank, RerankResult
+from api.infrastructure.http import HttpProviderRequest
 from api.utils.variables import EndpointRoute
 
 fake = Faker()
@@ -26,9 +27,9 @@ def _random_embeddings_input() -> list[int] | list[list[int]] | str | list[str]:
     )
 
 
-class ProviderOriginalRequestFactory(factory.Factory):
+class ProviderRequestFactory(factory.Factory):
     class Meta:
-        model = ProviderOriginalRequest
+        model = ProviderRequest
 
     endpoint = factory.Faker("random_element", elements=list(EndpointRoute))
     payload = None
@@ -60,9 +61,9 @@ class ProviderOriginalRequestFactory(factory.Factory):
         )
 
 
-class ProviderFormattedRequestFactory(factory.Factory):
+class HttpProviderRequestFactory(factory.Factory):
     class Meta:
-        model = ProviderFormattedRequest
+        model = HttpProviderRequest
         exclude = ["base_url"]
 
     base_url = "https://provider.test/"
@@ -104,7 +105,7 @@ class ProviderFormattedRequestFactory(factory.Factory):
 
 class ProviderEmbeddingsFormattedResponseFactory(factory.Factory):
     class Meta:
-        model = ProviderFormattedResponse
+        model = ProviderResponse
 
     dimensions = factory.Faker("random_int", min=1, max=1024)
 
@@ -138,7 +139,7 @@ class ProviderModelResponseFactory(factory.Factory):
 
 class ProviderModelsFormattedResponseFactory(factory.Factory):
     class Meta:
-        model = ProviderFormattedResponse
+        model = ProviderResponse
         exclude = ["count"]
 
     count: int = 1
@@ -148,7 +149,7 @@ class ProviderModelsFormattedResponseFactory(factory.Factory):
 
 class ProviderRerankFormattedResponseFactory(factory.Factory):
     class Meta:
-        model = ProviderFormattedResponse
+        model = ProviderResponse
 
     data = factory.LazyAttribute(
         lambda self: Rerank(

--- a/api/tests/unit/infrastructure/http/adapters/test_audiotranscriptionsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_audiotranscriptionsadapter.py
@@ -2,7 +2,7 @@ import base64
 from tempfile import SpooledTemporaryFile
 
 from api.domain.audio.entities import AudioTranscriptionsResponseFormat, CreateAudioTranscriptionsFile, CreateAudioTranscriptionsForm
-from api.domain.provider.entities import ProviderOriginalRequest, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderType
 from api.infrastructure.http.adapters.audio import AudioTranscriptionsAdapter
 from api.infrastructure.http.adapters.audio.mistral import MistralAudioTranscriptionsAdapter
 from api.tests.unit.use_case.factories import ProviderFactory
@@ -18,7 +18,7 @@ def mock_audio_file() -> SpooledTemporaryFile:
     return file
 
 
-def _original_request(**overrides) -> ProviderOriginalRequest:
+def _original_request(**overrides) -> ProviderRequest:
     form = CreateAudioTranscriptionsForm(
         file=CreateAudioTranscriptionsFile(name="speech.mp3", file=mock_audio_file(), content_type="audio/mpeg", size=11),
         model="audio-router",
@@ -30,10 +30,9 @@ def _original_request(**overrides) -> ProviderOriginalRequest:
     payload = {
         "endpoint": EndpointRoute.AUDIO_TRANSCRIPTIONS,
         "payload": form,
-        "files": form.get_files(),
     }
     payload.update(overrides)
-    return ProviderOriginalRequest(**payload)
+    return ProviderRequest(**payload)
 
 
 class TestAudioTranscriptionsAdapter:
@@ -44,7 +43,7 @@ class TestAudioTranscriptionsAdapter:
         original_request = _original_request()
 
         # Act
-        result = adapter.format_request(original_request=original_request)
+        result = adapter.to_http_request(request=original_request)
 
         # Assert
         assert result.form["model"] == "whisper-1"
@@ -56,10 +55,10 @@ class TestAudioTranscriptionsAdapter:
         # Arrange
         provider = ProviderFactory(type=ProviderType.VLLM, url="https://vllm.test", model_name="whisper-1")
         adapter = AudioTranscriptionsAdapter(provider=provider)
-        original_response = ProviderOriginalResponse(data={"text": "hello world"})
+        original_response = ProviderRawResponse(data={"text": "hello world"})
 
         # Act
-        result = adapter.format_response(original_request=_original_request(), original_response=original_response)
+        result = adapter.to_domain_response(request=_original_request(), raw_response=original_response)
 
         # Assert
         assert result.data.text == "hello world"
@@ -73,7 +72,7 @@ class TestMistralAudioTranscriptionsAdapter:
         adapter = MistralAudioTranscriptionsAdapter(provider=provider)
 
         # Act
-        result = adapter.format_request(original_request=_original_request())
+        result = adapter.to_http_request(request=_original_request())
 
         # Assert
         assert result.url == "https://mistral.test/v1/chat/completions"

--- a/api/tests/unit/infrastructure/http/adapters/test_embeddingsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_embeddingsadapter.py
@@ -6,13 +6,14 @@ from unittest.mock import Mock, patch
 import pytest
 
 from api.domain.embeddings.entities import Embeddings, EncodingFormat
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import ProviderRawResponse, ProviderResponse, ProviderType
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.embeddings.tei import TeiEmbeddingsAdapter
 from api.infrastructure.http.adapters.embeddings.vllm import VllmEmbeddingsAdapter
 from api.tests.integration.factories.tei import TeiEmbeddingsResponseFactory
 from api.tests.integration.factories.vllm import VllmEmbeddingsResponseFactory
-from api.tests.unit.infrastructure.factories import ProviderOriginalRequestFactory
+from api.tests.unit.infrastructure.factories import ProviderRequestFactory
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.utils.variables import EndpointRoute
 
@@ -123,7 +124,7 @@ class TestEmbeddingsAdapter:
     )
     def test_extract_request_id_with_id(self, adapter):
         # Arrange
-        original_response = ProviderOriginalResponse(data={"id": "abc"})
+        original_response = ProviderRawResponse(data={"id": "abc"})
 
         # Act
         result = adapter._extract_request_id(original_response)
@@ -138,7 +139,7 @@ class TestEmbeddingsAdapter:
     )
     def test_extract_request_id_without_id(self, adapter):
         # Arrange
-        original_response = ProviderOriginalResponse(data={})
+        original_response = ProviderRawResponse(data={})
 
         # Act
         with patch("api.infrastructure.http.adapters._httpprovideradapter.uuid4", return_value="123-456-789"):
@@ -152,13 +153,13 @@ class TestEmbeddingsAdapter:
         argvalues=["tei_embeddings_adapter", "vllm_embeddings_adapter"],
         indirect=["adapter"],
     )
-    def test_format_request_preserve_extra_fields(self, adapter):
+    def test_to_http_request_preserve_extra_fields(self, adapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
         original_request.payload.extra_field = "extra_value"
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.body["extra_field"] == "extra_value"
@@ -169,15 +170,15 @@ class TestEmbeddingsAdapter:
         argvalues=[("tei_embeddings_adapter", "test-tei-model"), ("vllm_embeddings_adapter", "test-vllm-model")],
         indirect=["adapter"],
     )
-    def test_format_request_replace_model_by_provider_model_name(self, adapter, provider_model_name):
+    def test_to_http_request_replace_model_by_provider_model_name(self, adapter, provider_model_name):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedRequest)
+        assert isinstance(result, HttpProviderRequest)
         assert "model" in result.body
         assert result.body["model"] == provider_model_name
 
@@ -186,13 +187,13 @@ class TestEmbeddingsAdapter:
         argvalues=["tei_embeddings_adapter", "vllm_embeddings_adapter"],
         indirect=["adapter"],
     )
-    def test_format_request_excludes_none_fields(self, adapter):
+    def test_to_http_request_excludes_none_fields(self, adapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
         original_request.payload.dimensions = None
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert "dimensions" not in result.body
@@ -204,12 +205,12 @@ class TestEmbeddingsAdapter:
         argvalues=[("tei_embeddings_adapter", HTTPMethod.POST), ("vllm_embeddings_adapter", HTTPMethod.POST)],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_method(self, adapter, method):
+    def test_to_http_request_return_correct_method(self, adapter, method):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.method == method
@@ -219,12 +220,12 @@ class TestEmbeddingsAdapter:
         argvalues=[("tei_embeddings_adapter", "https://tei.test/v1/embeddings"), ("vllm_embeddings_adapter", "https://vllm.test/v1/embeddings")],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_url(self, adapter, url):
+    def test_to_http_request_return_correct_url(self, adapter, url):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.url == url
@@ -237,17 +238,17 @@ class TestEmbeddingsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_correctly(self, adapter, response_data):
+    def test_to_domain_response_correctly(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(embeddings=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Embeddings)
         assert len(result.data.data) == 1
         assert result.data.data[0].embedding == response_data["data"][0]["embedding"]
@@ -259,22 +260,22 @@ class TestEmbeddingsAdapter:
         argvalues=["tei_embeddings_adapter", "vllm_embeddings_adapter"],
         indirect=["adapter"],
     )
-    def test_format_response_decodes_base64_embeddings(self, adapter):
+    def test_to_domain_response_decodes_base64_embeddings(self, adapter):
         # Arrange
         embedding = [0.1, 0.2, 0.3]
         response_data = TeiEmbeddingsResponseFactory(dimensions=3)
         response_data["data"][0]["embedding"] = base64.b64encode(array.array("f", embedding).tobytes()).decode()
 
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
+        original_request = ProviderRequestFactory(embeddings=True)
         original_request.payload.encoding_format = EncodingFormat.BASE64
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Embeddings)
         assert result.data.data[0].embedding == pytest.approx(embedding)
 
@@ -286,14 +287,14 @@ class TestEmbeddingsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_preserve_extra_fields(self, adapter, response_data):
+    def test_to_domain_response_preserve_extra_fields(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(embeddings=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
         assert result.data.extra_field == "extra_value"
@@ -303,11 +304,11 @@ class TestEmbeddingsAdapter:
         argvalues=["tei_embeddings_adapter", "vllm_embeddings_adapter"],
         indirect=["adapter"],
     )
-    def test_format_response_returns_validation_error_on_bad_data(self, adapter):
-        original_request = ProviderOriginalRequestFactory(embeddings=True)
-        original_response = ProviderOriginalResponse(data={"data": "invalid"})
+    def test_to_domain_response_returns_validation_error_on_bad_data(self, adapter):
+        original_request = ProviderRequestFactory(embeddings=True)
+        original_response = ProviderRawResponse(data={"data": "invalid"})
 
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         assert result.provider_type == adapter.provider.type
         assert isinstance(result, ProviderAdapterValidationResponseError)

--- a/api/tests/unit/infrastructure/http/adapters/test_metricsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_metricsadapter.py
@@ -3,13 +3,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from api.domain.provider.entities import BasicAuth, ProviderFormattedResponse, ProviderMetrics, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import BasicAuth, ProviderMetrics, ProviderRawResponse, ProviderResponse, ProviderType
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
 from api.infrastructure.http.adapters.metrics.mistral import MistralMetricsAdapter
 from api.infrastructure.http.adapters.metrics.vllm import VllmMetricsAdapter
 from api.tests.integration.factories.mistral import MistralMetricsResponseFactory
 from api.tests.integration.factories.vllm import VllmMetricsResponseFactory
-from api.tests.unit.infrastructure.factories import ProviderOriginalRequestFactory
+from api.tests.unit.infrastructure.factories import ProviderRequestFactory
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.utils.variables import EndpointRoute
 
@@ -139,12 +139,12 @@ class TestMetricsAdapter:
         argvalues=[("vllm_metrics_adapter", HTTPMethod.GET), ("mistral_metrics_adapter", HTTPMethod.GET)],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_method(self, adapter, method):
+    def test_to_http_request_return_correct_method(self, adapter, method):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.method == method
@@ -157,12 +157,12 @@ class TestMetricsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_url(self, adapter, url):
+    def test_to_http_request_return_correct_url(self, adapter, url):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.url == url
@@ -175,45 +175,45 @@ class TestMetricsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_has_no_usage(self, adapter, response_data):
+    def test_to_domain_response_has_no_usage(self, adapter, response_data):
         # Arrange
-        original_response = ProviderOriginalResponse(text=response_data["text"])
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_response = ProviderRawResponse(text=response_data["text"])
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, ProviderMetrics)
         assert getattr(result.data, "usage", "not found") == "not found"
 
-    def test_format_request_has_no_auth(self, vllm_metrics_adapter: VllmMetricsAdapter):
+    def test_to_http_request_has_no_auth(self, vllm_metrics_adapter: VllmMetricsAdapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = vllm_metrics_adapter.format_request(original_request)
+        result = vllm_metrics_adapter.to_http_request(original_request)
 
         # Assert
         assert result.auth is None
 
-    def test_format_request_includes_provider_basic_auth(self, mistral_metrics_adapter: MistralMetricsAdapter, mistral_provider):
+    def test_to_http_request_includes_provider_basic_auth(self, mistral_metrics_adapter: MistralMetricsAdapter, mistral_provider):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = mistral_metrics_adapter.format_request(original_request)
+        result = mistral_metrics_adapter.to_http_request(original_request)
 
         # Assert
         assert result.auth == mistral_provider.basic_auth
 
-    def test_format_request_has_no_auth_when_provider_has_none(self, mistral_metrics_adapter_without_auth: MistralMetricsAdapter):
+    def test_to_http_request_has_no_auth_when_provider_has_none(self, mistral_metrics_adapter_without_auth: MistralMetricsAdapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = mistral_metrics_adapter_without_auth.format_request(original_request)
+        result = mistral_metrics_adapter_without_auth.to_http_request(original_request)
 
         # Assert
         assert result.auth is None
@@ -226,16 +226,16 @@ class TestMetricsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_parses_prometheus_text(self, adapter, model_name, running, waiting):
+    def test_to_domain_response_parses_prometheus_text(self, adapter, model_name, running, waiting):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
-        original_response = ProviderOriginalResponse(text=build_metrics_text(model_name=model_name, running=running, waiting=waiting))
+        original_request = ProviderRequestFactory(metrics=True)
+        original_response = ProviderRawResponse(text=build_metrics_text(model_name=model_name, running=running, waiting=waiting))
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, ProviderMetrics)
         assert result.data.running_requests == running
         assert result.data.waiting_requests == waiting
@@ -248,10 +248,10 @@ class TestMetricsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_sums_samples_for_same_model(self, adapter, model_name):
+    def test_to_domain_response_sums_samples_for_same_model(self, adapter, model_name):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
-        original_response = ProviderOriginalResponse(
+        original_request = ProviderRequestFactory(metrics=True)
+        original_response = ProviderRawResponse(
             text=(
                 f'vllm:num_requests_running{{model_name="{model_name}"}} 2.0\n'
                 f'vllm:num_requests_running{{model_name="{model_name}"}} 3.0\n'
@@ -263,10 +263,10 @@ class TestMetricsAdapter:
         )
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert result.data.running_requests == 5.0
         assert result.data.waiting_requests == 5.0
 
@@ -275,13 +275,13 @@ class TestMetricsAdapter:
         argvalues=["vllm_metrics_adapter", "mistral_metrics_adapter"],
         indirect=["adapter"],
     )
-    def test_format_response_returns_validation_error_on_invalid_text(self, adapter):
+    def test_to_domain_response_returns_validation_error_on_invalid_text(self, adapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(metrics=True)
-        original_response = ProviderOriginalResponse(text="not valid prometheus text")
+        original_request = ProviderRequestFactory(metrics=True)
+        original_response = ProviderRawResponse(text="not valid prometheus text")
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
         assert isinstance(result, ProviderAdapterValidationResponseError)
@@ -296,21 +296,21 @@ class TestMetricsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_extracts_request_id(self, adapter, response_data):
+    def test_to_domain_response_extracts_request_id(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_response = ProviderOriginalResponse(text=response_data["text"])
-        original_request = ProviderOriginalRequestFactory(metrics=True)
+        original_response = ProviderRawResponse(text=response_data["text"])
+        original_request = ProviderRequestFactory(metrics=True)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, ProviderMetrics)
         assert result.id == "req-123"
         assert getattr(result.data, "id", "not found") == "not found"
-        adapter._extract_request_id.assert_called_once_with(original_response=original_response)
+        adapter._extract_request_id.assert_called_once_with(raw_response=original_response)
 
     @pytest.mark.parametrize(
         argnames=("adapter"),

--- a/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
@@ -5,8 +5,8 @@ import pytest
 
 from api.domain.model.entities import ModelCosts, Models, ModelType
 from api.domain.provider.entities import (
-    ProviderFormattedResponse,
-    ProviderOriginalResponse,
+    ProviderRawResponse,
+    ProviderResponse,
     ProviderType,
 )
 from api.infrastructure.http.adapters.models.albert import AlbertModelsAdapter
@@ -19,7 +19,7 @@ from api.tests.integration.factories.mistral import MistralModelsResponseFactory
 from api.tests.integration.factories.openai import OpenaiModelsResponseFactory
 from api.tests.integration.factories.tei import TeiModelsResponseFactory
 from api.tests.integration.factories.vllm import VllmModelsResponseFactory
-from api.tests.unit.infrastructure.factories import ProviderOriginalRequestFactory
+from api.tests.unit.infrastructure.factories import ProviderRequestFactory
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.utils.variables import EndpointRoute
 
@@ -176,12 +176,12 @@ class TestModelsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_method(self, adapter, method):
+    def test_to_http_request_return_correct_method(self, adapter, method):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(models=True)
+        original_request = ProviderRequestFactory(models=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.method == method
@@ -197,12 +197,12 @@ class TestModelsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_url(self, adapter, url):
+    def test_to_http_request_return_correct_url(self, adapter, url):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(models=True)
+        original_request = ProviderRequestFactory(models=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.url == url
@@ -218,30 +218,30 @@ class TestModelsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_has_no_usage(self, adapter, response_data):
+    def test_to_domain_response_has_no_usage(self, adapter, response_data):
         # Arrange
-        original_response = ProviderOriginalResponse(data=response_data)
-        original_request = ProviderOriginalRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert getattr(result.data, "usage", "not found") == "not found"
 
-    def test_format_response_correctly_when_provider_is_albert(self, albert_models_adapter: AlbertModelsAdapter):
+    def test_to_domain_response_correctly_when_provider_is_albert(self, albert_models_adapter: AlbertModelsAdapter):
         # Arrange
         response_data = AlbertModelsResponseFactory(count=3)
-        original_request = ProviderOriginalRequestFactory(models=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = albert_models_adapter.format_response(original_response=original_response, original_request=original_request)
+        result = albert_models_adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
@@ -250,17 +250,17 @@ class TestModelsAdapter:
         assert result.data.data[0].aliases == response_data["data"][0]["aliases"]
         assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
-    def test_format_response_correctly_when_provider_is_openai(self, openai_models_adapter: OpenaiModelsAdapter):
+    def test_to_domain_response_correctly_when_provider_is_openai(self, openai_models_adapter: OpenaiModelsAdapter):
         # Arrange
         response_data = OpenaiModelsResponseFactory(count=3)
-        original_request = ProviderOriginalRequestFactory(models=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = openai_models_adapter.format_response(original_response=original_response, original_request=original_request)
+        result = openai_models_adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
@@ -270,17 +270,17 @@ class TestModelsAdapter:
         assert result.data.data[0].aliases == []
         assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
-    def test_format_response_correctly_when_provider_is_mistral(self, mistral_models_adapter: MistralModelsAdapter):
+    def test_to_domain_response_correctly_when_provider_is_mistral(self, mistral_models_adapter: MistralModelsAdapter):
         # Arrange
         response_data = MistralModelsResponseFactory(count=3)
-        original_request = ProviderOriginalRequestFactory(models=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = mistral_models_adapter.format_response(original_response=original_response, original_request=original_request)
+        result = mistral_models_adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
@@ -290,17 +290,17 @@ class TestModelsAdapter:
         assert result.data.data[0].aliases == []
         assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
-    def test_format_response_correctly_when_provider_is_tei(self, tei_models_adapter: TeiModelsAdapter):
+    def test_to_domain_response_correctly_when_provider_is_tei(self, tei_models_adapter: TeiModelsAdapter):
         # Arrange
         response_data = TeiModelsResponseFactory(count=1)
-        original_request = ProviderOriginalRequestFactory(models=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = tei_models_adapter.format_response(original_response=original_response, original_request=original_request)
+        result = tei_models_adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 1
         assert result.data.data[0].id == response_data["model_id"]
@@ -310,17 +310,17 @@ class TestModelsAdapter:
         assert result.data.data[0].aliases == []
         assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
-    def test_format_response_correctly_when_provider_is_vllm(self, vllm_models_adapter: VllmModelsAdapter):
+    def test_to_domain_response_correctly_when_provider_is_vllm(self, vllm_models_adapter: VllmModelsAdapter):
         # Arrange
         response_data = VllmModelsResponseFactory(count=1)
-        original_request = ProviderOriginalRequestFactory(models=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = vllm_models_adapter.format_response(original_response=original_response, original_request=original_request)
+        result = vllm_models_adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 1
         assert result.data.data[0].id == response_data["data"][0]["id"]
@@ -341,21 +341,21 @@ class TestModelsAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_extracts_request_id(self, adapter, response_data):
+    def test_to_domain_response_extracts_request_id(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_response = ProviderOriginalResponse(data=response_data)
-        original_request = ProviderOriginalRequestFactory(models=True)
+        original_response = ProviderRawResponse(data=response_data)
+        original_request = ProviderRequestFactory(models=True)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Models)
         assert result.id == "req-123"
         assert getattr(result.data, "id", "not found") == "not found"
-        adapter._extract_request_id.assert_called_once_with(original_response=original_response)
+        adapter._extract_request_id.assert_called_once_with(raw_response=original_response)
 
     @pytest.mark.parametrize(
         argnames=("adapter"),

--- a/api/tests/unit/infrastructure/http/adapters/test_rerankadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_rerankadapter.py
@@ -4,14 +4,15 @@ from unittest.mock import Mock, patch
 from pydantic import BaseModel
 import pytest
 
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import ProviderRawResponse, ProviderResponse, ProviderType
 from api.domain.provider.errors import ProviderAdapterValidationResponseError
 from api.domain.rerank.entities import Rerank
+from api.infrastructure.http import HttpProviderRequest
 from api.infrastructure.http.adapters.rerank.tei import TeiRerankAdapter
 from api.infrastructure.http.adapters.rerank.vllm import VllmRerankAdapter
 from api.tests.integration.factories.tei import TeiRerankResponseFactory
 from api.tests.integration.factories.vllm import VllmRerankResponseFactory
-from api.tests.unit.infrastructure.factories import ProviderOriginalRequestFactory
+from api.tests.unit.infrastructure.factories import ProviderRequestFactory
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.utils.variables import EndpointRoute
 
@@ -122,7 +123,7 @@ class TestRerankAdapter:
     )
     def test_extract_request_id_with_id(self, adapter):
         # Arrange
-        original_response = ProviderOriginalResponse(data={"id": "abc"})
+        original_response = ProviderRawResponse(data={"id": "abc"})
 
         # Act
         result = adapter._extract_request_id(original_response)
@@ -137,7 +138,7 @@ class TestRerankAdapter:
     )
     def test_extract_request_id_without_id(self, adapter):
         # Arrange
-        original_response = ProviderOriginalResponse(data={})
+        original_response = ProviderRawResponse(data={})
 
         # Act
         with patch("api.infrastructure.http.adapters._httpprovideradapter.uuid4", return_value="123-456-789"):
@@ -151,13 +152,13 @@ class TestRerankAdapter:
         argvalues=["tei_rerank_adapter", "vllm_rerank_adapter"],
         indirect=["adapter"],
     )
-    def test_format_request_preserve_extra_fields(self, adapter):
+    def test_to_http_request_preserve_extra_fields(self, adapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
         original_request.payload.extra_field = "extra_value"
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.body["extra_field"] == "extra_value"
@@ -168,15 +169,15 @@ class TestRerankAdapter:
         argvalues=[("vllm_rerank_adapter", "test-vllm-model")],
         indirect=["adapter"],
     )
-    def test_format_request_replace_model_by_provider_model_name(self, adapter, provider_model_name):
+    def test_to_http_request_replace_model_by_provider_model_name(self, adapter, provider_model_name):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedRequest)
+        assert isinstance(result, HttpProviderRequest)
         assert "model" in result.body
         assert result.body["model"] == provider_model_name
 
@@ -185,13 +186,13 @@ class TestRerankAdapter:
         argvalues=["tei_rerank_adapter", "vllm_rerank_adapter"],
         indirect=["adapter"],
     )
-    def test_format_request_excludes_none_fields(self, adapter):
+    def test_to_http_request_excludes_none_fields(self, adapter):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
         original_request.payload.top_n = None
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert "top_n" not in result.body
@@ -202,12 +203,12 @@ class TestRerankAdapter:
         argvalues=[("tei_rerank_adapter", HTTPMethod.POST), ("vllm_rerank_adapter", HTTPMethod.POST)],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_method(self, adapter, method):
+    def test_to_http_request_return_correct_method(self, adapter, method):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.method == method
@@ -217,12 +218,12 @@ class TestRerankAdapter:
         argvalues=[("tei_rerank_adapter", "https://tei.test/rerank"), ("vllm_rerank_adapter", "https://vllm.test/v2/rerank")],
         indirect=["adapter"],
     )
-    def test_format_request_return_correct_url(self, adapter, url):
+    def test_to_http_request_return_correct_url(self, adapter, url):
         # Arrange
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
 
         # Act
-        result = adapter.format_request(original_request)
+        result = adapter.to_http_request(original_request)
 
         # Assert
         assert result.url == url
@@ -235,18 +236,18 @@ class TestRerankAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_correctly_with_top_n(self, adapter, response_data):
+    def test_to_domain_response_correctly_with_top_n(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
         original_request.payload.top_n = None
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Rerank)
         assert len(result.data.results) == 3
         assert result.data.results[0].relevance_score == 1
@@ -262,18 +263,18 @@ class TestRerankAdapter:
         ],
         indirect=["adapter"],
     )
-    def test_format_response_correctly_without_top_n(self, adapter, response_data):
+    def test_to_domain_response_correctly_without_top_n(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(rerank=True)
+        original_request = ProviderRequestFactory(rerank=True)
         original_request.payload.top_n = 2
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert isinstance(result.data, Rerank)
         assert len(result.data.results) == 2
         assert result.data.results[0].relevance_score == 1
@@ -286,14 +287,14 @@ class TestRerankAdapter:
         argvalues=[("vllm_rerank_adapter", VllmRerankResponseFactory(extra_field="extra_value"))],
         indirect=["adapter"],
     )
-    def test_format_response_preserve_extra_fields(self, adapter, response_data):
+    def test_to_domain_response_preserve_extra_fields(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(rerank=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(rerank=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
         assert result.data.extra_field == "extra_value"
@@ -303,14 +304,14 @@ class TestRerankAdapter:
         argvalues=[("tei_rerank_adapter", TeiRerankResponseFactory(return_text=True, sentences=["document1", "document1"]))],
         indirect=["adapter"],
     )
-    def test_format_response_preserve_extra_fields_for_tei(self, adapter, response_data):
+    def test_to_domain_response_preserve_extra_fields_for_tei(self, adapter, response_data):
         # Arrange
         adapter._extract_request_id = Mock(return_value="req-123")
-        original_request = ProviderOriginalRequestFactory(rerank=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(rerank=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
         assert result.data.results[0].text == "document1"
@@ -320,17 +321,17 @@ class TestRerankAdapter:
         argvalues=[("tei_rerank_adapter", TeiRerankResponseFactory()), ("vllm_rerank_adapter", VllmRerankResponseFactory())],
         indirect=["adapter"],
     )
-    def test_format_response_returns_validation_error_on_bad_data(self, adapter, response_data):
+    def test_to_domain_response_returns_validation_error_on_bad_data(self, adapter, response_data):
         # Arrange
         class _InvalidResponsePayload(BaseModel):
             id: int
 
         adapter.RESPONSE_TYPE = _InvalidResponsePayload
-        original_request = ProviderOriginalRequestFactory(rerank=True)
-        original_response = ProviderOriginalResponse(data=response_data)
+        original_request = ProviderRequestFactory(rerank=True)
+        original_response = ProviderRawResponse(data=response_data)
 
         # Act
-        result = adapter.format_response(original_response=original_response, original_request=original_request)
+        result = adapter.to_domain_response(raw_response=original_response, request=original_request)
 
         # Assert
         assert result.provider_type == adapter.provider.type

--- a/api/tests/unit/use_case/audio/test_createaudiotranscriptionsusecase.py
+++ b/api/tests/unit/use_case/audio/test_createaudiotranscriptionsusecase.py
@@ -10,7 +10,7 @@ from api.domain.audio.entities import (
 )
 from api.domain.audio.errors import AudioFileSizeLimitExceededError
 from api.domain.model.entities import ModelType as RouterType
-from api.domain.provider.entities import ProviderFormattedResponse
+from api.domain.provider.entities import ProviderResponse
 from api.domain.router.entities import RouterRateLimitState
 from api.domain.usage import UsageRecorder
 from api.tests.unit.use_case.factories import AuthenticatedUserFactory, RouterFactory
@@ -111,7 +111,7 @@ class TestCreateAudioTranscriptionsUseCase:
 class TestCreateAudioTranscriptionsUseCaseExecute:
     @pytest.fixture(autouse=True)
     def mock_collaborator_methods(self, use_case, router, sample_transcriptions):
-        formatted_response = ProviderFormattedResponse(id=sample_transcriptions.id, data=sample_transcriptions)
+        formatted_response = ProviderResponse(id=sample_transcriptions.id, data=sample_transcriptions)
         use_case._resolve_router = AsyncMock(return_value=router)
         use_case._check_rate_limits = AsyncMock(return_value=RouterRateLimitState.admin_rate_limit_state())
         use_case._send_request = AsyncMock(return_value=formatted_response)
@@ -160,7 +160,7 @@ class TestCreateAudioTranscriptionsUseCaseExecute:
         command = make_command(admin_user, response_format=AudioTranscriptionsResponseFormat.TEXT)
         rate_limit_state = RouterRateLimitState.admin_rate_limit_state()
         use_case._check_rate_limits.return_value = rate_limit_state
-        use_case._send_request.return_value = ProviderFormattedResponse(id="audio-1", text="hello world")
+        use_case._send_request.return_value = ProviderResponse(id="audio-1", text="hello world")
 
         # Act
         result = await use_case.execute(command=command)

--- a/api/tests/unit/use_case/health/test_gethealthmodelsusecase.py
+++ b/api/tests/unit/use_case/health/test_gethealthmodelsusecase.py
@@ -1,4 +1,3 @@
-from http import HTTPMethod
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -7,10 +6,9 @@ from api.domain.model.entities import HealthStatus, ModelHealthStatus
 from api.domain.model.errors import StatusCodeModelError
 from api.domain.provider.entities import (
     Provider,
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
     ProviderMetrics,
-    ProviderOriginalResponse,
+    ProviderRawResponse,
+    ProviderResponse,
     ProviderType,
 )
 from api.domain.provider.errors import ProviderAdapterValidationResponseError, UnsupportedProviderEndpointError
@@ -91,20 +89,19 @@ def configure_metrics(
     *,
     waiting: float = 0.0,
     running: float = 0.0,
-    format_response_result: ProviderFormattedResponse | ProviderAdapterValidationResponseError | None = None,
+    to_domain_response_result: ProviderResponse | ProviderAdapterValidationResponseError | None = None,
 ):
     adapter = MistralMetricsAdapter(provider=provider) if provider.type == ProviderType.MISTRAL else VllmMetricsAdapter(provider=provider)
-    adapter.format_response = MagicMock(
-        return_value=format_response_result
-        or ProviderFormattedResponse(id="req-123", data=ProviderMetrics(waiting_requests=waiting, running_requests=running))
+    adapter.to_domain_response = MagicMock(
+        return_value=to_domain_response_result
+        or ProviderResponse(id="req-123", data=ProviderMetrics(waiting_requests=waiting, running_requests=running))
     )
     provider_adapter_builder.build.return_value = adapter
-    provider_client.forward_request.return_value = ProviderOriginalResponse(text=METRICS_TEXT)
+    provider_client.forward.return_value = ProviderRawResponse(text=METRICS_TEXT)
 
 
 def configure_models_fallback(provider_adapter_builder, provider_client, *, models_response):
     models_adapter = MagicMock()
-    models_adapter.format_request.return_value = ProviderFormattedRequest(method=HTTPMethod.GET, url="https://provider.test/v1/models")
 
     def build_side_effect(endpoint, provider):
         if endpoint == EndpointRoute.METRICS:
@@ -112,7 +109,7 @@ def configure_models_fallback(provider_adapter_builder, provider_client, *, mode
         return models_adapter
 
     provider_adapter_builder.build.side_effect = build_side_effect
-    provider_client.forward_request.return_value = models_response
+    provider_client.forward.return_value = models_response
 
 
 class TestGetHealthModelsUseCase:
@@ -207,7 +204,7 @@ class TestGetHealthModelsUseCase:
         assert len(result.models) == 1
         assert result.models[0].status == HealthStatus.GREEN
         provider_adapter_builder.build.assert_called_once_with(endpoint=EndpointRoute.METRICS, provider=provider)
-        provider_client.forward_request.assert_called_once()
+        provider_client.forward.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_should_return_yellow_when_vllm_has_waiting_requests(
@@ -345,7 +342,7 @@ class TestGetHealthModelsUseCase:
         provider = ProviderFactory(id=1, router_id=1, type=ProviderType.VLLM)
         provider_repository.get_all_providers.return_value = [provider]
         configure_metrics(provider_adapter_builder, provider_client, provider)
-        provider_client.forward_request.return_value = StatusCodeModelError(status_code=500, detail="error")
+        provider_client.forward.return_value = StatusCodeModelError(status_code=500, detail="error")
 
         # Act
         result = await use_case.execute(command=default_command)
@@ -373,7 +370,7 @@ class TestGetHealthModelsUseCase:
             provider_adapter_builder,
             provider_client,
             provider,
-            format_response_result=ProviderAdapterValidationResponseError(provider_type=provider.type, errors=[{"msg": "invalid"}]),
+            to_domain_response_result=ProviderAdapterValidationResponseError(provider_type=provider.type, errors=[{"msg": "invalid"}]),
         )
 
         # Act
@@ -401,7 +398,7 @@ class TestGetHealthModelsUseCase:
         configure_models_fallback(
             provider_adapter_builder,
             provider_client,
-            models_response=ProviderOriginalResponse(data={"data": []}),
+            models_response=ProviderRawResponse(data={"data": []}),
         )
 
         # Act
@@ -411,7 +408,7 @@ class TestGetHealthModelsUseCase:
         assert isinstance(result, GetHealthModelsUseCaseSuccess)
         assert result.models[0].status == HealthStatus.GREEN
         assert provider_adapter_builder.build.call_count == 2
-        provider_client.forward_request.assert_called_once()
+        provider_client.forward.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_should_return_red_when_models_fallback_fails(
@@ -495,4 +492,4 @@ class TestGetHealthModelsUseCase:
 
         # Assert
         provider_adapter_builder.build.assert_called_once_with(endpoint=EndpointRoute.METRICS, provider=accessible_provider)
-        provider_client.forward_request.assert_called_once()
+        provider_client.forward.assert_called_once()

--- a/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
+++ b/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
@@ -8,7 +8,7 @@ from api.domain.model.entities import Model, Models
 from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import ModelNotFoundError, StatusCodeModelError
 from api.domain.provider import ProviderAdapter, ProviderAdapterBuilder, ProviderClient
-from api.domain.provider.entities import ProviderCapabilities, ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import ProviderCapabilities, ProviderRawResponse, ProviderResponse, ProviderType
 from api.domain.provider.errors import ProviderInvalidResponseError, ProviderNotReachableError
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.use_cases.services import ProviderCapabilitiesProbe
@@ -46,12 +46,12 @@ def model_entity(model_id: str = DEFAULT_MODEL_ID, aliases: list[str] | None = N
     )
 
 
-def models_formatted_response(*models: Model) -> ProviderFormattedResponse:
-    return ProviderFormattedResponse(id="req-123", data=Models(data=list(models)))
+def models_formatted_response(*models: Model) -> ProviderResponse:
+    return ProviderResponse(id="req-123", data=Models(data=list(models)))
 
 
-def embeddings_formatted_response(dimensions: int = 3) -> ProviderFormattedResponse:
-    return ProviderFormattedResponse(
+def embeddings_formatted_response(dimensions: int = 3) -> ProviderResponse:
+    return ProviderResponse(
         id="req-123",
         data=Embeddings(
             id="embeddings-1",
@@ -61,12 +61,12 @@ def embeddings_formatted_response(dimensions: int = 3) -> ProviderFormattedRespo
     )
 
 
-def empty_embeddings_formatted_response() -> ProviderFormattedResponse:
-    return ProviderFormattedResponse(id="req-123", data=Embeddings(id="embeddings-1", model=DEFAULT_MODEL_ID, data=[]))
+def empty_embeddings_formatted_response() -> ProviderResponse:
+    return ProviderResponse(id="req-123", data=Embeddings(id="embeddings-1", model=DEFAULT_MODEL_ID, data=[]))
 
 
 def provider_adapter_stub(
-    formatted_response: ProviderFormattedResponse,
+    formatted_response: ProviderResponse,
     provider_type: ProviderType = ProviderType.ALBERT,
     model_name: str = DEFAULT_MODEL_ID,
 ):
@@ -74,7 +74,7 @@ def provider_adapter_stub(
     adapter.provider = ProviderFactory(
         type=provider_type, url=DEFAULT_PROVIDER_URL, key=DEFAULT_PROVIDER_KEY, timeout=DEFAULT_PROVIDER_TIMEOUT, model_name=model_name
     )
-    adapter.format_response.return_value = formatted_response
+    adapter.to_domain_response.return_value = formatted_response
     return adapter
 
 
@@ -86,7 +86,7 @@ class TestProviderCapabilitiesProbe:
         provider_adapter_builder.build.return_value = provider_adapter_stub(
             formatted_response=models_formatted_response(model_entity(max_context_length=4096)), provider_type=ProviderType.ALBERT
         )
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -106,7 +106,7 @@ class TestProviderCapabilitiesProbe:
         assert probed_provider.url == DEFAULT_PROVIDER_URL
         assert probed_provider.key == DEFAULT_PROVIDER_KEY
         assert probed_provider.timeout == DEFAULT_PROVIDER_TIMEOUT
-        provider_client.forward_request.assert_awaited_once()
+        provider_client.forward.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_should_get_capabilities_from_the_models_and_embeddings_endpoints_for_an_embeddings_router(
@@ -121,7 +121,7 @@ class TestProviderCapabilitiesProbe:
             ),
             built_embeddings_adapter,
         ]
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_EMBEDDINGS_INFERENCE,
@@ -138,13 +138,14 @@ class TestProviderCapabilitiesProbe:
             EndpointRoute.EMBEDDINGS,
         ]
         assert provider_adapter_builder.build.call_args.kwargs["provider"].type == ProviderType.TEI
-        assert built_embeddings_adapter.format_request.call_args.kwargs["original_request"].payload.model == DEFAULT_MODEL_ID
-        assert provider_client.forward_request.await_count == 2
+        embeddings_request = provider_client.forward.await_args_list[1].kwargs["request"]
+        assert embeddings_request.payload.model == DEFAULT_MODEL_ID
+        assert provider_client.forward.await_count == 2
 
     @pytest.mark.asyncio
     async def test_should_return_provider_not_reachable_error_when_models_request_fails(self, probe, provider_adapter_builder, provider_client):
         provider_adapter_builder.build.return_value = provider_adapter_stub(formatted_response=models_formatted_response(model_entity()))
-        provider_client.forward_request.return_value = StatusCodeModelError(status_code=500, detail="error_detail")
+        provider_client.forward.return_value = StatusCodeModelError(status_code=500, detail="error_detail")
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -164,7 +165,7 @@ class TestProviderCapabilitiesProbe:
         provider_adapter_builder.build.return_value = provider_adapter_stub(
             formatted_response=models_formatted_response(model_entity(model_id="another-model"))
         )
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -183,8 +184,8 @@ class TestProviderCapabilitiesProbe:
             provider_adapter_stub(formatted_response=models_formatted_response(model_entity()), provider_type=ProviderType.TEI),
             provider_adapter_stub(formatted_response=embeddings_formatted_response(), provider_type=ProviderType.TEI),
         ]
-        provider_client.forward_request.side_effect = [
-            ProviderOriginalResponse(data={}),
+        provider_client.forward.side_effect = [
+            ProviderRawResponse(data={}),
             StatusCodeModelError(status_code=500, detail="error_detail"),
         ]
 
@@ -207,7 +208,7 @@ class TestProviderCapabilitiesProbe:
             provider_adapter_stub(formatted_response=models_formatted_response(model_entity()), provider_type=ProviderType.TEI),
             provider_adapter_stub(formatted_response=empty_embeddings_formatted_response(), provider_type=ProviderType.TEI),
         ]
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_EMBEDDINGS_INFERENCE,
@@ -229,7 +230,7 @@ class TestProviderCapabilitiesProbe:
             ),
             model_name="model-alias",
         )
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -249,7 +250,7 @@ class TestProviderCapabilitiesProbe:
         provider_adapter_builder.build.return_value = provider_adapter_stub(
             formatted_response=models_formatted_response(model_entity(max_context_length=10), model_entity(max_context_length=20))
         )
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -269,7 +270,7 @@ class TestProviderCapabilitiesProbe:
         provider_adapter_builder.build.return_value = provider_adapter_stub(
             formatted_response=models_formatted_response(model_entity(max_context_length=None))
         )
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,
@@ -285,7 +286,7 @@ class TestProviderCapabilitiesProbe:
     @pytest.mark.asyncio
     async def test_should_return_model_not_found_error_when_models_response_is_empty(self, probe, provider_adapter_builder, provider_client):
         provider_adapter_builder.build.return_value = provider_adapter_stub(formatted_response=models_formatted_response())
-        provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        provider_client.forward.return_value = ProviderRawResponse(data={})
 
         result = await probe.get_capabilities(
             router_type=RouterType.TEXT_GENERATION,

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -1,4 +1,3 @@
-from http import HTTPMethod
 from unittest.mock import AsyncMock, MagicMock, call, create_autospec, patch
 
 import pytest
@@ -9,9 +8,8 @@ from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import TooBusyModelError
 from api.domain.provider import ProviderAdapter
 from api.domain.provider.entities import (
-    ProviderFormattedRequest,
-    ProviderFormattedResponse,
-    ProviderOriginalResponse,
+    ProviderRawResponse,
+    ProviderResponse,
     ProviderType,
 )
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
@@ -143,21 +141,14 @@ def use_case(
     )
 
 
-def _mock_adapter(*, formatted_response=None, formatted_text=None, request_error=None, response_error=None):
+def _mock_adapter(*, formatted_response=None, formatted_text=None, response_error=None):
     adapter = create_autospec(ProviderAdapter, instance=True, spec_set=True)
-    adapter.format_request.return_value = ProviderFormattedRequest(
-        method=HTTPMethod.POST,
-        url="https://provider.example/v1/chat/completions",
-        body={},
-    )
     if response_error is not None:
-        adapter.format_response.return_value = response_error
+        adapter.to_domain_response.return_value = response_error
     elif formatted_text is not None:
-        adapter.format_response.return_value = ProviderFormattedResponse(id="req-1", text=formatted_text)
+        adapter.to_domain_response.return_value = ProviderResponse(id="req-1", text=formatted_text)
     elif formatted_response is not None:
-        adapter.format_response.return_value = ProviderFormattedResponse(id=formatted_response.id, data=formatted_response)
-    if request_error is not None:
-        adapter.format_request.return_value = request_error
+        adapter.to_domain_response.return_value = ProviderResponse(id=formatted_response.id, data=formatted_response)
     return adapter
 
 
@@ -360,14 +351,14 @@ class TestSendRequest:
         use_case.provider_repository.get_all_providers_of_router.return_value = [provider]
         use_case.provider_load_balancer.find_best_provider.return_value = provider
         use_case.provider_metrics_logger.increment_inflight.return_value = True
-        use_case.provider_client.forward_request.return_value = ProviderOriginalResponse(data={})
+        use_case.provider_client.forward.return_value = ProviderRawResponse(data={})
         use_case.provider_adapter_builder.build.return_value = _mock_adapter(formatted_response=sample_data)
 
     @pytest.mark.asyncio
-    async def test_should_return_request_validation_error_without_forwarding_when_request_is_invalid(self, use_case, router, provider, payload):
+    async def test_should_return_request_validation_error_when_provider_call_rejects_request(self, use_case, router, provider, payload):
         # Arrange
         validation_error = ProviderAdapterValidationRequestError(provider_type=ProviderType.VLLM, errors=[{"msg": "invalid"}])
-        use_case.provider_adapter_builder.build.return_value = _mock_adapter(request_error=validation_error)
+        use_case.provider_client.forward.return_value = validation_error
 
         # Act
         result = await use_case._send_request(router=router, prompt_tokens=1, payload=payload)
@@ -375,8 +366,11 @@ class TestSendRequest:
         # Assert
         assert result == validation_error
         use_case.provider_adapter_builder.build.assert_called_once_with(endpoint=ForwardingTestUseCase.ENDPOINT, provider=provider)
-        use_case.provider_metrics_logger.increment_inflight.assert_not_awaited()
-        use_case.provider_client.forward_request.assert_not_awaited()
+        use_case.provider_client.forward.assert_awaited_once()
+        forwarded_request = use_case.provider_client.forward.call_args.kwargs["request"]
+        assert forwarded_request.endpoint == ForwardingTestUseCase.ENDPOINT
+        assert forwarded_request.payload == payload
+        use_case.provider_metrics_logger.decrement_inflight.assert_awaited_once_with(provider_id=provider.id)
         use_case.usage_recorder.record_provider.assert_called_once_with(provider_id=provider.id, provider_model_name=provider.model_name)
         use_case.usage_recorder.record_usage.assert_not_called()
 
@@ -384,7 +378,7 @@ class TestSendRequest:
     async def test_should_return_forward_error_and_decrement_inflight_when_provider_call_fails(self, use_case, router, provider, payload):
         # Arrange
         provider_error = TooBusyModelError(status_code=503, detail="busy")
-        use_case.provider_client.forward_request.return_value = provider_error
+        use_case.provider_client.forward.return_value = provider_error
 
         # Act
         result = await use_case._send_request(router=router, prompt_tokens=1, payload=payload)
@@ -420,7 +414,7 @@ class TestSendRequest:
                 result = await use_case._send_request(router=router, prompt_tokens=1, payload=payload)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert result.data is sample_data
         assert result.data.usage == Usage(
             prompt_tokens=1,
@@ -434,9 +428,9 @@ class TestSendRequest:
             strategy=router.load_balancing_strategy,
             providers=[provider],
         )
-        original_request = use_case.provider_adapter_builder.build.return_value.format_request.call_args.kwargs["original_request"]
-        assert original_request.endpoint == ForwardingTestUseCase.ENDPOINT
-        assert original_request.payload == payload
+        forwarded_request = use_case.provider_client.forward.call_args.kwargs["request"]
+        assert forwarded_request.endpoint == ForwardingTestUseCase.ENDPOINT
+        assert forwarded_request.payload == payload
         use_case.provider_metrics_logger.log_metric.assert_has_awaits(
             [
                 call(provider_id=provider.id, metric=Metric.LATENCY, value=120),
@@ -476,7 +470,7 @@ class TestSendRequest:
                 result = await use_case._send_request(router=router, prompt_tokens=1, payload=payload)
 
         # Assert
-        assert isinstance(result, ProviderFormattedResponse)
+        assert isinstance(result, ProviderResponse)
         assert result.data is None
         use_case.usage_recorder.record_usage.assert_called_once_with(
             request_id="req-1",
@@ -489,7 +483,7 @@ class TestSendRequest:
 class TestExecute:
     @pytest.fixture(autouse=True)
     def mock_collaborator_methods(self, use_case, router, sample_data):
-        formatted_response = ProviderFormattedResponse(id=sample_data.id, data=sample_data)
+        formatted_response = ProviderResponse(id=sample_data.id, data=sample_data)
         use_case._resolve_router = AsyncMock(return_value=router)
         use_case._check_rate_limits = AsyncMock(return_value=RouterRateLimitState.admin_rate_limit_state())
         use_case._send_request = AsyncMock(return_value=formatted_response)

--- a/api/use_cases/_providerrequestforwardingusecase.py
+++ b/api/use_cases/_providerrequestforwardingusecase.py
@@ -9,7 +9,7 @@ from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
 from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderLoadBalancer, ProviderMetricsLogger, ProviderRepository
-from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.router import RouterRateLimiter, RouterRepository
 from api.domain.router.entities import Router, RouterRateLimitState
@@ -156,7 +156,7 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
         prompt_tokens: int,
         payload: ForwardablePayload,
     ) -> (
-        ProviderFormattedResponse
+        ProviderResponse
         | ProviderAdapterValidationRequestError
         | TooBusyModelError
         | UnknownModelError
@@ -167,33 +167,28 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
         provider = await self.provider_load_balancer.find_best_provider(strategy=router.load_balancing_strategy, providers=providers)
         self.usage_recorder.record_provider(provider_id=provider.id, provider_model_name=provider.model_name)
 
-        original_request = ProviderOriginalRequest(endpoint=self.ENDPOINT, payload=payload)
+        request = ProviderRequest(endpoint=self.ENDPOINT, payload=payload)
         adapter = self.provider_adapter_builder.build(endpoint=self.ENDPOINT, provider=provider)
-        match adapter.format_request(original_request=original_request):
-            case ProviderFormattedRequest() as formatted_request:
-                pass
-            case ProviderAdapterValidationRequestError() as error:
-                return error
 
         inflight_is_incremented = await self.provider_metrics_logger.increment_inflight(provider_id=provider.id)
 
         start_time = time.perf_counter()
-        result = await self.provider_client.forward_request(provider=provider, formatted_request=formatted_request)
+        result = await self.provider_client.forward(provider=provider, request=request)
         latency = int((time.perf_counter() - start_time) * 1000)  # ms
 
         if inflight_is_incremented:
             await self.provider_metrics_logger.decrement_inflight(provider_id=provider.id)
 
         match result:
-            case ProviderOriginalResponse() as original_response:
+            case ProviderRawResponse() as raw_response:
                 pass
             case error:
                 return error
 
-        result = adapter.format_response(original_request=original_request, original_response=original_response)
+        result = adapter.to_domain_response(request=request, raw_response=raw_response)
         match result:
-            case ProviderFormattedResponse() as formatted_response:
-                completion_tokens = self.model_tokenizer.compute_tokens(texts=formatted_response.get_completions())
+            case ProviderResponse() as provider_response:
+                completion_tokens = self.model_tokenizer.compute_tokens(texts=provider_response.get_completions())
 
                 environmental_impacts = self.model_environmental_impacts_computer.compute(
                     model_active_params=provider.model_active_params,
@@ -209,8 +204,8 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
                     cost_completion_tokens=router.cost_completion_tokens,
                 )
 
-                if formatted_response.data is not None:
-                    formatted_response.data.usage = Usage(
+                if provider_response.data is not None:
+                    provider_response.data.usage = Usage(
                         prompt_tokens=prompt_tokens,
                         completion_tokens=completion_tokens,
                         total_tokens=prompt_tokens + completion_tokens,
@@ -232,13 +227,13 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
                 return error
 
         self.usage_recorder.record_usage(
-            request_id=formatted_response.id,
+            request_id=provider_response.id,
             prompt_tokens=prompt_tokens,
             total_tokens=prompt_tokens + completion_tokens,
             cost=cost,
         )
 
-        return formatted_response
+        return provider_response
 
     async def execute(self, command: TCommand) -> ProviderRequestForwardingUseCaseResult[TData]:
         authenticated_user = command.authenticated_user
@@ -261,9 +256,9 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
 
         result = await self._send_request(router=router, prompt_tokens=prompt_tokens, payload=command.payload)
         match result:
-            case ProviderFormattedResponse() as formatted_response:
+            case ProviderResponse() as provider_response:
                 pass
             case error:
                 return error
 
-        return ProviderRequestForwardingUseCaseSuccess(data=formatted_response.data, headers=rate_limit_state.build_limit_headers)
+        return ProviderRequestForwardingUseCaseSuccess(data=provider_response.data, headers=rate_limit_state.build_limit_headers)

--- a/api/use_cases/audio/_createaudiotranscriptionsusecase.py
+++ b/api/use_cases/audio/_createaudiotranscriptionsusecase.py
@@ -5,7 +5,7 @@ from api.domain.audio.errors import AudioFileSizeLimitExceededError
 from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
 from api.domain.model.entities import ModelType as RouterType
 from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderLoadBalancer, ProviderMetricsLogger, ProviderRepository
-from api.domain.provider.entities import ProviderFormattedResponse
+from api.domain.provider.entities import ProviderResponse
 from api.domain.router import RouterRateLimiter, RouterRepository
 from api.domain.router.entities import Router, RouterRateLimitState
 from api.domain.usage import UsageRecorder
@@ -100,20 +100,20 @@ class CreateAudioTranscriptionsUseCase(ProviderRequestForwardingUseCase[CreateAu
 
         result = await self._send_request(router=router, prompt_tokens=prompt_tokens, payload=command.payload)
         match result:
-            case ProviderFormattedResponse() as formatted_response:
+            case ProviderResponse() as provider_response:
                 pass
             case error:
                 return error
 
-        if formatted_response.data:
+        if provider_response.data:
             return CreateAudioTranscriptionsJsonUseCaseSuccess(
-                data=formatted_response.data,
+                data=provider_response.data,
                 headers=rate_limit_state.build_limit_headers,
                 media_type=command.media_type,
             )
         else:
             return CreateAudioTranscriptionsTextUseCaseSuccess(
-                text=formatted_response.text,
+                text=provider_response.text,
                 headers=rate_limit_state.build_limit_headers,
                 media_type=command.media_type,
             )

--- a/api/use_cases/health/_gethealthmodelsusecase.py
+++ b/api/use_cases/health/_gethealthmodelsusecase.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from api.domain.model.entities import HealthStatus, ModelHealthStatus
 from api.domain.provider import ProviderAdapter, ProviderAdapterBuilder, ProviderClient, ProviderMetricsLogger, ProviderRepository
-from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import ProviderRawResponse, ProviderRequest, ProviderResponse, ProviderType
 from api.domain.provider.errors import ProviderAdapterValidationResponseError, UnsupportedProviderEndpointError
 from api.domain.router import RouterRepository
 from api.domain.user.views import AuthenticatedUserView
@@ -63,22 +63,20 @@ class GetHealthModelsUseCase:
                         pass
                     case UnsupportedProviderEndpointError():
                         adapter = self.provider_adapter_builder.build(endpoint=EndpointRoute.MODELS, provider=provider)
-                        original_request = ProviderOriginalRequest(endpoint=EndpointRoute.MODELS)
-                        formatted_request = adapter.format_request(original_request=original_request)
-                        response = await self.provider_client.forward_request(provider=provider, formatted_request=formatted_request)
+                        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
+                        response = await self.provider_client.forward(provider=provider, request=request)
                         match response:
-                            case ProviderOriginalResponse() as response:
+                            case ProviderRawResponse() as response:
                                 continue
                             case _:
                                 health.status = HealthStatus.RED
                                 continue
 
-                original_request = ProviderOriginalRequest(endpoint=EndpointRoute.METRICS)
-                formatted_request = adapter.format_request(original_request=original_request)
-                response = await self.provider_client.forward_request(provider=provider, formatted_request=formatted_request)
+                request = ProviderRequest(endpoint=EndpointRoute.METRICS)
+                response = await self.provider_client.forward(provider=provider, request=request)
 
                 match response:
-                    case ProviderOriginalResponse() as response:
+                    case ProviderRawResponse() as response:
                         pass
                     case _:
                         # @TODO: if another provider is healthy, we should not set the health to red
@@ -86,10 +84,10 @@ class GetHealthModelsUseCase:
                         health.status = HealthStatus.RED
                         continue
 
-                result = adapter.format_response(original_request=original_request, original_response=response)
+                result = adapter.to_domain_response(request=request, raw_response=response)
 
                 match result:
-                    case ProviderFormattedResponse() as formatted_response:
+                    case ProviderResponse() as provider_response:
                         pass
                     case ProviderAdapterValidationResponseError():
                         health.status = HealthStatus.RED
@@ -98,16 +96,16 @@ class GetHealthModelsUseCase:
                 match provider.type:
                     case ProviderType.VLLM:
                         if health.status != HealthStatus.RED:
-                            if formatted_response.data.waiting_requests > 0:
+                            if provider_response.data.waiting_requests > 0:
                                 health.status = HealthStatus.YELLOW
-                            if formatted_response.data.running_requests > 20:
+                            if provider_response.data.running_requests > 20:
                                 health.status = HealthStatus.RED
 
                     case ProviderType.MISTRAL:
                         if health.status != HealthStatus.RED:
-                            if formatted_response.data.running_requests > 58:
+                            if provider_response.data.running_requests > 58:
                                 health.status = HealthStatus.YELLOW
-                            if formatted_response.data.running_requests > 63:
+                            if provider_response.data.running_requests > 63:
                                 health.status = HealthStatus.RED
 
             models.append(health)

--- a/api/use_cases/services/_providercapabilitiesprobe.py
+++ b/api/use_cases/services/_providercapabilitiesprobe.py
@@ -2,7 +2,7 @@ from api.domain.embeddings.entities import CreateEmbeddingsBody
 from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import ModelNotFoundError
 from api.domain.provider import ProviderAdapter, ProviderAdapterBuilder, ProviderClient
-from api.domain.provider.entities import Provider, ProviderCapabilities, ProviderOriginalRequest, ProviderOriginalResponse, ProviderType
+from api.domain.provider.entities import Provider, ProviderCapabilities, ProviderRawResponse, ProviderRequest, ProviderType
 from api.domain.provider.errors import ProviderInvalidResponseError, ProviderNotReachableError
 from api.utils.variables import EndpointRoute
 
@@ -59,40 +59,38 @@ class ProviderCapabilitiesProbe:
         return ProviderCapabilities(max_context_length=max_context_length, vector_size=vector_size)
 
     async def _get_max_context_length(self, adapter: ProviderAdapter) -> int | None | ModelNotFoundError | ProviderNotReachableError:
-        original_request = ProviderOriginalRequest(endpoint=EndpointRoute.MODELS)
-        formatted_request = adapter.format_request(original_request=original_request)
-        response = await self.provider_client.forward_request(provider=adapter.provider, formatted_request=formatted_request)
+        request = ProviderRequest(endpoint=EndpointRoute.MODELS)
+        response = await self.provider_client.forward(provider=adapter.provider, request=request)
         match response:
-            case ProviderOriginalResponse() as response:
+            case ProviderRawResponse() as response:
                 pass
             case error:
                 return ProviderNotReachableError(model_name=adapter.provider.model_name, status_code=error.status_code, detail=error.detail)
 
-        formatted_response = adapter.format_response(original_response=response, original_request=original_request)
+        provider_response = adapter.to_domain_response(raw_response=response, request=request)
         model_name = adapter.provider.model_name
-        model = next((m for m in formatted_response.data.data if m.id == model_name or model_name in m.aliases), None)
+        model = next((m for m in provider_response.data.data if m.id == model_name or model_name in m.aliases), None)
         if model is None:
             return ModelNotFoundError(name=model_name)
 
         return model.max_context_length
 
     async def _get_vector_size(self, adapter: ProviderAdapter) -> int | ProviderNotReachableError | ProviderInvalidResponseError:
-        original_request = ProviderOriginalRequest(
+        request = ProviderRequest(
             endpoint=EndpointRoute.EMBEDDINGS,
             payload=CreateEmbeddingsBody(model=adapter.provider.model_name, input="hello world"),
         )
-        formatted_request = adapter.format_request(original_request=original_request)
-        response = await self.provider_client.forward_request(provider=adapter.provider, formatted_request=formatted_request)
+        response = await self.provider_client.forward(provider=adapter.provider, request=request)
         match response:
-            case ProviderOriginalResponse() as response:
+            case ProviderRawResponse() as response:
                 pass
             case error:
                 return ProviderNotReachableError(model_name=adapter.provider.model_name, status_code=error.status_code, detail=error.detail)
 
-        formatted_response = adapter.format_response(original_response=response, original_request=original_request)
-        if not formatted_response.data.data:
+        provider_response = adapter.to_domain_response(raw_response=response, request=request)
+        if not provider_response.data.data:
             return ProviderInvalidResponseError(model_name=adapter.provider.model_name, detail="no embedding returned")
 
-        vector_size = len(formatted_response.data.data[0].embedding)
+        vector_size = len(provider_response.data.data[0].embedding)
 
         return vector_size

--- a/api/utils/lifespan.py
+++ b/api/utils/lifespan.py
@@ -127,9 +127,10 @@ async def bootstrap_admin_role_and_user(configuration: Configuration, postgres_s
 async def bootstrap_models(configuration: Configuration, postgres_session: AsyncSession, bootstrap_admin_user_id: int) -> int:
     router_repository = PostgresRouterRepository(postgres_session=postgres_session, app_title=configuration.settings.app_title)
     provider_repository = PostgresProviderRepository(postgres_session=postgres_session)
+    provider_adapter_builder = HttpProviderAdapterBuilder()
     provider_capabilities_probe = ProviderCapabilitiesProbe(
-        provider_client=HttpProviderClient(),
-        provider_adapter_builder=HttpProviderAdapterBuilder(),
+        provider_client=HttpProviderClient(adapter_builder=provider_adapter_builder),
+        provider_adapter_builder=provider_adapter_builder,
     )
 
     result = await BootstrapModelsUseCase(


### PR DESCRIPTION
## Overview

Resolves [#993](https://github.com/etalab-ia/OpenGateLLM/issues/993). The domain `ProviderClient` port described an HTTP call (`ProviderFormattedRequest` with method, URL, form, files). This PR keeps the port in provider-call vocabulary (`ProviderRequest`) and moves HTTP encoding into `HttpProviderRequest` / `HttpProviderClient`.

- [x] `api/domain/` has no import from `http`, and request DTOs have no `method` / `form` / `files` fields
- [x] `ProviderClient` can be implemented by a non-HTTP transport without changing the port
- [x] The application layer no longer manipulates two objects both called "request"
- [x] Existing provider calls stay equivalent (JSON vs form vs multipart, extra-field passthrough, auth headers)

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

## Additional Notes

Internal rename of provider request/response types (`ProviderOriginalRequest` → `ProviderRequest`, `ProviderFormattedRequest` → `HttpProviderRequest`). Streaming (`forward_stream`) is unchanged and still unimplemented. Review focus: the `ProviderClient.forward` boundary and that HTTP adapters still emit the same wire requests.


Made with [Cursor](https://cursor.com)