### PR TITLE
feat(metric): remove normalized_latency reference (useless) - fix str, Enum usage

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.46%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.52%", "color": "green"}

--- a/api/clients/model/_basemodelprovider.py
+++ b/api/clients/model/_basemodelprovider.py
@@ -264,16 +264,6 @@ class BaseModelProvider(ABC):
             logger.error(f"Failed to log request metrics (latency) in redis (id: {self.id})", exc_info=True)
             await safe_redis_reset(redis_client)
 
-        try:
-            if latency is not None:
-                key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{Metric.NORMALIZED_LATENCY.value}:{self.id}"
-                await self._ensure_timeseries_exists(redis_client, key)
-                # Use milliseconds timestamp to avoid collisions
-                await redis_client.ts().add(key=key, timestamp=int(time.time() * 1000), value=latency)
-        except Exception:
-            logger.error(f"Failed to log request metrics (latency) in redis (id: {self.id})", exc_info=True)
-            await safe_redis_reset(redis_client)
-
     def _start_langfuse_observation(self, request_content: RequestContent, ctx=None) -> Any | None:
         langfuse_obs = None
         if global_context.langfuse_client is not None:

--- a/api/domain/provider/entities.py
+++ b/api/domain/provider/entities.py
@@ -18,7 +18,6 @@ HostingZone = StrEnum("HostingZone", {str(code).upper(): str(code) for code in s
 class Metric(StrEnum):
     LATENCY = "latency"  # requests latency
     TTFT = "ttft"  # time to first token
-    NORMALIZED_LATENCY = "normalized_latency"  # intended as latency per completion token, but the raw latency is written as is (never normalized)
 
 
 class QoSMetric(StrEnum):

--- a/api/infrastructure/redis/_redisprovidermetricslogger.py
+++ b/api/infrastructure/redis/_redisprovidermetricslogger.py
@@ -20,11 +20,9 @@ class RedisProviderMetricsLogger(ProviderMetricsLogger):
     async def log_metric(self, provider_id: int, metric: Metric, value: float) -> None:
         try:
             timestamp = int(time.time() * 1000)
-            # Maintain all metric series aligned per provider.
-            for series_metric in (Metric.TTFT, Metric.LATENCY):
-                series_key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{series_metric.value}:{provider_id}"
-                await self._ensure_timeseries_exists(series_key)
-                await self.redis_client.ts().add(key=series_key, timestamp=timestamp, value=value)
+            key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{metric.value}:{provider_id}"
+            await self._ensure_timeseries_exists(key)
+            await self.redis_client.ts().add(key=key, timestamp=timestamp, value=value)
         except Exception:
             logger.exception(f"Failed to log request metrics ({metric.value}) in redis (id: {provider_id})")
             await self._safe_redis_reset()

--- a/api/infrastructure/redis/_redisprovidermetricslogger.py
+++ b/api/infrastructure/redis/_redisprovidermetricslogger.py
@@ -21,7 +21,7 @@ class RedisProviderMetricsLogger(ProviderMetricsLogger):
         try:
             timestamp = int(time.time() * 1000)
             # Maintain all metric series aligned per provider.
-            for series_metric in (Metric.TTFT, Metric.LATENCY, Metric.NORMALIZED_LATENCY):
+            for series_metric in (Metric.TTFT, Metric.LATENCY):
                 series_key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{series_metric.value}:{provider_id}"
                 await self._ensure_timeseries_exists(series_key)
                 await self.redis_client.ts().add(key=series_key, timestamp=timestamp, value=value)

--- a/api/schemas/core/models.py
+++ b/api/schemas/core/models.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from http import HTTPMethod
 from typing import Annotated
 
@@ -45,12 +45,11 @@ class RequestContent(BaseModel):
     additional_data: dict = Field(default={}, description="The additional data to add to the response.")
 
 
-class Metric(str, Enum):
+class Metric(StrEnum):
     TTFT = "ttft"  # time to first token
     LATENCY = "latency"  # requests latency
     INFLIGHT = "inflight"  # requests concurrency
     PERFORMANCE = "performance"  # custom performance metric
-    NORMALIZED_LATENCY = "normalized_latency"  # requests latency normalized by the completion tokens
 
 
 # TEI

--- a/api/tests/integration/redis/test_redisprovidermetricslogger.py
+++ b/api/tests/integration/redis/test_redisprovidermetricslogger.py
@@ -14,7 +14,7 @@ def repository(redis_client):
 
 @pytest.mark.asyncio(loop_scope="session")
 class TestRedisProviderMetricsLogger:
-    @pytest.mark.parametrize("metric", [Metric.TTFT, Metric.LATENCY, Metric.NORMALIZED_LATENCY])
+    @pytest.mark.parametrize("metric", [Metric.TTFT, Metric.LATENCY])
     async def test_log_multiple_metric(self, repository: RedisProviderMetricsLogger, redis_client: AsyncRedis, metric: Metric):
         # Arrange
         provider_id = 42
@@ -30,7 +30,7 @@ class TestRedisProviderMetricsLogger:
         assert values[0][1] == 120
         assert values[1][1] == 240
 
-    @pytest.mark.parametrize("metric", [Metric.TTFT, Metric.LATENCY, Metric.NORMALIZED_LATENCY])
+    @pytest.mark.parametrize("metric", [Metric.TTFT, Metric.LATENCY])
     async def test_get_metric_history(self, repository, redis_client: AsyncRedis, metric: Metric):
         # Arrange
         provider_id = 43

--- a/api/tests/integration/redis/test_redisprovidermetricslogger.py
+++ b/api/tests/integration/redis/test_redisprovidermetricslogger.py
@@ -19,16 +19,19 @@ class TestRedisProviderMetricsLogger:
         # Arrange
         provider_id = 42
         key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{metric.value}:{provider_id}"
+        other_metric = Metric.LATENCY if metric == Metric.TTFT else Metric.TTFT
+        other_key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{other_metric.value}:{provider_id}"
 
         # Act
-        await repository.log_metric(provider_id=provider_id, metric=metric.TTFT, value=120)
-        await repository.log_metric(provider_id=provider_id, metric=metric.TTFT, value=240)
+        await repository.log_metric(provider_id=provider_id, metric=metric, value=120)
+        await repository.log_metric(provider_id=provider_id, metric=metric, value=240)
 
         # Assert
         values = await redis_client.ts().range(key=key, from_time="-", to_time="+")
         assert len(values) == 2
         assert values[0][1] == 120
         assert values[1][1] == 240
+        assert await redis_client.exists(other_key) == 0
 
     @pytest.mark.parametrize("metric", [Metric.TTFT, Metric.LATENCY])
     async def test_get_metric_history(self, repository, redis_client: AsyncRedis, metric: Metric):

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -1,5 +1,5 @@
 from http import HTTPMethod
-from unittest.mock import AsyncMock, MagicMock, call, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
@@ -437,12 +437,7 @@ class TestSendRequest:
         original_request = use_case.provider_adapter_builder.build.return_value.format_request.call_args.kwargs["original_request"]
         assert original_request.endpoint == ForwardingTestUseCase.ENDPOINT
         assert original_request.payload == payload
-        use_case.provider_metrics_logger.log_metric.assert_has_awaits(
-            [
-                call(provider_id=provider.id, metric=Metric.LATENCY, value=120),
-                call(provider_id=provider.id, metric=Metric.NORMALIZED_LATENCY, value=120),
-            ]
-        )
+        use_case.provider_metrics_logger.log_metric.assert_awaited_once_with(provider_id=provider.id, metric=Metric.LATENCY, value=120)
         use_case.provider_metrics_logger.decrement_inflight.assert_awaited_once_with(provider_id=provider.id)
         model_tokenizer.compute_tokens.assert_called_once_with(texts=["world"])
         model_environmental_impacts_computer.compute.assert_called_once_with(

--- a/api/use_cases/_providerrequestforwardingusecase.py
+++ b/api/use_cases/_providerrequestforwardingusecase.py
@@ -223,11 +223,6 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
                     metric=Metric.LATENCY,
                     value=latency,
                 )
-                await self.provider_metrics_logger.log_metric(
-                    provider_id=provider.id,
-                    metric=Metric.NORMALIZED_LATENCY,
-                    value=latency,  # raw latency: legacy never divided this metric by completion tokens
-                )
             case ProviderAdapterValidationResponseError() as error:
                 return error
 


### PR DESCRIPTION
## Overview

Resolves #1031.

After a successful provider forward, `ProviderRequestForwardingUseCase` logged both `Metric.LATENCY` and `Metric.NORMALIZED_LATENCY` with **the same raw latency value**. `NORMALIZED_LATENCY` was documented as latency per completion token, but it was never divided by anything — the series was a duplicate of `LATENCY` under a misleading name.

The metric is removed end to end:

- **`api/use_cases/_providerrequestforwardingusecase.py`** — the second `log_metric(..., metric=Metric.NORMALIZED_LATENCY, ...)` call is gone. Only `Metric.LATENCY` is logged.
- **`api/infrastructure/redis/_redisprovidermetricslogger.py`** — removing the call was not enough on its own: `log_metric` ignores its `metric` argument when writing and loops over a fixed tuple of series, so `normalized_latency` would have kept being written. The tuple is now `(Metric.TTFT, Metric.LATENCY)`.
- **`api/clients/model/_basemodelprovider.py`** — the legacy provider client wrote the same series in a third `try` block; removed.
- **`api/domain/provider/entities.py`** and **`api/schemas/core/models.py`** — the `NORMALIZED_LATENCY` member is dropped from both `Metric` enums, so it can no longer be selected as a provider `qos_metric`. Leaving it selectable while stopping to write the series would have been worse than the status quo: `apply_sync_qos_policy` / `apply_async_qos_policy` would have read an empty timeseries and silently degraded routing.
- **Tests** — the unit expectation moves from `assert_has_awaits([...])` to `assert_awaited_once_with(...)`, which additionally pins that there is now exactly **one** log call; the two Redis integration parametrizations drop the removed member.

The commit also carries a small lint fix, hence the second line of the title. `api/schemas/core/models.py` declared `class Metric(str, Enum)`, which ruff rejects with `UP042`. That error pre-existed this branch, but pre-commit only lints changed files, so it started blocking commits as soon as this PR touched that file. `Metric` now inherits from `enum.StrEnum`. This was verified to be behaviour-neutral before being applied:

- `f"{metric}"` differs between the two forms (`'Metric.TTFT'` vs `'ttft'`) — no call site interpolates a `Metric` without `.value`.
- `api/sql/models.py` maps `qos_metric: Mapped[Metric | None]`; both forms resolve to the same SQLAlchemy `Enum` type and persist the member **names**, so storage is unchanged.
- `Enum` is still imported: `Endpoint` and `TruncationDirection` use it.

**Definition of Done:**

- [x] Only `Metric.LATENCY` is logged for request latency
- [x] The second `log_metric(..., metric=Metric.NORMALIZED_LATENCY, ...)` call is removed
- [x] `NORMALIZED_LATENCY` / `"normalized_latency"` is gone from the domain, schemas, Redis logger and `_basemodelprovider.py`
- [x] Unit tests no longer expect that metric (`test_should_enrich_usage_and_log_metrics_when_formatted_response_has_data`)
- [x] Redis integration tests no longer parametrize over that metric
- [x] No `normalized_latency` reference remains anywhere in the Python codebase
- [x] `pre-commit` passes on every changed file

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

`Metric.NORMALIZED_LATENCY` is removed from the enum backing the configuration field `qos_metric`, which looks like a config-level breaking change but is not one in practice: the Postgres enum type `metric` has only ever accepted `TTFT`, `LATENCY`, `INFLIGHT`, `PERFORMANCE` (see migration `2025_11_13_2012-9ba1f6a21f20_refacto_model_provision.py`, `sa.Enum('TTFT', 'LATENCY', 'INFLIGHT', 'PERFORMANCE', name='metric')`). A provider configured with `qos_metric: normalized_latency` passed Pydantic validation and then failed on write, so no persisted row can hold that value. Verified against a live database: `select count(*) from provider where qos_metric::text = 'NORMALIZED_LATENCY'` returns `0`, and the enum type lists 4 labels.

The `normalized_latency` Redis timeseries simply stops being written; existing keys expire on their own via `METRICS__TIMESERIE_RETENTION_SECONDS`.

## Check lists

### Review checklist

- [ ] Updated or added documentation — *N/A: the only doc surfaces mentioning this metric (`docs/openapi.json`, `docs/src/content/docs/configuration/configuration_file.mdx`) are generated by the `Release updates` workflow and are deliberately not hand-edited here.*
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

`api/sql/models.py` is **not** modified by this PR — no Alembic migration is required.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change; the Postgres `metric` enum type never contained the removed value*
- [ ] Configuration file has been modified — *N/A: no `config*.yml` in the repo used `qos_metric: normalized_latency`*
- [ ] Environment variables have been modified — *N/A*

No new or updated environment variables and no special deployment steps.

## Additional Notes

Two points worth a reviewer's attention:

1. **The scope is wider than the single `log_metric` call named in the issue, on purpose.** Deleting only that call would have left the series alive — the Redis logger writes every series in its tuple regardless of the `metric` argument it receives. The issue's second acceptance criterion ("related references are cleaned up if unused") is what drives the enum and `_basemodelprovider.py` removals.

2. **A closely related bug is left untouched, deliberately.** `RedisProviderMetricsLogger.log_metric` still writes the value it receives into *both* remaining series. Since `LATENCY` is now the only metric logged through that path, the `ttft` series is fed with latency values — meaning a provider configured with `qos_metric: ttft` is in fact throttled on latency. This is the same class of defect as the one this PR fixes, on a different metric, and out of scope for #1031. Happy to open a dedicated issue.

Verification run locally: unit `644 passed`, integration `599 passed, 1 skipped`, `pre-commit run --files` green on all 7 changed files.
