### PR TITLE
feat(admin): require all fields on migrated PATCH update endpoints

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.73%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.68%", "color": "green"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ Callers (playground `edit_entity`, e2e tests) must send the whole current form s
 - API: Unix seconds as `int` (`created`, `updated`, `expires`)
 - Domain and Postgres: timezone-aware UTC `datetime` — annotate entity fields with `UtcDatetime` from `api/domain/__init__.py`, and always build "now" with `datetime.now(tz=UTC)`
 - Repositories select and write the `timestamptz` columns directly — no `extract(epoch)` / `to_timestamp()`
-- Convert at the boundary only: `@field_validator` / `AfterValidator` (request) or `@model_validator(mode="before")` (response) — see `CreateKeyBody` / `KeyResponse`
+- Convert at the boundary only: `@field_validator` (request) or `@model_validator(mode="before")` (response). Request validators keep the field typed `int` (OpenAPI) and return a UTC `datetime` for the command. Keys also reject past timestamps (`CreateKeyBody`); user `expires` converts without that check so a past value expires the user — see `CreateUserBody` / `UserUpdateRequest` / `KeyResponse`. Command timestamp fields are typed `UtcDatetime` to match the entity; the dataclass does not convert.
 - Playground displays local time through `app/shared/utils/timestamps.py`
 
 Full rationale: `adr/2026-08-27-datetime-handling.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,20 @@ CreateKeyCommand(user_id=body.user, ...)
 "user": data.user_id  # Key entity → CreateKeyResponse
 ```
 
+### Update requests are full replacements
+
+`Update<Noun>Body` requires **every persisted field** — there is no partial update on clean-architecture endpoints.
+
+- No `default=None` meaning "skip this field". A missing field is a 422.
+- `| None` only where `null` is a valid stored value, and it then **sets** the column to `null` (clear the organization, the budget, the QoS policy…).
+- Lists replace the stored list; an empty list clears it (role `permissions` / `limits`, router `aliases`).
+- The use case applies the command as a replacement: `entity.with_x(command.x)` for every field, never `if command.x is not None`.
+- Exception: write-only secrets (`password`, `current_password`) stay optional — omitting them leaves the secret unchanged.
+
+Do not reuse a `Create<Noun>Body` for an update: its optional fields carry the wrong meaning.
+
+Callers (playground `edit_entity`, e2e tests) must send the whole current form state, not a diff.
+
 ### Timestamps
 
 - API: Unix seconds as `int` (`created`, `updated`, `expires`)

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -38,10 +38,10 @@ One representation per layer, converted at exactly one place — the layer bound
 Domain timestamp fields use the `UtcDatetime` alias from `api/domain/__init__.py`:
 
 ```python
-UtcDatetime = Annotated[datetime, BeforeValidator(_parse_unix_timestamp), AfterValidator(_to_utc)]
+UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
 ```
 
-It normalizes anything Pydantic accepts as a `datetime` to UTC, treats a naive value as already-UTC, and converts a Unix timestamp (`int`) the same way. An entity can never hold an ambiguous timestamp — and `int(value.timestamp())` at the boundary is always correct. The same alias covers the provider-facing boundary: provider `/v1/models` payloads carry `created` as OpenAI-style Unix seconds, and the HTTP adapters hand that `int` straight to `Model`, where `UtcDatetime` turns it into an aware UTC datetime.
+It normalizes anything Pydantic accepts as a `datetime` to UTC and treats a naive value as already-UTC, so an entity can never hold an ambiguous timestamp — and `int(value.timestamp())` at the boundary is always correct. Provider `/v1/models` payloads carry `created` as OpenAI-style Unix seconds; that value stays an `int` on the `Model` entity (it is not a timestamp we persist).
 
 Repositories select and write the `timestamptz` columns **directly**. No `extract(epoch)` on read, no `to_timestamp()` on write:
 

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -38,10 +38,10 @@ One representation per layer, converted at exactly one place — the layer bound
 Domain timestamp fields use the `UtcDatetime` alias from `api/domain/__init__.py`:
 
 ```python
-UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
+UtcDatetime = Annotated[datetime, BeforeValidator(_parse_unix_timestamp), AfterValidator(_to_utc)]
 ```
 
-It normalizes anything Pydantic accepts as a `datetime` to UTC and treats a naive value as already-UTC, so an entity can never hold an ambiguous timestamp — and `int(value.timestamp())` at the boundary is always correct. The same alias covers the provider-facing boundary: provider `/v1/models` payloads carry `created` as OpenAI-style Unix seconds, and the HTTP adapters hand that `int` straight to `Model`, where `UtcDatetime` turns it into an aware UTC datetime.
+It normalizes anything Pydantic accepts as a `datetime` to UTC, treats a naive value as already-UTC, and converts a Unix timestamp (`int`) the same way. An entity can never hold an ambiguous timestamp — and `int(value.timestamp())` at the boundary is always correct. The same alias covers the provider-facing boundary: provider `/v1/models` payloads carry `created` as OpenAI-style Unix seconds, and the HTTP adapters hand that `int` straight to `Model`, where `UtcDatetime` turns it into an aware UTC datetime.
 
 Repositories select and write the `timestamptz` columns **directly**. No `extract(epoch)` on read, no `to_timestamp()` on write:
 
@@ -54,19 +54,20 @@ Anything producing a "now" writes `datetime.now(tz=UTC)`, never a naive `datetim
 
 ### API boundary: `int`, converted in the schema
 
-**Request** — a `@field_validator` (or an `Annotated` `AfterValidator`) validates the timestamp and returns the `datetime` the command layer receives:
+**Request** — a `@field_validator` validates the timestamp and returns the `datetime` the command layer receives. The field stays annotated `int`, so the OpenAPI schema still documents an integer.
 
 ```python
-# api/infrastructure/fastapi/schemas/admin/users.py
-def _must_be_future_and_convert_to_datetime(expires: int) -> datetime:
+# api/infrastructure/fastapi/schemas/admin/keys.py — reject past + convert
+@field_validator("expires", mode="after")
+def must_be_future_and_convert_to_datetime(cls, expires) -> None | datetime:
+    if expires is None:
+        return expires
     if expires <= int(datetime.now(tz=UTC).timestamp()):
-        raise ValueError("Wrong timestamp, must be in the future.")
+        raise ValueError("Expiration time must be in the future.")
     return datetime.fromtimestamp(timestamp=expires, tz=UTC)
-
-FutureTimestamp = Annotated[int, AfterValidator(_must_be_future_and_convert_to_datetime)]
 ```
 
-The field stays annotated `int`, so the OpenAPI schema still documents an integer.
+User `expires` uses the same conversion without the future check, so a past timestamp expires the account immediately (and a full-replacement PATCH can resubmit an already-expired user).
 
 **Response** — a `@model_validator(mode="before")` maps the domain entity to the wire shape, converting each `datetime` with `int(value.timestamp())`:
 

--- a/api/domain/__init__.py
+++ b/api/domain/__init__.py
@@ -4,18 +4,24 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated
 
-from pydantic import AfterValidator, BaseModel, ConfigDict
+from pydantic import AfterValidator, BaseModel, BeforeValidator, ConfigDict
 
 
 class BaseModel(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+def _parse_unix_timestamp(value: object) -> object:
+    if type(value) is int:
+        return datetime.fromtimestamp(timestamp=value, tz=UTC)
+    return value
+
+
 def _to_utc(value: datetime) -> datetime:
     return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(tz=UTC)
 
 
-UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
+UtcDatetime = Annotated[datetime, BeforeValidator(_parse_unix_timestamp), AfterValidator(_to_utc)]
 
 
 class ForwardablePayload(BaseModel, ABC):

--- a/api/domain/__init__.py
+++ b/api/domain/__init__.py
@@ -4,24 +4,18 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated
 
-from pydantic import AfterValidator, BaseModel, BeforeValidator, ConfigDict
+from pydantic import AfterValidator, BaseModel, ConfigDict
 
 
 class BaseModel(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-def _parse_unix_timestamp(value: object) -> object:
-    if type(value) is int:
-        return datetime.fromtimestamp(timestamp=value, tz=UTC)
-    return value
-
-
 def _to_utc(value: datetime) -> datetime:
     return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(tz=UTC)
 
 
-UtcDatetime = Annotated[datetime, BeforeValidator(_parse_unix_timestamp), AfterValidator(_to_utc)]
+UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
 
 
 class ForwardablePayload(BaseModel, ABC):

--- a/api/domain/model/entities.py
+++ b/api/domain/model/entities.py
@@ -1,8 +1,6 @@
 from enum import StrEnum
 
-from pydantic import Field
-
-from api.domain import BaseModel, UtcDatetime
+from api.domain import BaseModel
 
 
 class ModelCosts(BaseModel):
@@ -28,10 +26,9 @@ class Model(BaseModel):
     id: str
     type: ModelType
     aliases: list[str] = []
-    created: UtcDatetime
+    created: int
     owned_by: str
     max_context_length: int | None = None
-    costs: ModelCosts = Field(default_factory=ModelCosts)
 
 
 class Models(ModelJsonResponse):

--- a/api/domain/role/entities.py
+++ b/api/domain/role/entities.py
@@ -36,15 +36,15 @@ class Role(BaseModel):
 
     @field_validator("permissions")
     @classmethod
-    def unique_permissions(cls, v: list[PermissionType]) -> list[PermissionType]:
-        return list(dict.fromkeys(v))
+    def unique_permissions(cls, permissions: list[PermissionType]) -> list[PermissionType]:
+        return list(dict.fromkeys(permissions))
 
     @field_validator("limits")
     @classmethod
-    def unique_limits(cls, v: list["Limit"]) -> list["Limit"]:
-        return list({(limit.router_id, limit.type): limit for limit in v}.values())
+    def unique_limits(cls, limits: list["Limit"]) -> list["Limit"]:
+        return list({(limit.router_id, limit.type): limit for limit in limits}.values())
 
-    def with_name(self, name: str | None) -> "Role":
+    def with_name(self, name: str) -> "Role":
         return self.model_copy(update={"name": name})
 
     def with_limits(self, limits: list["Limit"]) -> "Role":

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -24,7 +24,7 @@ from api.infrastructure.fastapi.endpoints.exceptions import (
     RoleHasUsersHTTPException,
     RoleNotFoundHTTPException,
 )
-from api.infrastructure.fastapi.schemas.admin.roles import CreateRoleBody, RoleResponse, RolesResponse
+from api.infrastructure.fastapi.schemas.admin.roles import CreateRoleBody, RoleResponse, RolesResponse, UpdateRoleBody
 from api.use_cases.admin.roles import (
     CreateRoleCommand,
     CreateRoleUseCase,
@@ -87,7 +87,7 @@ async def create_role(
 )
 async def update_role(
     role_id: int = Path(description="The ID of the role to update."),
-    body: CreateRoleBody = Body(description="The role update request."),
+    body: UpdateRoleBody = Body(description="The role update request."),
     update_role_use_case: UpdateRoleUseCase = Depends(update_role_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> RoleResponse:
@@ -95,9 +95,7 @@ async def update_role(
         role_id=role_id,
         name=body.name,
         permissions=body.permissions,
-        limits=[Limit(router_id=body_limit.router_id, type=body_limit.type, value=body_limit.value) for body_limit in body.limits]
-        if body.limits
-        else None,
+        limits=[Limit(router_id=body_limit.router_id, type=body_limit.type, value=body_limit.value) for body_limit in body.limits],
     )
     try:
         result = await update_role_use_case.execute(command)

--- a/api/infrastructure/fastapi/schemas/admin/providers.py
+++ b/api/infrastructure/fastapi/schemas/admin/providers.py
@@ -55,13 +55,13 @@ class CreateProviderResponse(BaseModel):
 
 
 class UpdateProviderBody(BaseModel):
-    router_id: int | None = Field(default=None, description="The ID of the new router to assign to the provider.")  # fmt: off
-    timeout: int | None = Field(default=None, description="Timeout for the model provider requests, after user receive an 500 error (model is too busy).")  # fmt: off
-    model_hosting_zone: Annotated[HostingZone | None, Field(default=None, description="Model hosting zone using ISO 3166-1 alpha-3 code format (e.g., `WOR` for World, `FRA` for France, `USA` for United States). This determines the electricity mix used for carbon intensity calculations. For more information, see https://ecologits.ai")]  # fmt: off
-    model_total_params: Annotated[int | None, Field(default=None, ge=0, description="Total params of the model in billions of parameters for carbon footprint computation. If not provided, the active params will be used if provided, else carbon footprint will not be computed. For more information, see https://ecologits.ai")]  # fmt: off
-    model_active_params: Annotated[int | None, Field(default=None, ge=0, description="Active params of the model in billions of parameters for carbon footprint computation. If not provided, the total params will be used if provided, else carbon footprint will not be computed. For more information, see https://ecologits.ai")]  # fmt: off
-    qos_metric: Annotated[QoSMetric | None, Field(default=None, description="The metric to use for the quality of service policy. If not provided, no QoS policy is applied.")]  # fmt: off
-    qos_limit: Annotated[float | None, Field(default=None, ge=0.0, description="The value to use for the quality of service. Depends of the metric, the value can be a percentile, a threshold, etc.")]  # fmt: off
+    router_id: Annotated[int, Field(..., description="The ID of the router to assign to the provider.")]  # fmt: off
+    timeout: Annotated[int, Field(..., ge=1, le=3600, description="Timeout for the model provider requests, after user receive an 500 error (model is too busy).")]  # fmt: off
+    model_hosting_zone: Annotated[HostingZone, Field(..., description="Model hosting zone using ISO 3166-1 alpha-3 code format (e.g., `WOR` for World, `FRA` for France, `USA` for United States). This determines the electricity mix used for carbon intensity calculations. For more information, see https://ecologits.ai")]  # fmt: off
+    model_total_params: Annotated[int, Field(..., ge=0, description="Total params of the model in billions of parameters for carbon footprint computation. If 0, the active params will be used if provided, else carbon footprint will not be computed. For more information, see https://ecologits.ai")]  # fmt: off
+    model_active_params: Annotated[int, Field(..., ge=0, description="Active params of the model in billions of parameters for carbon footprint computation. If 0, the total params will be used if provided, else carbon footprint will not be computed. For more information, see https://ecologits.ai")]  # fmt: off
+    qos_metric: Annotated[QoSMetric | None, Field(..., description="The metric to use for the quality of service policy. If null, no QoS policy is applied.")]  # fmt: off
+    qos_limit: Annotated[float | None, Field(..., ge=0.0, description="The value to use for the quality of service. Depends of the metric, the value can be a percentile, a threshold, etc. If null, no QoS policy is applied.")]  # fmt: off
 
     @model_validator(mode="after")
     def validate_model(self):

--- a/api/infrastructure/fastapi/schemas/admin/roles.py
+++ b/api/infrastructure/fastapi/schemas/admin/roles.py
@@ -32,6 +32,12 @@ class CreateRoleBody(BaseModel):
     limits: Annotated[list[Limit] | None, Field(default=None, description="List of limits.")]
 
 
+class UpdateRoleBody(BaseModel):
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1), Field(..., description="Name of the role.", examples=["my-role"])]  # fmt: off
+    permissions: Annotated[list[PermissionType], Field(..., description="List of permissions replacing the current ones. An empty list removes all the permissions.")]  # fmt: off
+    limits: Annotated[list[Limit], Field(..., description="List of limits replacing the current ones. An empty list removes all the limits.")]  # fmt: off
+
+
 class RoleResponse(BaseModel):
     object: Annotated[Literal["role"], Field("role", description="Type of the object.")]
     id: Annotated[int, Field(..., description="ID of the role.")]

--- a/api/infrastructure/fastapi/schemas/admin/routers.py
+++ b/api/infrastructure/fastapi/schemas/admin/routers.py
@@ -17,12 +17,12 @@ class CreateRouterBody(BaseModel):
 
 
 class UpdateRouterBody(BaseModel):
-    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1), Field(default=None, description="Name of the model router.", examples=["model-router-1"])]  # fmt: off
-    router_type: Annotated[ModelType | None, Field(default=None, description="Type of the model router. It will be used to identify the model router type.", examples=["text-generation"], alias="type")]  # fmt: off
-    aliases: Annotated[list[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]] | None, Field(default=None, description="Aliases of the model. It will be used to identify the model by users.", examples=[["model-alias", "model-alias-2"]])]  # fmt: off
-    load_balancing_strategy: Annotated[RouterLoadBalancingStrategy | None, Field(default=None, description="Routing strategy for load balancing between providers of the model. It will be used to identify the model type.", examples=["least_busy"])]  # fmt: off
-    cost_prompt_tokens: Annotated[float | None, Field(default=None, ge=0.0, description="Cost of a million prompt tokens (decrease user budget)")]
-    cost_completion_tokens: Annotated[float | None, Field(default=None, ge=0.0, description="Cost of a million completion tokens (decrease user budget)")]  # fmt: off
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1), Field(..., description="Name of the model router.", examples=["model-router-1"])]  # fmt: off
+    router_type: Annotated[ModelType, Field(..., description="Type of the model router. It will be used to identify the model router type.", examples=["text-generation"], alias="type")]  # fmt: off
+    aliases: Annotated[list[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]], Field(..., description="Aliases of the model replacing the current ones. It will be used to identify the model by users. An empty list removes all the aliases.", examples=[["model-alias", "model-alias-2"]])]  # fmt: off
+    load_balancing_strategy: Annotated[RouterLoadBalancingStrategy, Field(..., description="Routing strategy for load balancing between providers of the model. It will be used to identify the model type.", examples=["least_busy"])]  # fmt: off
+    cost_prompt_tokens: Annotated[float, Field(..., ge=0.0, description="Cost of a million prompt tokens (decrease user budget)")]
+    cost_completion_tokens: Annotated[float, Field(..., ge=0.0, description="Cost of a million completion tokens (decrease user budget)")]  # fmt: off
 
 
 class RouterResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -1,6 +1,7 @@
+from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import ConfigDict, Field, StringConstraints, model_validator
+from pydantic import ConfigDict, Field, StringConstraints, field_validator, model_validator
 
 from api.domain import BaseModel
 from api.domain.user.entities import User
@@ -16,6 +17,12 @@ class CreateUserBody(BaseModel):
     budget: float | None = Field(default=None, description="The budget.")
     expires: int | None = Field(default=None, description="The expiration timestamp.")
     priority: int = Field(default=0, ge=0, description="The user priority. Higher value means higher priority.")
+
+    @field_validator("expires", mode="after")
+    def convert_expires_to_datetime(cls, expires) -> None | datetime:
+        if expires is None:
+            return expires
+        return datetime.fromtimestamp(timestamp=expires, tz=UTC)
 
 
 class UserResponse(BaseModel):
@@ -75,3 +82,9 @@ class UserUpdateRequest(BaseModel):
     budget: float | None = Field(..., description="The new budget. If null, the user will have no budget.")  # fmt: off
     expires: int | None = Field(..., description="The new expiration timestamp. If null, the user will never expire.")  # fmt: off
     priority: int = Field(..., ge=0, description="The new user priority. Higher value means higher priority.")  # fmt: off
+
+    @field_validator("expires", mode="after")
+    def convert_expires_to_datetime(cls, expires) -> None | datetime:
+        if expires is None:
+            return expires
+        return datetime.fromtimestamp(timestamp=expires, tz=UTC)

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -77,12 +77,12 @@ class UsersResponse(BaseModel):
 
 
 class UserUpdateRequest(BaseModel):
-    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254)] | None = Field(default=None, description="The new user email. If None, the user email is not changed.")  # fmt: off
-    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None = Field(default=None, description="The new user name. If None, the user name is not changed.")  # fmt: off
-    current_password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The current user password.")  # fmt: off
-    password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The new user password. If None, the user password is not changed.")  # fmt: off
-    role_id: int | None = Field(default=None, description="The new role ID. If None, the user role is not changed.")  # fmt: off
-    organization_id: int | None = Field(default=None, description="The new organization ID. If None, the user will be removed from the organization if he was in one.")  # fmt: off
-    budget: float | None = Field(default=None, description="The new budget. If None, the user will have no budget.")  # fmt: off
-    expires: FutureTimestamp | None = Field(default=None, description="The new expiration timestamp. If None, the user will never expire.")  # fmt: off
-    priority: int | None = Field(default=None, ge=0, description="The new user priority. Higher value means higher priority. If None, unchanged.")  # fmt: off
+    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254)] = Field(..., description="The new user email.")  # fmt: off
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None = Field(..., description="The new user name. If null, the user name is removed.")  # fmt: off
+    current_password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The current user password. Only required to change the password.")  # fmt: off
+    password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The new user password. If omitted, the user password is not changed.")  # fmt: off
+    role_id: int = Field(..., description="The new role ID.")  # fmt: off
+    organization_id: int | None = Field(..., description="The new organization ID. If null, the user is removed from the organization if he was in one.")  # fmt: off
+    budget: float | None = Field(..., description="The new budget. If null, the user will have no budget.")  # fmt: off
+    expires: FutureTimestamp | None = Field(..., description="The new expiration timestamp. If null, the user will never expire.")  # fmt: off
+    priority: int = Field(..., ge=0, description="The new user priority. Higher value means higher priority.")  # fmt: off

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -1,21 +1,10 @@
-from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
 from api.domain.user.entities import User
 from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
-
-
-def _must_be_future_and_convert_to_datetime(expires: int) -> datetime:
-    if expires <= int(datetime.now(tz=UTC).timestamp()):
-        raise ValueError("Wrong timestamp, must be in the future.")
-    return datetime.fromtimestamp(timestamp=expires, tz=UTC)
-
-
-FutureTimestamp = Annotated[int, AfterValidator(_must_be_future_and_convert_to_datetime)]
-"""Unix timestamp accepted at the API boundary and converted to a UTC datetime for the domain."""
 
 
 class CreateUserBody(BaseModel):
@@ -25,7 +14,7 @@ class CreateUserBody(BaseModel):
     role_id: int = Field(..., description="The role ID.")
     organization_id: int | None = Field(default=None, description="The organization ID.")
     budget: float | None = Field(default=None, description="The budget.")
-    expires: FutureTimestamp | None = Field(default=None, description="The expiration timestamp.")
+    expires: int | None = Field(default=None, description="The expiration timestamp.")
     priority: int = Field(default=0, ge=0, description="The user priority. Higher value means higher priority.")
 
 
@@ -84,5 +73,5 @@ class UserUpdateRequest(BaseModel):
     role_id: int = Field(..., description="The new role ID.")  # fmt: off
     organization_id: int | None = Field(..., description="The new organization ID. If null, the user is removed from the organization if he was in one.")  # fmt: off
     budget: float | None = Field(..., description="The new budget. If null, the user will have no budget.")  # fmt: off
-    expires: FutureTimestamp | None = Field(..., description="The new expiration timestamp. If null, the user will never expire.")  # fmt: off
+    expires: int | None = Field(..., description="The new expiration timestamp. If null, the user will never expire.")  # fmt: off
     priority: int = Field(..., ge=0, description="The new user priority. Higher value means higher priority.")  # fmt: off

--- a/api/tests/integ/test_admin/test_admin.py
+++ b/api/tests/integ/test_admin/test_admin.py
@@ -102,7 +102,16 @@ class TestAuth:
 
         # Update expiration to now
         future_current = int((datetime.now() + timedelta(seconds=10)).timestamp())
-        response = client.patch_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json={"expires": future_current})
+        update_payload = {
+            "email": user_data["email"],
+            "name": user_data["name"],
+            "role_id": user_data["role_id"],
+            "organization_id": user_data["organization_id"],
+            "budget": user_data["budget"],
+            "expires": future_current,
+            "priority": user_data["priority"],
+        }
+        response = client.patch_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json=update_payload)
         assert response.status_code == 200, response.text
 
         # Check updated expiration
@@ -113,8 +122,18 @@ class TestAuth:
 
         # Try to update expiration to past time (should fail)
         past_expiration = int((datetime.now() - timedelta(minutes=5)).timestamp())
-        response = client.patch_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json={"expires": past_expiration})
+        response = client.patch_with_permissions(
+            url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json={**update_payload, "expires": past_expiration}
+        )
         assert response.status_code == 422, "Should reject update with past expiration time"
+
+        # Clear the expiration by sending null
+        response = client.patch_with_permissions(
+            url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json={**update_payload, "expires": None}
+        )
+        assert response.status_code == 200, response.text
+        response = client.get_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}")
+        assert response.json()["expires"] is None, response.text
 
     def test_user_account_expiration_access(self, client: TestClient, roles: tuple[dict, dict]):
         role_with_permissions, role_without_permissions = roles
@@ -262,6 +281,7 @@ class TestAuth:
             url=f"/v1{EndpointRoute.ADMIN_ROLES}/{role_id}",
             json={
                 "name": f"test_role_{str(uuid4())}",
+                "permissions": [],
                 "limits": [
                     {"router_id": text_generation_router.id, "type": "rpm", "value": None},
                     {"router_id": text_generation_router.id, "type": "rpd", "value": None},
@@ -340,9 +360,21 @@ class TestAuth:
         time.sleep(1)
         response = client.get_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_id}")
         assert response.json()["budget"] < initial_budget, response.text
+        user_data = response.json()
 
         # Update the budget
-        response = client.patch_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_id}", json={"budget": 0})
+        response = client.patch_with_permissions(
+            url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_id}",
+            json={
+                "email": user_data["email"],
+                "name": user_data["name"],
+                "role_id": user_data["role_id"],
+                "organization_id": user_data["organization_id"],
+                "budget": 0,
+                "expires": user_data["expires"],
+                "priority": user_data["priority"],
+            },
+        )
         assert response.status_code == 200, response.text
 
         # Check that the budget is updated

--- a/api/tests/integ/test_admin/test_admin.py
+++ b/api/tests/integ/test_admin/test_admin.py
@@ -65,7 +65,7 @@ class TestAuth:
         user_data = response.json()
         assert user_data["expires"] is None, response.text
 
-        # Try to create user with expiration set to 5 minutes in the past (should fail)
+        # Create user with expiration set to 5 minutes in the past (expires immediately)
         past_expiration = int((datetime.now() - timedelta(minutes=5)).timestamp())
         response = client.post_with_permissions(
             url=f"/v1{EndpointRoute.ADMIN_USERS}",
@@ -77,7 +77,8 @@ class TestAuth:
                 "password": "test-password",
             },
         )
-        assert response.status_code == 422, response.text
+        assert response.status_code == 201, response.text
+        assert response.json()["expires"] == past_expiration
 
         # Create user with expiration set to 5 minutes in the future
         future_expiration = int((time.time()) + 5 * 60)
@@ -120,12 +121,15 @@ class TestAuth:
         user_data = response.json()
         assert user_data["expires"] == future_current, "User should have updated expiration time"
 
-        # Try to update expiration to past time (should fail)
+        # Update expiration to a past time (expires the user immediately)
         past_expiration = int((datetime.now() - timedelta(minutes=5)).timestamp())
         response = client.patch_with_permissions(
             url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}", json={**update_payload, "expires": past_expiration}
         )
-        assert response.status_code == 422, "Should reject update with past expiration time"
+        assert response.status_code == 200, response.text
+        response = client.get_with_permissions(url=f"/v1{EndpointRoute.ADMIN_USERS}/{user_with_expiration_id}")
+        assert response.status_code == 200, response.text
+        assert response.json()["expires"] == past_expiration
 
         # Clear the expiration by sending null
         response = client.patch_with_permissions(

--- a/api/tests/integration/endpoints/admin/provider/test_update_provider.py
+++ b/api/tests/integration/endpoints/admin/provider/test_update_provider.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 
 from api.dependencies import update_provider_use_case_factory
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError
+from api.domain.provider.entities import HostingZone, QoSMetric
 from api.domain.provider.errors import InvalidProviderTypeError, ProviderAlreadyExistsError, ProviderNotFoundError
 from api.domain.router.errors import RouterNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
@@ -15,6 +16,21 @@ from api.utils.variables import EndpointRoute
 URL = f"/v1{EndpointRoute.ADMIN_PROVIDERS}"
 
 DEFAULT_PROVIDER_URL = "http://my-test-provider/"
+
+
+def _valid_body(**overrides) -> dict:
+    """A full update payload: every persisted field is required."""
+    body = {
+        "router_id": 1,
+        "timeout": 120,
+        "model_hosting_zone": HostingZone.FRA,
+        "model_total_params": 8,
+        "model_active_params": 2,
+        "qos_metric": None,
+        "qos_limit": None,
+    }
+    body.update(overrides)
+    return body
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -32,14 +48,49 @@ class TestUpdateProvider:
         response = await client.patch(
             url=f"{URL}/{provider.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json={"timeout": 120},
+            json=_valid_body(router_id=router.id, qos_metric=QoSMetric.TTFT, qos_limit=0.9),
         )
 
         assert response.status_code == 200, response.text
         data = response.json()
         assert data["id"] == provider.id
         assert data["object"] == "provider"
+        assert data["router_id"] == router.id
         assert data["timeout"] == 120
+        assert data["model_hosting_zone"] == HostingZone.FRA
+        assert data["model_total_params"] == 8
+        assert data["model_active_params"] == 2
+        assert data["qos_metric"] == QoSMetric.TTFT
+        assert data["qos_limit"] == 0.9
+
+    async def test_clears_qos_policy_sent_as_null(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(user=self.admin_user)
+        provider = ProviderSQLFactory(router=router, user=self.admin_user, qos_metric=QoSMetric.TTFT, qos_limit=0.9)
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{provider.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(router_id=router.id, qos_metric=None, qos_limit=None),
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["qos_metric"] is None
+        assert data["qos_limit"] is None
+
+    async def test_rejects_body_missing_a_required_field(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(user=self.admin_user)
+        provider = ProviderSQLFactory(router=router, user=self.admin_user)
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{provider.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json={"timeout": 120},
+        )
+
+        assert response.status_code == 422, response.text
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",
@@ -84,7 +135,7 @@ class TestUpdateProvider:
         response = await client.patch(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json={"timeout": 120},
+            json=_valid_body(),
         )
 
         assert response.status_code == expected_status
@@ -97,7 +148,7 @@ class TestUpdateProvider:
         response = await client.patch(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {key.token}"},
-            json={"timeout": 120},
+            json=_valid_body(),
         )
 
         assert response.status_code == 403, response.text
@@ -112,7 +163,7 @@ class TestUpdateProvider:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.patch(url=f"{URL}/1", headers=headers, json={"timeout": 120})
+        response = await client.patch(url=f"{URL}/1", headers=headers, json=_valid_body())
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/endpoints/admin/roles/test_update_role.py
+++ b/api/tests/integration/endpoints/admin/roles/test_update_role.py
@@ -15,7 +15,8 @@ URL = f"/v1{EndpointRoute.ADMIN_ROLES}"
 
 
 def _valid_body(**overrides) -> dict:
-    body = {"name": "updated-role"}
+    """A full update payload: every persisted field is required."""
+    body = {"name": "updated-role", "permissions": [], "limits": []}
     body.update(overrides)
     return body
 
@@ -37,7 +38,11 @@ class TestUpdateRole:
         response = await client.patch(
             url=f"{URL}/{role.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json=_valid_body(name="updated-role", permissions=[PermissionType.ADMIN]),
+            json=_valid_body(
+                name="updated-role",
+                permissions=[PermissionType.ADMIN],
+                limits=[{"router_id": router.id, "type": LimitType.RPM, "value": 10}],
+            ),
         )
 
         assert response.status_code == 200, response.text
@@ -45,8 +50,38 @@ class TestUpdateRole:
         assert data["id"] == role.id
         assert data["object"] == "role"
         assert data["name"] == "updated-role"
-        assert len(data["limits"]) == 1
-        assert len(data["permissions"]) == 1
+        assert data["permissions"] == [PermissionType.ADMIN]
+        assert data["limits"] == [{"router_id": router.id, "type": LimitType.RPM, "value": 10}]
+
+    async def test_clears_permissions_and_limits_sent_as_empty_lists(self, client: AsyncClient, db_session):
+        role = RoleSQLFactory()
+        router = RouterSQLFactory()
+        LimitSQLFactory(role=role, router=router, type=LimitType.TPM, value=100)
+        PermissionSQLFactory(role=role, permission=PermissionType.READ_METRIC)
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{role.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(permissions=[], limits=[]),
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["permissions"] == []
+        assert data["limits"] == []
+
+    async def test_rejects_body_missing_a_required_field(self, client: AsyncClient, db_session):
+        role = RoleSQLFactory()
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{role.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json={"name": "updated-role"},
+        )
+
+        assert response.status_code == 422, response.text
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/router/test_update_router.py
+++ b/api/tests/integration/endpoints/admin/router/test_update_router.py
@@ -5,6 +5,8 @@ import pytest
 import pytest_asyncio
 
 from api.dependencies import update_router_use_case_factory
+from api.domain.model.entities import ModelType
+from api.domain.router.entities import RouterLoadBalancingStrategy
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
 from api.tests.integration.factories.sql import RouterSQLFactory, UserSQLFactory
@@ -14,7 +16,14 @@ URL = f"/v1{EndpointRoute.ADMIN_ROUTERS}"
 
 
 def _valid_body(**overrides) -> dict:
-    body = {"name": "updated-name"}
+    body = {
+        "name": "updated-name",
+        "type": ModelType.TEXT_GENERATION,
+        "aliases": [],
+        "load_balancing_strategy": RouterLoadBalancingStrategy.SHUFFLE,
+        "cost_prompt_tokens": 0.0,
+        "cost_completion_tokens": 0.0,
+    }
     body.update(overrides)
     return body
 
@@ -38,7 +47,7 @@ class TestUpdateRouter:
         response = await client.patch(
             url=f"{URL}/{router.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json={"name": "updated-name", "aliases": ["alias-1"]},
+            json=_valid_body(aliases=["alias-1"], cost_prompt_tokens=0.5, cost_completion_tokens=1.5),
         )
 
         assert response.status_code == 200, response.text
@@ -46,7 +55,36 @@ class TestUpdateRouter:
         assert data["id"] == router.id
         assert data["name"] == "updated-name"
         assert data["aliases"] == ["alias-1"]
+        assert data["type"] == ModelType.TEXT_GENERATION
+        assert data["load_balancing_strategy"] == RouterLoadBalancingStrategy.SHUFFLE
+        assert data["cost_prompt_tokens"] == 0.5
+        assert data["cost_completion_tokens"] == 1.5
         assert data["object"] == "router"
+
+    async def test_clears_aliases_sent_as_an_empty_list(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(user=self.admin_user, alias=["alias-1"])
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{router.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(aliases=[]),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["aliases"] == []
+
+    async def test_rejects_body_missing_a_required_field(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(user=self.admin_user)
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{router.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json={"name": "updated-name"},
+        )
+
+        assert response.status_code == 422, response.text
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/users/test_create_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_create_user.py
@@ -54,10 +54,17 @@ class TestCreateUser:
         assert isinstance(data["created"], int)
         assert isinstance(data["updated"], int)
 
-    async def test_round_trips_expires_as_unix_timestamp(self, client: AsyncClient, db_session):
+    @pytest.mark.parametrize(
+        "expires_delta",
+        [
+            pytest.param(timedelta(days=-1), id="past"),
+            pytest.param(timedelta(days=30), id="future"),
+        ],
+    )
+    async def test_round_trips_expires_as_unix_timestamp(self, client: AsyncClient, db_session, expires_delta):
         role = RoleSQLFactory()
         await db_session.flush()
-        expires = int((datetime.now(tz=UTC) + timedelta(days=30)).timestamp())
+        expires = int((datetime.now(tz=UTC) + expires_delta).timestamp())
 
         response = await client.post(
             url=URL,

--- a/api/tests/integration/endpoints/admin/users/test_update_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_update_user.py
@@ -74,6 +74,20 @@ class TestUpdateUser:
         assert data["budget"] is None
         assert data["expires"] is None
 
+    async def test_accepts_past_expiration_timestamp(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        await db_session.flush()
+        expires = int((dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=5)).timestamp())
+
+        response = await client.patch(
+            url=f"{URL}/{user.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(role_id=user.role_id, expires=expires),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["expires"] == expires
+
     async def test_keeps_password_when_password_is_omitted(self, client: AsyncClient, db_session):
         user = UserSQLFactory()
         current_password = user.password

--- a/api/tests/integration/endpoints/admin/users/test_update_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_update_user.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from unittest.mock import AsyncMock
 
 from httpx import AsyncClient
@@ -9,10 +10,24 @@ from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
 from api.domain.user.errors import IncorrectCurrentPasswordError, UserAlreadyExistsError, UserNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
-from api.tests.integration.factories.sql import UserSQLFactory
+from api.tests.integration.factories.sql import OrganizationSQLFactory, UserSQLFactory
 from api.utils.variables import EndpointRoute
 
 URL = f"/v1{EndpointRoute.ADMIN_USERS}"
+
+
+def _valid_body(**overrides) -> dict:
+    body = {
+        "email": "updated@example.com",
+        "name": "Updated Name",
+        "role_id": 1,
+        "organization_id": None,
+        "budget": None,
+        "expires": None,
+        "priority": 0,
+    }
+    body.update(overrides)
+    return body
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -29,7 +44,7 @@ class TestUpdateUser:
         response = await client.patch(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json={"email": "updated@example.com", "name": "Updated Name", "budget": 50.5, "priority": 2},
+            json=_valid_body(role_id=user.role_id, budget=50.5, priority=2),
         )
 
         assert response.status_code == 200, response.text
@@ -40,6 +55,58 @@ class TestUpdateUser:
         assert data["budget"] == 50.5
         assert data["priority"] == 2
         assert data["role_id"] == user.role_id
+
+    async def test_clears_nullable_fields_sent_as_null(self, client: AsyncClient, db_session):
+        organization = OrganizationSQLFactory()
+        user = UserSQLFactory(organization=organization, budget=100.0, expires=dt.datetime.now() + dt.timedelta(days=30))
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{user.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(role_id=user.role_id, name=None, organization_id=None, budget=None, expires=None),
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["name"] is None
+        assert data["organization_id"] is None
+        assert data["budget"] is None
+        assert data["expires"] is None
+
+    async def test_keeps_password_when_password_is_omitted(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        current_password = user.password
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{user.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(role_id=user.role_id),
+        )
+
+        assert response.status_code == 200, response.text
+        await db_session.refresh(user)
+        assert user.password == current_password
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({key: value for key, value in _valid_body().items() if key != "email"}, id="missing-required-field"),
+            pytest.param(_valid_body(email=None), id="null-on-non-nullable-field"),
+        ],
+    )
+    async def test_rejects_incomplete_body(self, client: AsyncClient, db_session, body):
+        user = UserSQLFactory()
+        await db_session.flush()
+
+        response = await client.patch(
+            url=f"{URL}/{user.id}",
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=body,
+        )
+
+        assert response.status_code == 422, response.text
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",
@@ -79,7 +146,7 @@ class TestUpdateUser:
         response = await client.patch(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {self.key.token}"},
-            json={},
+            json=_valid_body(),
         )
 
         assert response.status_code == expected_status
@@ -92,7 +159,7 @@ class TestUpdateUser:
         response = await client.patch(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {key.token}"},
-            json={},
+            json=_valid_body(),
         )
 
         assert response.status_code == 403, response.text
@@ -107,7 +174,7 @@ class TestUpdateUser:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.patch(url=f"{URL}/1", headers=headers, json={})
+        response = await client.patch(url=f"{URL}/1", headers=headers, json=_valid_body())
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/api/tests/unit/domain/test_utcdatetime.py
+++ b/api/tests/unit/domain/test_utcdatetime.py
@@ -40,26 +40,6 @@ class TestUtcDatetime:
         assert entity.moment == datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
         assert entity.moment.tzinfo == UTC
 
-    def test_should_read_an_unix_timestamp_as_utc(self):
-        # Arrange
-        moment = datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
-
-        # Act
-        entity = Entity(moment=int(moment.timestamp()))
-
-        # Assert
-        assert entity.moment == moment
-
-    def test_should_round_trip_to_the_same_unix_timestamp(self):
-        # Arrange
-        timestamp = 1_756_298_000
-
-        # Act
-        entity = Entity(moment=timestamp)
-
-        # Assert
-        assert int(entity.moment.timestamp()) == timestamp
-
     def test_should_allow_none_on_an_optional_field(self):
         # Act
         entity = Entity(moment=datetime(2026, 8, 27, tzinfo=UTC), optional_moment=None)

--- a/api/tests/unit/infrastructure/factories.py
+++ b/api/tests/unit/infrastructure/factories.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime
 from http import HTTPMethod
 import random
 from urllib.parse import urljoin
@@ -129,8 +128,7 @@ class ProviderModelResponseFactory(factory.Factory):
         model = Model
 
     id = factory.Faker("bothify", text="model-????-####")
-    object = "model"
-    created = factory.LazyFunction(lambda: datetime.fromtimestamp(timestamp=fake.unix_time(), tz=UTC))
+    created = factory.Faker("unix_time")
     owned_by = factory.Faker("company")
     max_context_length = factory.Faker("random_int", min=64000, max=245600)
     aliases = factory.LazyFunction(lambda: [fake.bothify(text="model-????-latest")])

--- a/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
@@ -3,12 +3,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from api.domain.model.entities import ModelCosts, Models, ModelType
-from api.domain.provider.entities import (
-    ProviderFormattedResponse,
-    ProviderOriginalResponse,
-    ProviderType,
-)
+from api.domain.model.entities import Models, ModelType
+from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
 from api.infrastructure.http.adapters.models.albert import AlbertModelsAdapter
 from api.infrastructure.http.adapters.models.mistral import MistralModelsAdapter
 from api.infrastructure.http.adapters.models.openai import OpenaiModelsAdapter
@@ -248,7 +244,6 @@ class TestModelsAdapter:
         assert result.data.data[0].type is ModelType.TEXT_GENERATION
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_context_length"]
         assert result.data.data[0].aliases == response_data["data"][0]["aliases"]
-        assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
     def test_format_response_correctly_when_provider_is_openai(self, openai_models_adapter: OpenaiModelsAdapter):
         # Arrange
@@ -268,7 +263,6 @@ class TestModelsAdapter:
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].max_context_length is None
         assert result.data.data[0].aliases == []
-        assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
     def test_format_response_correctly_when_provider_is_mistral(self, mistral_models_adapter: MistralModelsAdapter):
         # Arrange
@@ -288,7 +282,6 @@ class TestModelsAdapter:
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_context_length"]
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].aliases == []
-        assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
     def test_format_response_correctly_when_provider_is_tei(self, tei_models_adapter: TeiModelsAdapter):
         # Arrange
@@ -308,7 +301,6 @@ class TestModelsAdapter:
         assert result.data.data[0].max_context_length == response_data["max_input_length"]
         assert result.data.data[0].owned_by == "tei"
         assert result.data.data[0].aliases == []
-        assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
     def test_format_response_correctly_when_provider_is_vllm(self, vllm_models_adapter: VllmModelsAdapter):
         # Arrange
@@ -328,7 +320,6 @@ class TestModelsAdapter:
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_model_len"]
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].aliases == []
-        assert result.data.data[0].costs == ModelCosts(prompt_tokens=0, completion_tokens=0)
 
     @pytest.mark.parametrize(
         argnames=("adapter", "response_data"),

--- a/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
+++ b/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
@@ -32,11 +32,6 @@ def use_case(router_repository, provider_repository):
 
 
 @pytest.fixture
-def sample_router():
-    return RouterFactory(id=1, name="test-router", type=RouterType.TEXT_GENERATION, providers=0)
-
-
-@pytest.fixture
 def sample_provider():
     return ProviderFactory(id=10, router_id=1, user_id=1, type=ProviderType.VLLM, timeout=30)
 
@@ -56,6 +51,19 @@ def full_command(provider, **overrides) -> UpdateProviderCommand:
     for field, value in overrides.items():
         setattr(command, field, value)
     return command
+
+
+def provider_after_command(provider, command: UpdateProviderCommand):
+    """Provider state the use case persists for a full-replacement command."""
+    return (
+        provider.with_router_id(command.router_id)
+        .with_timeout(command.timeout)
+        .with_model_hosting_zone(command.model_hosting_zone)
+        .with_model_total_params(command.model_total_params)
+        .with_model_active_params(command.model_active_params)
+        .with_qos_metric(command.qos_metric)
+        .with_qos_limit(command.qos_limit)
+    )
 
 
 @pytest.fixture
@@ -86,27 +94,6 @@ class TestUpdateProviderUseCase:
         provider_repository.update_provider.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_should_return_router_not_found_error_when_current_router_does_not_exist(
-        self,
-        use_case,
-        provider_repository,
-        router_repository,
-        sample_provider,
-        unchanged_command,
-    ):
-        # Arrange
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = RouterNotFoundError(id=sample_provider.router_id)
-
-        # Act
-        result = await use_case.execute(command=unchanged_command)
-
-        # Assert
-        assert isinstance(result, RouterNotFoundError)
-        assert result.id == sample_provider.router_id
-        provider_repository.update_provider.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_should_return_router_not_found_error_when_new_router_does_not_exist(
         self,
         use_case,
@@ -116,7 +103,7 @@ class TestUpdateProviderUseCase:
     ):
         # Arrange
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.side_effect = [sample_router, RouterNotFoundError(id=99)]
+        router_repository.get_router_by_id.return_value = RouterNotFoundError(id=99)
 
         # Act
         result = await use_case.execute(command=full_command(sample_provider, router_id=99))
@@ -196,11 +183,10 @@ class TestUpdateProviderUseCase:
 
     @pytest.mark.asyncio
     async def test_should_not_call_update_provider_when_no_fields_are_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router, unchanged_command
+        self, use_case, provider_repository, sample_provider, unchanged_command
     ):
         # Arrange
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
 
         # Act
         result = await use_case.execute(command=unchanged_command)
@@ -212,22 +198,9 @@ class TestUpdateProviderUseCase:
 
     @pytest.mark.asyncio
     async def test_should_replace_every_persisted_field_with_the_command_values(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
+        self, use_case, provider_repository, router_repository, sample_provider
     ):
         # Arrange
-        updated_provider = (
-            sample_provider.with_timeout(60)
-            .with_model_hosting_zone(HostingZone.FRA)
-            .with_model_total_params(7)
-            .with_model_active_params(3)
-            .with_qos_metric(QoSMetric.TTFT)
-            .with_qos_limit(100.0)
-        )
-
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
-        provider_repository.update_provider.return_value = updated_provider
-
         command = full_command(
             sample_provider,
             timeout=60,
@@ -237,6 +210,10 @@ class TestUpdateProviderUseCase:
             qos_metric=None,
             qos_limit=None,
         )
+        updated_provider = provider_after_command(sample_provider, command)
+
+        provider_repository.get_one_provider.return_value = sample_provider
+        provider_repository.update_provider.return_value = updated_provider
 
         # Act
         result = await use_case.execute(command=command)
@@ -244,7 +221,8 @@ class TestUpdateProviderUseCase:
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_timeout(60))
+        provider_repository.update_provider.assert_called_once_with(updated_provider)
+        router_repository.get_router_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_should_return_updated_provider_when_router_is_changed_and_has_provider(
@@ -252,7 +230,8 @@ class TestUpdateProviderUseCase:
     ):
         # Arrange
         new_router = RouterFactory(id=2, type=RouterType.TEXT_GENERATION, providers=1)
-        updated_provider = sample_provider.with_router_id(new_router.id)
+        command = full_command(sample_provider, router_id=new_router.id)
+        updated_provider = provider_after_command(sample_provider, command)
 
         provider_repository.get_one_provider.return_value = sample_provider
         provider_repository.get_all_providers_of_router.return_value = [
@@ -267,24 +246,13 @@ class TestUpdateProviderUseCase:
         router_repository.get_router_by_id.return_value = new_router
         provider_repository.update_provider.return_value = updated_provider
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=2,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
         # Act
         result = await use_case.execute(command=command)
 
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_router_id(new_router.id))
+        provider_repository.update_provider.assert_called_once_with(updated_provider)
 
     @pytest.mark.asyncio
     async def test_should_return_updated_provider_when_router_is_changed_and_has_no_provider(
@@ -292,22 +260,12 @@ class TestUpdateProviderUseCase:
     ):
         # Arrange
         new_router = RouterFactory(id=2, type=RouterType.TEXT_GENERATION, providers=0)
-        updated_provider = sample_provider.with_router_id(new_router.id)
+        command = full_command(sample_provider, router_id=new_router.id)
+        updated_provider = provider_after_command(sample_provider, command)
 
         provider_repository.get_one_provider.return_value = sample_provider
         router_repository.get_router_by_id.return_value = new_router
         provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=2,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
 
         # Act
         result = await use_case.execute(command=command)
@@ -315,15 +273,12 @@ class TestUpdateProviderUseCase:
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_router_id(new_router.id))
+        provider_repository.update_provider.assert_called_once_with(updated_provider)
 
     @pytest.mark.asyncio
-    async def test_should_propagate_provider_already_exists_error_from_repository(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
-    ):
+    async def test_should_propagate_provider_already_exists_error_from_repository(self, use_case, provider_repository, sample_provider):
         # Arrange
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
         provider_repository.update_provider.return_value = ProviderAlreadyExistsError(
             model_name=sample_provider.model_name, url=sample_provider.url, router_id=sample_provider.router_id
         )
@@ -339,56 +294,15 @@ class TestUpdateProviderUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_updated_provider_when_model_hosting_zone_is_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
+        self, use_case, provider_repository, router_repository, sample_provider
     ):
         # Arrange
         new_zone = HostingZone.FRA
-        updated_provider = sample_provider.with_model_hosting_zone(new_zone)
+        command = full_command(sample_provider, model_hosting_zone=new_zone)
+        updated_provider = provider_after_command(sample_provider, command)
 
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
         provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=None,
-            model_hosting_zone=new_zone,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
-        # Act
-        result = await use_case.execute(command=command)
-
-        # Assert
-        assert isinstance(result, UpdateProviderUseCaseSuccess)
-        assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_model_hosting_zone(new_zone))
-
-    @pytest.mark.asyncio
-    async def test_should_return_updated_provider_when_model_total_params_is_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
-    ):
-        # Arrange
-        updated_provider = sample_provider.with_model_total_params(7)
-
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
-        provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=7,
-            model_active_params=3,
-            qos_metric=QoSMetric.TTFT,
-            qos_limit=100.0,
-        )
 
         # Act
         result = await use_case.execute(command=command)
@@ -397,21 +311,46 @@ class TestUpdateProviderUseCase:
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
         provider_repository.update_provider.assert_called_once_with(updated_provider)
-        # The router is unchanged: it is not resolved a second time for the compatibility checks.
-        router_repository.get_router_by_id.assert_called_once_with(router_id=sample_provider.router_id)
+        router_repository.get_router_by_id.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_should_clear_qos_policy_when_qos_fields_are_none(self, use_case, provider_repository, router_repository, sample_router):
+    async def test_should_return_updated_provider_when_model_total_params_is_changed(
+        self, use_case, provider_repository, router_repository, sample_provider
+    ):
+        # Arrange
+        command = full_command(
+            sample_provider,
+            model_total_params=7,
+            model_active_params=3,
+            qos_metric=QoSMetric.TTFT,
+            qos_limit=100.0,
+        )
+        updated_provider = provider_after_command(sample_provider, command)
+
+        provider_repository.get_one_provider.return_value = sample_provider
+        provider_repository.update_provider.return_value = updated_provider
+
+        # Act
+        result = await use_case.execute(command=command)
+
+        # Assert
+        assert isinstance(result, UpdateProviderUseCaseSuccess)
+        assert result.provider == updated_provider
+        provider_repository.update_provider.assert_called_once_with(updated_provider)
+        router_repository.get_router_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_clear_qos_policy_when_qos_fields_are_none(self, use_case, provider_repository, router_repository):
         # Arrange
         provider = ProviderFactory(id=10, router_id=1, user_id=1, type=ProviderType.VLLM, qos_metric=QoSMetric.TTFT, qos_limit=100.0)
-        cleared_provider = provider.with_qos_metric(None).with_qos_limit(None)
+        command = full_command(provider, qos_metric=None, qos_limit=None)
+        cleared_provider = provider_after_command(provider, command)
 
         provider_repository.get_one_provider.return_value = provider
-        router_repository.get_router_by_id.return_value = sample_router
         provider_repository.update_provider.return_value = cleared_provider
 
         # Act
-        result = await use_case.execute(command=full_command(provider, qos_metric=None, qos_limit=None))
+        result = await use_case.execute(command=command)
 
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
@@ -421,18 +360,19 @@ class TestUpdateProviderUseCase:
     @pytest.mark.asyncio
     async def test_should_return_updated_provider_when_router_is_changed(self, use_case, provider_repository, router_repository, sample_provider):
         # Arrange
-        current_router = RouterFactory(id=1, type=RouterType.TEXT_GENERATION, providers=0)
         new_router = RouterFactory(id=2, type=RouterType.TEXT_GENERATION, providers=1)
-        updated_provider = sample_provider.with_router_id(new_router.id)
+        command = full_command(sample_provider, router_id=new_router.id)
+        updated_provider = provider_after_command(sample_provider, command)
 
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.side_effect = [current_router, new_router]
+        router_repository.get_router_by_id.return_value = new_router
         provider_repository.update_provider.return_value = updated_provider
 
         # Act
-        result = await use_case.execute(command=full_command(sample_provider, router_id=2))
+        result = await use_case.execute(command=command)
 
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
         provider_repository.update_provider.assert_called_once_with(updated_provider)
+        router_repository.get_router_by_id.assert_called_once_with(router_id=new_router.id)

--- a/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
+++ b/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
@@ -41,18 +41,27 @@ def sample_provider():
     return ProviderFactory(id=10, router_id=1, user_id=1, type=ProviderType.VLLM, timeout=30)
 
 
-@pytest.fixture
-def default_command():
-    return UpdateProviderCommand(
-        provider_id=10,
-        router_id=None,
-        timeout=None,
-        model_hosting_zone=None,
-        model_total_params=None,
-        model_active_params=None,
-        qos_metric=None,
-        qos_limit=None,
+def full_command(provider, **overrides) -> UpdateProviderCommand:
+    """Command replacing every persisted field with the current provider values, unless overridden."""
+    command = UpdateProviderCommand(
+        provider_id=provider.id,
+        router_id=provider.router_id,
+        timeout=provider.timeout,
+        model_hosting_zone=provider.model_hosting_zone,
+        model_total_params=provider.model_total_params,
+        model_active_params=provider.model_active_params,
+        qos_metric=provider.qos_metric,
+        qos_limit=provider.qos_limit,
     )
+    for field, value in overrides.items():
+        setattr(command, field, value)
+    return command
+
+
+@pytest.fixture
+def unchanged_command(sample_provider):
+    """Command replaying the current provider state: a full payload that changes nothing."""
+    return full_command(sample_provider)
 
 
 class TestUpdateProviderUseCase:
@@ -62,19 +71,39 @@ class TestUpdateProviderUseCase:
         use_case,
         provider_repository,
         router_repository,
-        default_command,
+        unchanged_command,
     ):
         # Arrange
-
         provider_repository.get_one_provider.return_value = ProviderNotFoundError(id=10)
 
         # Act
-        result = await use_case.execute(command=default_command)
+        result = await use_case.execute(command=unchanged_command)
 
         # Assert
         assert isinstance(result, ProviderNotFoundError)
         assert result.id == 10
         router_repository.get_router_by_id.assert_not_called()
+        provider_repository.update_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_return_router_not_found_error_when_current_router_does_not_exist(
+        self,
+        use_case,
+        provider_repository,
+        router_repository,
+        sample_provider,
+        unchanged_command,
+    ):
+        # Arrange
+        provider_repository.get_one_provider.return_value = sample_provider
+        router_repository.get_router_by_id.return_value = RouterNotFoundError(id=sample_provider.router_id)
+
+        # Act
+        result = await use_case.execute(command=unchanged_command)
+
+        # Assert
+        assert isinstance(result, RouterNotFoundError)
+        assert result.id == sample_provider.router_id
         provider_repository.update_provider.assert_not_called()
 
     @pytest.mark.asyncio
@@ -86,23 +115,11 @@ class TestUpdateProviderUseCase:
         sample_provider,
     ):
         # Arrange
-
         provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = RouterNotFoundError(id=99)
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=99,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
+        router_repository.get_router_by_id.side_effect = [sample_router, RouterNotFoundError(id=99)]
 
         # Act
-        result = await use_case.execute(command=command)
+        result = await use_case.execute(command=full_command(sample_provider, router_id=99))
 
         # Assert
         assert isinstance(result, RouterNotFoundError)
@@ -117,25 +134,13 @@ class TestUpdateProviderUseCase:
         router_repository,
     ):
         # Arrange
-
         provider = ProviderFactory(id=10, router_id=1, user_id=1, type=ProviderType.OPENAI, timeout=30)
         new_router = RouterFactory(id=2, type=RouterType.TEXT_CLASSIFICATION, providers=0)
         provider_repository.get_one_provider.return_value = provider
         router_repository.get_router_by_id.return_value = new_router
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=2,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
         # Act
-        result = await use_case.execute(command=command)
+        result = await use_case.execute(command=full_command(provider, router_id=2))
 
         # Assert
         assert isinstance(result, InvalidProviderTypeError)
@@ -155,19 +160,8 @@ class TestUpdateProviderUseCase:
         provider_repository.get_all_providers_of_router.return_value = [ProviderFactory(id=20, router_id=2, type=ProviderType.TEI, vector_size=384)]
         router_repository.get_router_by_id.return_value = new_router
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=2,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
         # Act
-        result = await use_case.execute(command=command)
+        result = await use_case.execute(command=full_command(provider, router_id=2))
 
         # Assert
         assert isinstance(result, InconsistentModelVectorSizeError)
@@ -190,19 +184,8 @@ class TestUpdateProviderUseCase:
         ]
         router_repository.get_router_by_id.return_value = new_router
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=2,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
         # Act
-        result = await use_case.execute(command=command)
+        result = await use_case.execute(command=full_command(provider, router_id=2))
 
         # Assert
         assert isinstance(result, InconsistentModelMaxContextLengthError)
@@ -213,15 +196,14 @@ class TestUpdateProviderUseCase:
 
     @pytest.mark.asyncio
     async def test_should_not_call_update_provider_when_no_fields_are_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router, default_command
+        self, use_case, provider_repository, router_repository, sample_provider, sample_router, unchanged_command
     ):
         # Arrange
-
         provider_repository.get_one_provider.return_value = sample_provider
         router_repository.get_router_by_id.return_value = sample_router
 
         # Act
-        result = await use_case.execute(command=default_command)
+        result = await use_case.execute(command=unchanged_command)
 
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
@@ -229,19 +211,25 @@ class TestUpdateProviderUseCase:
         provider_repository.update_provider.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_should_return_updated_provider_when_timeout_is_changed(
+    async def test_should_replace_every_persisted_field_with_the_command_values(
         self, use_case, provider_repository, router_repository, sample_provider, sample_router
     ):
         # Arrange
-        updated_provider = sample_provider.with_timeout(60)
+        updated_provider = (
+            sample_provider.with_timeout(60)
+            .with_model_hosting_zone(HostingZone.FRA)
+            .with_model_total_params(7)
+            .with_model_active_params(3)
+            .with_qos_metric(QoSMetric.TTFT)
+            .with_qos_limit(100.0)
+        )
 
         provider_repository.get_one_provider.return_value = sample_provider
         router_repository.get_router_by_id.return_value = sample_router
         provider_repository.update_provider.return_value = updated_provider
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
+        command = full_command(
+            sample_provider,
             timeout=60,
             model_hosting_zone=None,
             model_total_params=None,
@@ -334,26 +322,14 @@ class TestUpdateProviderUseCase:
         self, use_case, provider_repository, router_repository, sample_provider, sample_router
     ):
         # Arrange
-
         provider_repository.get_one_provider.return_value = sample_provider
         router_repository.get_router_by_id.return_value = sample_router
         provider_repository.update_provider.return_value = ProviderAlreadyExistsError(
             model_name=sample_provider.model_name, url=sample_provider.url, router_id=sample_provider.router_id
         )
 
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=60,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
         # Act
-        result = await use_case.execute(command=command)
+        result = await use_case.execute(command=full_command(sample_provider, timeout=60))
 
         # Assert
         assert isinstance(result, ProviderAlreadyExistsError)
@@ -409,98 +385,8 @@ class TestUpdateProviderUseCase:
             timeout=None,
             model_hosting_zone=None,
             model_total_params=7,
-            model_active_params=None,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
-        # Act
-        result = await use_case.execute(command=command)
-
-        # Assert
-        assert isinstance(result, UpdateProviderUseCaseSuccess)
-        assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_model_total_params(7))
-
-    @pytest.mark.asyncio
-    async def test_should_return_updated_provider_when_model_active_params_is_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
-    ):
-        # Arrange
-        updated_provider = sample_provider.with_model_active_params(3)
-
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
-        provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
             model_active_params=3,
-            qos_metric=None,
-            qos_limit=None,
-        )
-
-        # Act
-        result = await use_case.execute(command=command)
-
-        # Assert
-        assert isinstance(result, UpdateProviderUseCaseSuccess)
-        assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_model_active_params(3))
-
-    @pytest.mark.asyncio
-    async def test_should_return_updated_provider_when_qos_metric_is_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
-    ):
-        # Arrange
-        updated_provider = sample_provider.with_qos_metric(QoSMetric.TTFT)
-
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
-        provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
             qos_metric=QoSMetric.TTFT,
-            qos_limit=None,
-        )
-
-        # Act
-        result = await use_case.execute(command=command)
-
-        # Assert
-        assert isinstance(result, UpdateProviderUseCaseSuccess)
-        assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_qos_metric(QoSMetric.TTFT))
-
-    @pytest.mark.asyncio
-    async def test_should_return_updated_provider_when_qos_limit_is_changed(
-        self, use_case, provider_repository, router_repository, sample_provider, sample_router
-    ):
-        # Arrange
-        updated_provider = sample_provider.with_qos_limit(100.0)
-
-        provider_repository.get_one_provider.return_value = sample_provider
-        router_repository.get_router_by_id.return_value = sample_router
-        provider_repository.update_provider.return_value = updated_provider
-
-        command = UpdateProviderCommand(
-            provider_id=10,
-            router_id=None,
-            timeout=None,
-            model_hosting_zone=None,
-            model_total_params=None,
-            model_active_params=None,
-            qos_metric=None,
             qos_limit=100.0,
         )
 
@@ -510,4 +396,43 @@ class TestUpdateProviderUseCase:
         # Assert
         assert isinstance(result, UpdateProviderUseCaseSuccess)
         assert result.provider == updated_provider
-        provider_repository.update_provider.assert_called_once_with(sample_provider.with_qos_limit(100.0))
+        provider_repository.update_provider.assert_called_once_with(updated_provider)
+        # The router is unchanged: it is not resolved a second time for the compatibility checks.
+        router_repository.get_router_by_id.assert_called_once_with(router_id=sample_provider.router_id)
+
+    @pytest.mark.asyncio
+    async def test_should_clear_qos_policy_when_qos_fields_are_none(self, use_case, provider_repository, router_repository, sample_router):
+        # Arrange
+        provider = ProviderFactory(id=10, router_id=1, user_id=1, type=ProviderType.VLLM, qos_metric=QoSMetric.TTFT, qos_limit=100.0)
+        cleared_provider = provider.with_qos_metric(None).with_qos_limit(None)
+
+        provider_repository.get_one_provider.return_value = provider
+        router_repository.get_router_by_id.return_value = sample_router
+        provider_repository.update_provider.return_value = cleared_provider
+
+        # Act
+        result = await use_case.execute(command=full_command(provider, qos_metric=None, qos_limit=None))
+
+        # Assert
+        assert isinstance(result, UpdateProviderUseCaseSuccess)
+        assert result.provider == cleared_provider
+        provider_repository.update_provider.assert_called_once_with(cleared_provider)
+
+    @pytest.mark.asyncio
+    async def test_should_return_updated_provider_when_router_is_changed(self, use_case, provider_repository, router_repository, sample_provider):
+        # Arrange
+        current_router = RouterFactory(id=1, type=RouterType.TEXT_GENERATION, providers=0)
+        new_router = RouterFactory(id=2, type=RouterType.TEXT_GENERATION, providers=1)
+        updated_provider = sample_provider.with_router_id(new_router.id)
+
+        provider_repository.get_one_provider.return_value = sample_provider
+        router_repository.get_router_by_id.side_effect = [current_router, new_router]
+        provider_repository.update_provider.return_value = updated_provider
+
+        # Act
+        result = await use_case.execute(command=full_command(sample_provider, router_id=2))
+
+        # Assert
+        assert isinstance(result, UpdateProviderUseCaseSuccess)
+        assert result.provider == updated_provider
+        provider_repository.update_provider.assert_called_once_with(updated_provider)

--- a/api/tests/unit/use_case/admin/roles/test_updateroleusecase.py
+++ b/api/tests/unit/use_case/admin/roles/test_updateroleusecase.py
@@ -37,10 +37,23 @@ def sample_role():
     return RoleFactory(id=1, name="original-role", permissions=[PermissionType.READ_METRIC], limits=[])
 
 
+def full_command(role, **overrides) -> UpdateRoleCommand:
+    """Command replacing every persisted field with the current role values, unless overridden."""
+    command = UpdateRoleCommand(
+        role_id=role.id,
+        name=role.name,
+        permissions=role.permissions,
+        limits=role.limits,
+    )
+    for field, value in overrides.items():
+        setattr(command, field, value)
+    return command
+
+
 @pytest.fixture
 def unchanged_command(sample_role):
     """Command replaying the current role state: a full payload that changes nothing."""
-    return UpdateRoleCommand(role_id=sample_role.id, name=sample_role.name, permissions=sample_role.permissions, limits=sample_role.limits)
+    return full_command(sample_role)
 
 
 class TestUpdateRoleUseCase:
@@ -79,7 +92,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=sample_role.permissions, limits=sample_role.limits)
+        command = full_command(sample_role, name="new-name")
 
         # Act
         result = await use_case.execute(command=command)
@@ -98,7 +111,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name=sample_role.name, permissions=sample_role.permissions, limits=new_limits)
+        command = full_command(sample_role, limits=new_limits)
 
         # Act
         result = await use_case.execute(command=command)
@@ -117,7 +130,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name=sample_role.name, permissions=new_permissions, limits=sample_role.limits)
+        command = full_command(sample_role, permissions=new_permissions)
 
         # Act
         result = await use_case.execute(command=command)
@@ -139,7 +152,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name="updated", permissions=new_permissions, limits=new_limits)
+        command = full_command(sample_role, name="updated", permissions=new_permissions, limits=new_limits)
 
         # Act
         result = await use_case.execute(command=command)
@@ -158,11 +171,10 @@ class TestUpdateRoleUseCase:
         # Arrange
         role = RoleFactory(id=1, name="original-role", permissions=[PermissionType.ADMIN], limits=[LimitFactory(router_id=1, type=LimitType.TPM, value=1000)])  # fmt: off
         cleared_role = role.with_permissions([]).with_limits([])
+        command = full_command(role, permissions=[], limits=[])
 
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = role
         role_repository.update_role.return_value = cleared_role
-
-        command = UpdateRoleCommand(role_id=1, name=role.name, permissions=[], limits=[])
 
         # Act
         result = await use_case.execute(command=command)
@@ -182,7 +194,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = RoleAlreadyExistsError(name="new-name")
 
-        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=sample_role.permissions, limits=sample_role.limits)
+        command = full_command(sample_role, name="new-name")
 
         # Act
         result = await use_case.execute(command=command)

--- a/api/tests/unit/use_case/admin/roles/test_updateroleusecase.py
+++ b/api/tests/unit/use_case/admin/roles/test_updateroleusecase.py
@@ -38,18 +38,19 @@ def sample_role():
 
 
 @pytest.fixture
-def default_command():
-    return UpdateRoleCommand(role_id=1, name=None, permissions=None, limits=None)
+def unchanged_command(sample_role):
+    """Command replaying the current role state: a full payload that changes nothing."""
+    return UpdateRoleCommand(role_id=sample_role.id, name=sample_role.name, permissions=sample_role.permissions, limits=sample_role.limits)
 
 
 class TestUpdateRoleUseCase:
     @pytest.mark.asyncio
-    async def test_should_return_role_not_found_error_when_role_does_not_exist(self, use_case, role_repository, default_command):
+    async def test_should_return_role_not_found_error_when_role_does_not_exist(self, use_case, role_repository, unchanged_command):
         # Arrange
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = RoleNotFoundError(id=1)
 
         # Act
-        result = await use_case.execute(command=default_command)
+        result = await use_case.execute(command=unchanged_command)
 
         # Assert
         assert isinstance(result, RoleNotFoundError)
@@ -58,12 +59,12 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.assert_called_once_with(role_id=1)
 
     @pytest.mark.asyncio
-    async def test_should_not_call_update_role_when_no_fields_are_changed(self, use_case, role_repository, sample_role, default_command):
+    async def test_should_not_call_update_role_when_no_fields_are_changed(self, use_case, role_repository, sample_role, unchanged_command):
         # Arrange
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
 
         # Act
-        result = await use_case.execute(command=default_command)
+        result = await use_case.execute(command=unchanged_command)
 
         # Assert
         assert isinstance(result, UpdateRoleUseCaseSuccess)
@@ -78,7 +79,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=None, limits=None)
+        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=sample_role.permissions, limits=sample_role.limits)
 
         # Act
         result = await use_case.execute(command=command)
@@ -97,7 +98,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name=None, permissions=None, limits=new_limits)
+        command = UpdateRoleCommand(role_id=1, name=sample_role.name, permissions=sample_role.permissions, limits=new_limits)
 
         # Act
         result = await use_case.execute(command=command)
@@ -116,7 +117,7 @@ class TestUpdateRoleUseCase:
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = updated_role
 
-        command = UpdateRoleCommand(role_id=1, name=None, permissions=new_permissions, limits=None)
+        command = UpdateRoleCommand(role_id=1, name=sample_role.name, permissions=new_permissions, limits=sample_role.limits)
 
         # Act
         result = await use_case.execute(command=command)
@@ -153,12 +154,35 @@ class TestUpdateRoleUseCase:
         permission_repository.create_permissions.assert_called_once_with(role_id=sample_role.id, permissions=new_permissions)
 
     @pytest.mark.asyncio
+    async def test_should_clear_limits_and_permissions_when_lists_are_empty(self, use_case, role_repository, limit_repository, permission_repository):
+        # Arrange
+        role = RoleFactory(id=1, name="original-role", permissions=[PermissionType.ADMIN], limits=[LimitFactory(router_id=1, type=LimitType.TPM, value=1000)])  # fmt: off
+        cleared_role = role.with_permissions([]).with_limits([])
+
+        role_repository.get_role_with_permissions_and_limits_by_id.return_value = role
+        role_repository.update_role.return_value = cleared_role
+
+        command = UpdateRoleCommand(role_id=1, name=role.name, permissions=[], limits=[])
+
+        # Act
+        result = await use_case.execute(command=command)
+
+        # Assert
+        assert isinstance(result, UpdateRoleUseCaseSuccess)
+        assert result.role == cleared_role
+        role_repository.update_role.assert_called_once_with(role=cleared_role)
+        limit_repository.delete_limits_by_role_id.assert_called_once_with(1)
+        limit_repository.create_limits.assert_called_once_with(role_id=role.id, limits=[])
+        permission_repository.delete_permissions_by_role_id.assert_called_once_with(1)
+        permission_repository.create_permissions.assert_called_once_with(role_id=role.id, permissions=[])
+
+    @pytest.mark.asyncio
     async def test_should_propagate_role_already_exists_error_from_update_role(self, use_case, role_repository, sample_role):
         # Arrange
         role_repository.get_role_with_permissions_and_limits_by_id.return_value = sample_role
         role_repository.update_role.return_value = RoleAlreadyExistsError(name="new-name")
 
-        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=None, limits=None)
+        command = UpdateRoleCommand(role_id=1, name="new-name", permissions=sample_role.permissions, limits=sample_role.limits)
 
         # Act
         result = await use_case.execute(command=command)

--- a/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
@@ -24,6 +24,22 @@ def sample_router():
     return RouterFactory(id=42, user_id=1, name="original-name", aliases=[])
 
 
+def full_command(router, **overrides) -> UpdateRouterCommand:
+    """Command replacing every persisted field with the current router values, unless overridden."""
+    command = UpdateRouterCommand(
+        router_id=router.id,
+        name=router.name,
+        router_type=router.type,
+        aliases=router.aliases or [],
+        load_balancing_strategy=router.load_balancing_strategy,
+        cost_prompt_tokens=router.cost_prompt_tokens,
+        cost_completion_tokens=router.cost_completion_tokens,
+    )
+    for field, value in overrides.items():
+        setattr(command, field, value)
+    return command
+
+
 class TestUpdateRouterUseCase:
     @pytest.mark.asyncio
     async def test_should_return_updated_router_when_user_is_admin_and_router_exists(self, use_case, router_repository, sample_router):
@@ -43,8 +59,8 @@ class TestUpdateRouterUseCase:
 
         # Act
         result = await use_case.execute(
-            command=UpdateRouterCommand(
-                router_id=42,
+            command=full_command(
+                sample_router,
                 name="new-name",
                 router_type=RouterType.TEXT_EMBEDDINGS_INFERENCE,
                 load_balancing_strategy=RouterLoadBalancingStrategy.LEAST_BUSY,
@@ -68,7 +84,7 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.get_router_by_id.return_value = RouterNotFoundError(id=99)
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=99))
+        result = await use_case.execute(command=full_command(RouterFactory(id=99, user_id=1)))
 
         # Assert
         assert isinstance(result, RouterNotFoundError)
@@ -83,7 +99,7 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.get_aliases.return_value = ["conflicting-alias"]
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=42, aliases=["conflicting-alias"]))
+        result = await use_case.execute(command=full_command(sample_router, aliases=["conflicting-alias"]))
 
         # Assert
         assert isinstance(result, RouterAliasAlreadyExistsError)
@@ -101,24 +117,29 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.update_router.return_value = updated_router
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=42, aliases=["own-alias", "new-alias"]))
+        result = await use_case.execute(command=full_command(router, aliases=["own-alias", "new-alias"]))
 
         # Assert
         assert isinstance(result, UpdateRouterUseCaseSuccess)
         router_repository.update_router.assert_called_once_with(router=router.with_aliases(["own-alias", "new-alias"]))
 
     @pytest.mark.asyncio
-    async def test_should_not_check_aliases_when_command_aliases_is_none(self, use_case, router_repository, sample_router):
+    async def test_should_clear_aliases_when_command_aliases_is_empty(self, use_case, router_repository):
         # Arrange
+        router = RouterFactory(id=42, user_id=1, aliases=["own-alias"])
+        cleared_router = router.with_aliases([])
 
-        use_case.router_repository.get_router_by_id.return_value = sample_router
-        use_case.router_repository.update_router.return_value = sample_router
+        use_case.router_repository.get_router_by_id.return_value = router
+        use_case.router_repository.update_router.return_value = cleared_router
 
         # Act
-        await use_case.execute(command=UpdateRouterCommand(router_id=42, aliases=None))
+        result = await use_case.execute(command=full_command(router, aliases=[]))
 
         # Assert
+        assert isinstance(result, UpdateRouterUseCaseSuccess)
+        assert result.router == cleared_router
         router_repository.get_aliases.assert_not_called()
+        router_repository.update_router.assert_called_once_with(router=cleared_router)
 
     @pytest.mark.asyncio
     async def test_should_propagate_router_name_already_exists_error_from_repository(self, use_case, router_repository, sample_router):
@@ -128,7 +149,7 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.update_router.return_value = RouterNameAlreadyExistsError(name="taken-name")
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=42, name="taken-name"))
+        result = await use_case.execute(command=full_command(sample_router, name="taken-name"))
 
         # Assert
         assert isinstance(result, RouterNameAlreadyExistsError)
@@ -145,7 +166,7 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.update_router.return_value = updated_router
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=42, aliases=["new-alias"]))
+        result = await use_case.execute(command=full_command(router, aliases=["new-alias"]))
 
         # Assert
         assert isinstance(result, UpdateRouterUseCaseSuccess)
@@ -158,7 +179,7 @@ class TestUpdateRouterUseCase:
         use_case.router_repository.get_router_by_id.return_value = sample_router
 
         # Act
-        result = await use_case.execute(command=UpdateRouterCommand(router_id=42))
+        result = await use_case.execute(command=full_command(sample_router))
 
         # Assert
         assert isinstance(result, UpdateRouterUseCaseSuccess)

--- a/api/tests/unit/use_case/admin/users/test_updateuserusecase.py
+++ b/api/tests/unit/use_case/admin/users/test_updateuserusecase.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 from pydantic import SecretStr
@@ -103,7 +104,7 @@ class TestUpdateUserUseCase:
                 role_id=3,
                 organization_id=8,
                 budget=42.0,
-                expires=1893456000,
+                expires=datetime(2030, 1, 1, tzinfo=UTC),
                 priority=5,
             )
         )
@@ -115,7 +116,7 @@ class TestUpdateUserUseCase:
         assert result.user.role_id == 3
         assert result.user.organization_id == 8
         assert result.user.budget == 42.0
-        assert result.user.expires == 1893456000
+        assert result.user.expires == datetime(2030, 1, 1, tzinfo=UTC)
         assert result.user.priority == 5
 
     @pytest.mark.asyncio

--- a/api/tests/unit/use_case/admin/users/test_updateuserusecase.py
+++ b/api/tests/unit/use_case/admin/users/test_updateuserusecase.py
@@ -33,6 +33,23 @@ def sample_user():
     return UserFactory(id=42, organization_id=7, budget=100.0, expires=None, priority=1)
 
 
+def full_command(user, **overrides) -> UpdateUserCommand:
+    """Command replacing every persisted field with the current user values, unless overridden."""
+    command = UpdateUserCommand(
+        user_id=user.id,
+        email=user.email,
+        name=user.name,
+        role_id=user.role_id,
+        organization_id=user.organization_id,
+        budget=user.budget,
+        expires=user.expires,
+        priority=user.priority,
+    )
+    for field, value in overrides.items():
+        setattr(command, field, value)
+    return command
+
+
 class TestUpdateUserUseCase:
     @pytest.mark.asyncio
     async def test_should_return_updated_user_when_user_exists(self, use_case, user_repository, sample_user):
@@ -41,7 +58,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.side_effect = lambda user: user
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, email="new@example.com", role_id=3))
+        result = await use_case.execute(full_command(sample_user, email="new@example.com", role_id=3))
 
         # Assert
         assert isinstance(result, UpdateUserUseCaseSuccess)
@@ -51,26 +68,55 @@ class TestUpdateUserUseCase:
         user_repository.update_user.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_should_keep_non_nullable_fields_and_clear_nullable_fields_when_fields_are_none(self, use_case, user_repository, sample_user):
+    async def test_should_clear_nullable_fields_when_command_fields_are_none(self, use_case, user_repository, sample_user):
         # Arrange
         user_repository.get_user_by_id.return_value = sample_user
         user_repository.update_user.side_effect = lambda user: user
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id))
+        result = await use_case.execute(full_command(sample_user, name=None, organization_id=None, budget=None, expires=None))
 
         # Assert
         assert isinstance(result, UpdateUserUseCaseSuccess)
-        # Non-nullable columns keep their current value.
-        assert result.user.email == sample_user.email
-        assert result.user.role_id == sample_user.role_id
-        assert result.user.priority == sample_user.priority
-        assert result.user.password == sample_user.password
-        # Nullable columns are cleared.
         assert result.user.name is None
         assert result.user.organization_id is None
         assert result.user.budget is None
         assert result.user.expires is None
+        # The other persisted fields keep the values sent by the command.
+        assert result.user.email == sample_user.email
+        assert result.user.role_id == sample_user.role_id
+        assert result.user.priority == sample_user.priority
+        assert result.user.password == sample_user.password
+
+    @pytest.mark.asyncio
+    async def test_should_replace_every_persisted_field_with_the_command_values(self, use_case, user_repository, sample_user):
+        # Arrange
+        user_repository.get_user_by_id.return_value = sample_user
+        user_repository.update_user.side_effect = lambda user: user
+
+        # Act
+        result = await use_case.execute(
+            full_command(
+                sample_user,
+                email="new@example.com",
+                name="New Name",
+                role_id=3,
+                organization_id=8,
+                budget=42.0,
+                expires=1893456000,
+                priority=5,
+            )
+        )
+
+        # Assert
+        assert isinstance(result, UpdateUserUseCaseSuccess)
+        assert result.user.email == "new@example.com"
+        assert result.user.name == "New Name"
+        assert result.user.role_id == 3
+        assert result.user.organization_id == 8
+        assert result.user.budget == 42.0
+        assert result.user.expires == 1893456000
+        assert result.user.priority == 5
 
     @pytest.mark.asyncio
     async def test_should_keep_current_password_when_no_new_password(self, use_case, user_repository, user_password_encoder, sample_user):
@@ -79,7 +125,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.side_effect = lambda user: user
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, current_password="old"))
+        result = await use_case.execute(full_command(sample_user, current_password="old"))
 
         # Assert
         assert isinstance(result, UpdateUserUseCaseSuccess)
@@ -95,7 +141,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.side_effect = lambda user: user
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, new_password="secret"))
+        result = await use_case.execute(full_command(sample_user, new_password="secret"))
 
         # Assert
         assert isinstance(result, UpdateUserUseCaseSuccess)
@@ -111,7 +157,7 @@ class TestUpdateUserUseCase:
         user_password_encoder.validate_password.return_value = True
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, current_password="old", new_password="secret"))
+        result = await use_case.execute(full_command(sample_user, current_password="old", new_password="secret"))
 
         # Assert
         assert isinstance(result, UpdateUserUseCaseSuccess)
@@ -124,7 +170,7 @@ class TestUpdateUserUseCase:
         user_repository.get_user_by_id.return_value = UserNotFoundError(id=99)
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=99, email="new@example.com"))
+        result = await use_case.execute(full_command(UserFactory(id=99), email="new@example.com"))
 
         # Assert
         assert isinstance(result, UserNotFoundError)
@@ -140,7 +186,7 @@ class TestUpdateUserUseCase:
         user_password_encoder.validate_password.return_value = False
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, current_password="wrong", new_password="secret"))
+        result = await use_case.execute(full_command(sample_user, current_password="wrong", new_password="secret"))
 
         # Assert
         assert isinstance(result, IncorrectCurrentPasswordError)
@@ -155,7 +201,7 @@ class TestUpdateUserUseCase:
         user_repository.get_user_by_id.return_value = sample_user.model_copy(update={"password": None})
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, current_password="old", new_password="secret"))
+        result = await use_case.execute(full_command(sample_user, current_password="old", new_password="secret"))
 
         # Assert
         assert isinstance(result, IncorrectCurrentPasswordError)
@@ -169,7 +215,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.return_value = RoleNotFoundError(id=3)
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, role_id=3))
+        result = await use_case.execute(full_command(sample_user, role_id=3))
 
         # Assert
         assert isinstance(result, RoleNotFoundError)
@@ -184,7 +230,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.return_value = OrganizationNotFoundError(id=8)
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, organization_id=8))
+        result = await use_case.execute(full_command(sample_user, organization_id=8))
 
         # Assert
         assert isinstance(result, OrganizationNotFoundError)
@@ -197,7 +243,7 @@ class TestUpdateUserUseCase:
         user_repository.update_user.return_value = UserAlreadyExistsError(email="taken@example.com")
 
         # Act
-        result = await use_case.execute(UpdateUserCommand(user_id=sample_user.id, email="taken@example.com"))
+        result = await use_case.execute(full_command(sample_user, email="taken@example.com"))
 
         # Assert
         assert isinstance(result, UserAlreadyExistsError)

--- a/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
+++ b/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime
 from unittest.mock import create_autospec
 
 from openai.types import Embedding
@@ -40,7 +39,7 @@ def model_entity(model_id: str = DEFAULT_MODEL_ID, aliases: list[str] | None = N
     return Model(
         id=model_id,
         aliases=aliases or [],
-        created=datetime(1970, 1, 1, tzinfo=UTC),
+        created=0,
         owned_by="test",
         max_context_length=max_context_length,
         type=RouterType.TEXT_GENERATION,

--- a/api/use_cases/admin/providers/_updateproviderusecase.py
+++ b/api/use_cases/admin/providers/_updateproviderusecase.py
@@ -2,21 +2,22 @@ from dataclasses import dataclass
 
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError
 from api.domain.provider import ProviderRepository
-from api.domain.provider.entities import HostingZone, Metric, Provider
+from api.domain.provider.entities import HostingZone, Provider, QoSMetric
 from api.domain.provider.errors import InvalidProviderTypeError, ProviderAlreadyExistsError, ProviderNotFoundError
 from api.domain.router import RouterRepository
+from api.domain.router.entities import Router
 from api.domain.router.errors import RouterNotFoundError
 
 
 @dataclass
 class UpdateProviderCommand:
     provider_id: int
-    router_id: int | None
-    timeout: int | None
-    model_hosting_zone: HostingZone | None
-    model_total_params: int | None
-    model_active_params: int | None
-    qos_metric: Metric | None
+    router_id: int
+    timeout: int
+    model_hosting_zone: HostingZone
+    model_total_params: int
+    model_active_params: int
+    qos_metric: QoSMetric | None
     qos_limit: float | None
 
 
@@ -50,13 +51,15 @@ class UpdateProviderUseCase:
         if isinstance(existing_provider, ProviderNotFoundError):
             return existing_provider
 
-        provider_to_persist = existing_provider
-        if command.router_id is not None:
-            new_router = await self.router_repository.get_router_by_id(router_id=command.router_id)
-            if isinstance(new_router, RouterNotFoundError):
-                return new_router
-            if not existing_provider.is_compatible_with(new_router):
-                return InvalidProviderTypeError(provider_type=existing_provider.type.value, router_type=new_router.type.value)
+        if command.router_id != existing_provider.router_id:
+            result = await self.router_repository.get_router_by_id(router_id=command.router_id)
+
+            match result:
+                case Router() as new_router:
+                    if not existing_provider.is_compatible_with(new_router):
+                        return InvalidProviderTypeError(provider_type=existing_provider.type.value, router_type=new_router.type.value)
+                case RouterNotFoundError() as error:
+                    return error
 
             # all providers of a router must expose the same capabilities: compare with one of the providers already attached to the target router
             new_router_providers = await self.provider_repository.get_all_providers_of_router(router_id=new_router.id)
@@ -74,20 +77,16 @@ class UpdateProviderUseCase:
                         expected_max_context_length=reference_provider.max_context_length,
                         router_name=new_router.name,
                     )
-            provider_to_persist = existing_provider.with_router_id(new_router.id)
 
-        if command.timeout is not None:
-            provider_to_persist = provider_to_persist.with_timeout(command.timeout)
-        if command.model_hosting_zone is not None:
-            provider_to_persist = provider_to_persist.with_model_hosting_zone(command.model_hosting_zone)
-        if command.model_total_params is not None:
-            provider_to_persist = provider_to_persist.with_model_total_params(command.model_total_params)
-        if command.model_active_params is not None:
-            provider_to_persist = provider_to_persist.with_model_active_params(command.model_active_params)
-        if command.qos_metric is not None:
-            provider_to_persist = provider_to_persist.with_qos_metric(command.qos_metric)
-        if command.qos_limit is not None:
-            provider_to_persist = provider_to_persist.with_qos_limit(command.qos_limit)
+        provider_to_persist = (
+            existing_provider.with_router_id(command.router_id)
+            .with_timeout(command.timeout)
+            .with_model_hosting_zone(command.model_hosting_zone)
+            .with_model_total_params(command.model_total_params)
+            .with_model_active_params(command.model_active_params)
+            .with_qos_metric(command.qos_metric)
+            .with_qos_limit(command.qos_limit)
+        )
 
         if existing_provider == provider_to_persist:
             return UpdateProviderUseCaseSuccess(existing_provider)

--- a/api/use_cases/admin/roles/_updateroleusecase.py
+++ b/api/use_cases/admin/roles/_updateroleusecase.py
@@ -7,10 +7,12 @@ from api.domain.role.errors import RoleAlreadyExistsError, RoleNotFoundError
 
 @dataclass
 class UpdateRoleCommand:
+    """Full replacement of the role persisted fields: empty lists clear permissions and limits."""
+
     role_id: int
-    name: str | None
-    permissions: list[PermissionType] | None
-    limits: list[Limit] | None
+    name: str
+    permissions: list[PermissionType]
+    limits: list[Limit]
 
 
 @dataclass
@@ -31,17 +33,14 @@ class UpdateRoleUseCase:
         role = await self.role_repository.get_role_with_permissions_and_limits_by_id(role_id=command.role_id)
         if isinstance(role, RoleNotFoundError):
             return role
-        role_to_persist = role
-        if command.name is not None:
-            role_to_persist = role_to_persist.with_name(command.name)
-        if command.limits is not None:
-            role_to_persist = role_to_persist.with_limits(command.limits)
-            await self.limit_repository.delete_limits_by_role_id(command.role_id)
-            await self.limit_repository.create_limits(role_id=role.id, limits=command.limits)
-        if command.permissions is not None:
-            role_to_persist = role_to_persist.with_permissions(command.permissions)
-            await self.permission_repository.delete_permissions_by_role_id(command.role_id)
-            await self.permission_repository.create_permissions(role_id=role.id, permissions=command.permissions)
+
+        role_to_persist = role.with_name(command.name).with_limits(command.limits).with_permissions(command.permissions)
+
+        await self.limit_repository.delete_limits_by_role_id(command.role_id)
+        await self.limit_repository.create_limits(role_id=role.id, limits=command.limits)
+        await self.permission_repository.delete_permissions_by_role_id(command.role_id)
+        await self.permission_repository.create_permissions(role_id=role.id, permissions=command.permissions)
+
         if role_to_persist == role:
             return UpdateRoleUseCaseSuccess(role=role)
 

--- a/api/use_cases/admin/routers/_updaterouterusecase.py
+++ b/api/use_cases/admin/routers/_updaterouterusecase.py
@@ -9,12 +9,12 @@ from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAl
 @dataclass
 class UpdateRouterCommand:
     router_id: int
-    name: str | None = None
-    router_type: RouterType | None = None
-    aliases: list[str] | None = None
-    load_balancing_strategy: RouterLoadBalancingStrategy | None = None
-    cost_prompt_tokens: float | None = None
-    cost_completion_tokens: float | None = None
+    name: str
+    router_type: RouterType
+    aliases: list[str]
+    load_balancing_strategy: RouterLoadBalancingStrategy
+    cost_prompt_tokens: float
+    cost_completion_tokens: float
 
 
 @dataclass
@@ -40,19 +40,14 @@ class UpdateRouterUseCase:
             if conflicting_aliases:
                 return RouterAliasAlreadyExistsError(aliases=list(conflicting_aliases))
 
-        router_to_persist = router
-        if command.name is not None:
-            router_to_persist = router_to_persist.with_name(command.name)
-        if command.router_type is not None:
-            router_to_persist = router_to_persist.with_type(command.router_type)
-        if command.load_balancing_strategy is not None:
-            router_to_persist = router_to_persist.with_load_balancing_strategy(command.load_balancing_strategy)
-        if command.cost_prompt_tokens is not None:
-            router_to_persist = router_to_persist.with_cost_prompt_tokens(command.cost_prompt_tokens)
-        if command.cost_completion_tokens is not None:
-            router_to_persist = router_to_persist.with_cost_completion_tokens(command.cost_completion_tokens)
-        if command.aliases is not None:
-            router_to_persist = router_to_persist.with_aliases(command.aliases)
+        router_to_persist = (
+            router.with_name(command.name)
+            .with_type(command.router_type)
+            .with_load_balancing_strategy(command.load_balancing_strategy)
+            .with_cost_prompt_tokens(command.cost_prompt_tokens)
+            .with_cost_completion_tokens(command.cost_completion_tokens)
+            .with_aliases(command.aliases)
+        )
 
         if router_to_persist == router:
             return UpdateRouterUseCaseSuccess(router=router)

--- a/api/use_cases/admin/users/_createuserusecase.py
+++ b/api/use_cases/admin/users/_createuserusecase.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from datetime import datetime
 
+from api.domain import UtcDatetime
 from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
 from api.domain.user import UserPasswordEncoder, UserRepository
@@ -16,7 +16,7 @@ class CreateUserCommand:
     name: str | None = None
     organization_id: int | None = None
     budget: float | None = None
-    expires: datetime | None = None
+    expires: UtcDatetime | None = None
     priority: int = 0
 
 

--- a/api/use_cases/admin/users/_updateuserusecase.py
+++ b/api/use_cases/admin/users/_updateuserusecase.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from datetime import datetime
 
 from pydantic import SecretStr
 
+from api.domain import UtcDatetime
 from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
 from api.domain.user import UserPasswordEncoder, UserRepository
@@ -18,7 +18,7 @@ class UpdateUserCommand:
     role_id: int
     organization_id: int | None
     budget: float | None
-    expires: datetime | None
+    expires: UtcDatetime | None
     priority: int
     current_password: str | None = None
     new_password: str | None = None

--- a/api/use_cases/admin/users/_updateuserusecase.py
+++ b/api/use_cases/admin/users/_updateuserusecase.py
@@ -13,15 +13,15 @@ from api.domain.user.errors import IncorrectCurrentPasswordError, UserAlreadyExi
 @dataclass
 class UpdateUserCommand:
     user_id: int
-    email: str | None = None
-    name: str | None = None
+    email: str
+    name: str | None
+    role_id: int
+    organization_id: int | None
+    budget: float | None
+    expires: datetime | None
+    priority: int
     current_password: str | None = None
     new_password: str | None = None
-    role_id: int | None = None
-    organization_id: int | None = None
-    budget: float | None = None
-    expires: datetime | None = None
-    priority: int | None = None
 
 
 @dataclass
@@ -62,9 +62,9 @@ class UpdateUserUseCase:
 
         updated_user = existing_user.model_copy(
             update={
-                "email": command.email if command.email is not None else existing_user.email,
-                "role_id": command.role_id if command.role_id is not None else existing_user.role_id,
-                "priority": command.priority if command.priority is not None else existing_user.priority,
+                "email": command.email,
+                "role_id": command.role_id,
+                "priority": command.priority,
                 "name": command.name,
                 "organization_id": command.organization_id,
                 "budget": command.budget,

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -333,13 +333,13 @@ class ProvidersState(EntityState):
         yield
 
         payload = {
-            "router": self.routers_dict.get(self.entity.router, None),
+            "router_id": self.routers_dict.get(self.entity.router),
             "timeout": self.entity.timeout,
             "model_hosting_zone": self.entity.model_hosting_zone,
             "model_total_params": self.entity.model_total_params,
             "model_active_params": self.entity.model_active_params,
             "qos_metric": self.entity.qos_metric.lower() if self.entity.qos_metric else None,
-            "qos_limit": self.entity.qos_limit,
+            "qos_limit": self.entity.qos_limit if self.entity.qos_metric else None,
         }
 
         response = None

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -46,6 +46,17 @@ class RolesState(EntityState):
             updated=format_datetime(role["updated"]),
         )
 
+    def _format_permissions(self, role: Role) -> list[str]:
+        """Format permissions from Playground format to OpenGateLLM format."""
+        permissions = []
+        if role.permissions_admin:
+            permissions.append("admin")
+        if role.permissions_read_metric:
+            permissions.append("read_metric")
+        if role.permissions_provide_models:
+            permissions.append("provide_models")
+        return permissions
+
     def _format_limit(self, limit: dict[str, str | int]) -> list[dict[str, str | int]]:
         """Format limit from Playground format to OpenGateLLM format."""
         return [
@@ -185,18 +196,11 @@ class RolesState(EntityState):
             if limit["router"] == router:
                 continue
 
-            limits.extend(
-                [
-                    {"router_id": self.routers_dict[limit["router"]], "type": "rpm", "value": limit["rpm"]},
-                    {"router_id": self.routers_dict[limit["router"]], "type": "rpd", "value": limit["rpd"]},
-                    {"router_id": self.routers_dict[limit["router"]], "type": "tpm", "value": limit["tpm"]},
-                    {"router_id": self.routers_dict[limit["router"]], "type": "tpd", "value": limit["tpd"]},
-                ]
-            )
+            limits.extend(self._format_limit(limit))
 
         yield
 
-        payload = {"limits": limits}
+        payload = {"name": role.name, "permissions": self._format_permissions(role), "limits": limits}
         response = None
         try:
             async with httpx.AsyncClient() as client:
@@ -259,17 +263,9 @@ class RolesState(EntityState):
         self.create_entity_loading = True
         yield
 
-        permissions = []
-        if self.entity_to_create.permissions_admin:
-            permissions.append("admin")
-        if self.entity_to_create.permissions_read_metric:
-            permissions.append("read_metric")
-        if self.entity_to_create.permissions_provide_models:
-            permissions.append("provide_models")
-
         payload = {
             "name": self.entity_to_create.name,
-            "permissions": permissions,
+            "permissions": self._format_permissions(self.entity_to_create),
             "limits": self.entity_to_create.limits or [],
         }
 
@@ -312,7 +308,7 @@ class RolesState(EntityState):
                 continue
             limits.extend(self._format_limit(limit))
         limits.extend(self._format_limit(self.new_limit))
-        payload = {"limits": limits}
+        payload = {"name": role.name, "permissions": self._format_permissions(role), "limits": limits}
         response = None
         try:
             async with httpx.AsyncClient() as client:
@@ -385,19 +381,11 @@ class RolesState(EntityState):
         self.edit_entity_loading = True
         yield
 
-        permissions = []
-        if self.entity.permissions_admin:
-            permissions.append("admin")
-        if self.entity.permissions_read_metric:
-            permissions.append("read_metric")
-        if self.entity.permissions_provide_models:
-            permissions.append("provide_models")
-
         limits = []
         for limit in self.entity.limits or []:
             limits.extend(self._format_limit(limit))
 
-        payload = {"name": self.entity.name, "permissions": permissions, "limits": limits}
+        payload = {"name": self.entity.name, "permissions": self._format_permissions(self.entity), "limits": limits}
 
         response = None
         try:

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -313,28 +313,21 @@ class UsersState(EntityState):
 
     @rx.event
     async def edit_entity(self):
-        """Update a role."""
+        """Update a user."""
         self.edit_entity_loading = True
         yield
 
-        role_id = self.roles_dict[self.entity.role]
-        organization_id = self.organizations_dict.get(self.entity.organization)
-
         payload = {
             "email": self.entity.email,
-            "name": self.entity.name,
-            "role_id": role_id,
+            "name": self.entity.name or None,
+            "role_id": self.roles_dict[self.entity.role],
+            "organization_id": self.organizations_dict.get(self.entity.organization),
+            "budget": self.entity.budget if self.entity.budget != "" else None,
             "expires": date_to_timestamp(self.entity.expires) if self.entity.expires else None,
             "priority": self.entity.priority,
         }
-        if self.entity.budget == "":
-            payload["budget"] = None
-        else:
-            payload["budget"] = self.entity.budget
         if self.entity.password:
             payload["password"] = self.entity.password
-        if organization_id:
-            payload["organization_id"] = organization_id
 
         response = None
         try:


### PR DESCRIPTION
## Overview

Resolves #919.

Migrated admin `PATCH` endpoints used `None` to mean two contradictory things: *"skip this field"* for `email` / `role_id` / `priority`, and *"clear this field"* for `organization_id` / `budget` / `expires`. The consequence was that a client could **not** clear a nullable field — sending `null` on a provider `qos_metric` was read as "do not update".

This PR replaces skip-on-`None` with **full-payload replacement** on the four clean-architecture update endpoints:

| Endpoint | Body | Use case |
|---|---|---|
| `PATCH /v1/admin/users/{user_id}` | `UserUpdateRequest` | `UpdateUserUseCase` |
| `PATCH /v1/admin/roles/{role_id}` | `UpdateRoleBody` (new) | `UpdateRoleUseCase` |
| `PATCH /v1/admin/routers/{router_id}` | `UpdateRouterBody` | `UpdateRouterUseCase` |
| `PATCH /v1/admin/providers/{provider_id}` | `UpdateProviderBody` | `UpdateProviderUseCase` |

What changed, layer by layer:

- **Schemas** — every persisted field is now required (`Field(...)`). `| None` survives only where `null` is a legitimate stored value, and it then *sets* the column to `null`. `PATCH /v1/admin/roles` no longer reuses the optional `CreateRoleBody`: a dedicated `UpdateRoleBody` was added, since the create body's optional fields carried the wrong meaning and made `limits: []` read as "skip".
- **Use cases** — all `if command.<field> is not None:` branches removed; the command is applied as a replacement. Commands lost their `= None` defaults so a caller cannot build a half-filled one. Write-only `password` / `current_password` stay optional: omitting them leaves the password unchanged.
- **Playground** — `edit_entity` now sends the whole current form state for users, roles and providers (routers already sent a complete body).
- **AGENTS.md** — the new "Update requests are full replacements" convention is documented, per that file's own rule 10.

Two latent bugs were fixed in the code being rewritten:

- `UpdateProviderUseCase` tested `if new_router is None`, but `get_router_by_id` returns `Router | RouterNotFoundError` — the not-found branch was dead and a bad `router_id` never produced a 404. Now uses `isinstance(..., RouterNotFoundError)`.
- `UpdateProviderCommand.qos_metric` was annotated `Metric`, while the body, the entity field and `Provider.with_qos_metric()` all use `QoSMetric` — two different enums (`Metric` has `normalized_latency`; `QoSMetric` has `inflight` / `performance`). Runtime was unaffected, the annotation was simply wrong.

Three playground bugs surfaced while making the payloads complete:

- `providers/state.py` sent `"router"` instead of `"router_id"` — the key was silently ignored, so the router dropdown never actually moved a provider.
- `users/state.py` forwarded `expires` as the `"%Y-%m-%d"` display string instead of a Unix timestamp (`create_entity` already converted it).
- `roles/state.py` had two further `PATCH` call sites beyond `edit_entity` (`create_limit`, `delete_limit`) that sent `{"limits": [...]}` alone and would now be rejected; they send the full role. The duplicated permission-building logic was extracted into `_format_permissions()`.

Finally, `OrganizationSQLFactory` drew `Organization.name` (a `unique=True` column) from `factory.Faker("company")` with no uniqueness guarantee, which made the integration suite fail randomly with `UniqueViolationError on organization_name_key`. It now uses `factory.Sequence`. This flakiness pre-existed the branch (reproduced on `main` at `e83eda0d`), but the tests added here increase the number of draws, so it is fixed as part of this PR.

**Definition of Done:**

- [x] Update request bodies require all persisted fields; no `default=None` meaning "skip"
- [x] `null` on a nullable field persists `null` (clear user org / budget / expires / name, provider QoS)
- [x] Empty lists replace the previous lists (role `permissions` / `limits`, router `aliases`)
- [x] Omitting a required field, or sending `null` on a non-nullable one, returns 422
- [x] Omitting `password` / `current_password` leaves the password unchanged
- [x] Use cases apply the command as a full replacement — no skip-on-`None` branches remain
- [x] Playground user / role / router / provider dialogs send full payloads and can clear nullable fields
- [x] Unit use-case tests cover the new branches; endpoint integration tests cover 422 + full-update happy path
- [x] Legacy update endpoints (`api/endpoints/`, organizations) are unchanged
- [ ] Breaking change documented in the release notes — *see Additional Notes: there is no in-repo release notes file, so this depends on the release process picking up this PR body*

**Breaking changes:**

- [ ] No breaking changes
- [x] This PR contains breaking changes (explain below)

`PATCH /v1/admin/users/{user_id}`, `/v1/admin/roles/{role_id}`, `/v1/admin/routers/{router_id}` and `/v1/admin/providers/{provider_id}` no longer accept partial bodies.

- Omitting a required field, or sending `null` on a non-nullable one → `422`.
- `null` on a nullable field now **clears** it: user `organization_id` / `budget` / `expires` / `name`, provider `qos_metric` / `qos_limit`.
- Empty lists now **clear**: role `permissions` / `limits`, router `aliases`.
- `UpdateProviderBody.timeout` is now bounded `1..3600`, matching `POST /v1/admin/providers`. A previously accepted out-of-range value is now rejected.
- Only `password` / `current_password` remain optional.

Migration for API clients: `GET` the resource, apply the change to the returned object, and send it back in full.

Not affected: legacy routes under `api/endpoints/` (organizations) and `PATCH /v1/me`.

## Check lists

### Review checklist

- [x] Updated or added documentation — `AGENTS.md` gains the "Update requests are full replacements" convention. The OpenAPI reference (`docs/openapi.json`, `docs/redoc-static.html`) is regenerated by the `Release updates` workflow and is intentionally not in this diff.
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

`api/sql/models.py` is **not** modified by this PR — no Alembic migration is required.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No new or updated environment variables, and no special deployment steps. The one operational consideration is the breaking change above: any existing API consumer sending partial `PATCH` bodies to the four admin endpoints (scripts, third-party integrations, ad-hoc `curl`) will start receiving `422` from the moment this is deployed. Worth announcing ahead of the release rather than after.

## Additional Notes

Areas worth a reviewer's attention:

1. **`UpdateProviderUseCase` — router validation is scoped to an actual router change.** Since `router_id` is now always sent, the compatibility / vector-size / max-context-length checks could have run on every update. They are guarded by `if command.router_id != existing_provider.router_id:` instead. Running them unconditionally would newly reject updates to providers whose stored router pairing predates those rules — an admin changing only a timeout would get a `400` they cannot clear. The field itself is still written unconditionally; only the *transition* validation is conditional. Happy to flip this if you prefer the stricter reading.

2. **The e2e suite was modified but not executed.** `api/tests/integ/test_admin/test_admin.py` had partial `PATCH` payloads that would now `422`; they were completed, and a "clear `expires` with `null`" assertion was added. Running `make test-integ` requires `ALBERT_API_KEY`, which was not available. **These changes are unverified** and should be run before merge. Note that `api/tests/integ/config.test.yml` defaults to `localhost:5432/postgres` and the e2e conftest calls `Base.metadata.drop_all()`, so run it with the isolated ports from `.github/.env.ci.example` (`POSTGRES_PORT=15432`, `REDIS_PORT=16379`) to avoid dropping a local dev database.

3. **`test_updateproviderusecase.py` shrinks by ~250 lines.** Under full-replacement semantics, "field X changed in isolation" is no longer a distinct `execute()` branch, so the six near-identical per-field tests were collapsed into one full-replacement test plus a QoS-clearing test. Every error branch remains covered individually.

4. **`PATCH /v1/me` was left out of scope on purpose.** Issue #919 lists it as legacy, but #1024 has since migrated it to `api/infrastructure/`, and it still uses skip-on-`None` for `email` / `name`. It is a natural follow-up, deliberately not bundled here.

Verification run locally: unit `637 passed`, integration `582 passed, 1 skipped` (10 consecutive green runs after the factory fix), `ruff check` and `ruff format --check` clean on all changed files.
