### PR TITLE
feat(datetime): standardize datetime handling across API, domain and playground

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.70%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.73%", "color": "green"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,21 @@ The domain and API term for an API credential is **key** (`Key`, `CreateKeyRespo
 
 ---
 
+## Domain
+
+| Kind | Location | Form |
+|------|----------|------|
+| Entity | `domain/<context>/entities.py` | Pydantic `BaseModel` (from `api.domain`) |
+| Error | `domain/<context>/errors.py` | `@dataclass` |
+| Repository port | `domain/<context>/_<entity>repository.py` | `ABC` |
+| `Command` / `UseCaseSuccess` | `use_cases/<area>/` | `@dataclass` |
+
+**Entities are Pydantic models, never `@dataclass`.** A `@dataclass` validates nothing at construction, so it silently accepts a wrong type and skips the `UtcDatetime` normalization — an entity built with a naive `datetime` would then serialize to a shifted Unix timestamp. `BaseModel` also gives `model_copy(update=...)`, which the `with_*` helpers (`Router.with_name`, `Provider.with_timeout`, `Role.with_limits`) rely on.
+
+`@dataclass` is for the plain carriers that never hold invariants: domain errors, and the `Command` / `UseCaseSuccess` pairs of the use-case layer.
+
+---
+
 ## Schemas
 
 Location: `api/infrastructure/fastapi/schemas/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,12 @@ CreateKeyCommand(user_id=body.user, ...)
 ### Timestamps
 
 - API: Unix seconds as `int` (`created`, `updated`, `expires`)
-- Domain: `datetime`
-- Convert in `@field_validator` (request) or `@model_validator(mode="before")` (response)
+- Domain and Postgres: timezone-aware UTC `datetime` — annotate entity fields with `UtcDatetime` from `api/domain/__init__.py`, and always build "now" with `datetime.now(tz=UTC)`
+- Repositories select and write the `timestamptz` columns directly — no `extract(epoch)` / `to_timestamp()`
+- Convert at the boundary only: `@field_validator` / `AfterValidator` (request) or `@model_validator(mode="before")` (response) — see `CreateKeyBody` / `KeyResponse`
+- Playground displays local time through `app/shared/utils/timestamps.py`
+
+Full rationale: `adr/2026-08-27-datetime-handling.md`.
 
 ### Aliases
 

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -1,0 +1,113 @@
+# ADR - 2026-08-27 - Datetime handling across API, domain and playground
+
+* **Status:** Accepted
+* **Date:** 2026-08-27
+* **Authors:** Development Team
+* **Related:**
+  * [#960 — [clean-architecture] Standardize datetime handling across API and playground](https://github.com/etalab-ia/OpenGateLLM/issues/960)
+  * [ADR 2026-01-07 — Migration to Clean Architecture](2026-01-07-clean-architecture-migration.md)
+* **Decision Outcome:** Unix timestamps (`int`) at the HTTP boundary only, timezone-aware UTC `datetime` in the domain and in Postgres, local-timezone rendering in the playground.
+
+---
+
+## Context
+
+Before this decision, the same instant was represented differently depending on which file you opened:
+
+* `api/infrastructure/fastapi/schemas/admin/keys.py` already did the right thing — accept `int`, convert to UTC `datetime` in a validator, keep `datetime` in the domain and in SQL, convert back to `int` in the response — but nothing said it was *the* convention.
+* Several domain entities (`Role`, `Router`, `Provider`, `User`, `Model`, `AuthenticatedUserView`) carried `int` timestamps, so the Postgres adapters had to flatten `timestamptz` columns to epoch seconds (`cast(func.extract("epoch", column), Integer)`) on the way out and re-inflate them (`func.to_timestamp(...)`) on the way in. `api/domain/role/entities.py` carried a `TODO` waiting for exactly this decision.
+* Several `datetime.now()` calls were naive local time. Some were harmless (`int(datetime.now().timestamp())` yields the right epoch), but some were not: `Usage(created=datetime.now())` wrote a naive local timestamp straight into a `timestamptz` column, shifting every usage record by the server's UTC offset.
+* The playground formatted dates with `datetime.fromtimestamp(...)`, which happens to render local time but says nothing about which timezone it assumes, and did so with a copy of the same expression in each feature state.
+
+The cost of that spread: no single place to reason about "what timezone is this value in?", conversions duplicated in adapters that should be dumb mappers, and a class of bug (naive datetime into an aware column) that only shows up outside UTC.
+
+## Decision
+
+One representation per layer, converted at exactly one place — the layer boundary.
+
+| Layer | Representation |
+|-------|----------------|
+| HTTP request / response (JSON) | Unix seconds, `int` |
+| API schemas (`api/infrastructure/fastapi/schemas/`) | `int` on the wire, converted in a validator |
+| Use cases, domain entities, repository ports | timezone-aware UTC `datetime` |
+| Postgres (`api/sql/models.py`) | `DateTime(timezone=True)` (`UtcDateTime`) |
+| Playground display | the viewer's local timezone |
+
+### Domain and persistence: aware UTC `datetime`
+
+Domain timestamp fields use the `UtcDatetime` alias from `api/domain/__init__.py`:
+
+```python
+UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
+```
+
+It normalizes anything Pydantic accepts as a `datetime` to UTC and treats a naive value as already-UTC, so an entity can never hold an ambiguous timestamp — and `int(value.timestamp())` at the boundary is always correct. The same alias covers the provider-facing boundary: provider `/v1/models` payloads carry `created` as OpenAI-style Unix seconds, and the HTTP adapters hand that `int` straight to `Model`, where `UtcDatetime` turns it into an aware UTC datetime.
+
+Repositories select and write the `timestamptz` columns **directly**. No `extract(epoch)` on read, no `to_timestamp()` on write:
+
+```python
+# api/infrastructure/postgres/_postgresrolesrepository.py
+select(RoleTable.id, RoleTable.name, RoleTable.created, RoleTable.updated)
+```
+
+Anything producing a "now" writes `datetime.now(tz=UTC)`, never a naive `datetime.now()`.
+
+### API boundary: `int`, converted in the schema
+
+**Request** — a `@field_validator` (or an `Annotated` `AfterValidator`) validates the timestamp and returns the `datetime` the command layer receives:
+
+```python
+# api/infrastructure/fastapi/schemas/admin/users.py
+def _must_be_future_and_convert_to_datetime(expires: int) -> datetime:
+    if expires <= int(datetime.now(tz=UTC).timestamp()):
+        raise ValueError("Wrong timestamp, must be in the future.")
+    return datetime.fromtimestamp(timestamp=expires, tz=UTC)
+
+FutureTimestamp = Annotated[int, AfterValidator(_must_be_future_and_convert_to_datetime)]
+```
+
+The field stays annotated `int`, so the OpenAPI schema still documents an integer.
+
+**Response** — a `@model_validator(mode="before")` maps the domain entity to the wire shape, converting each `datetime` with `int(value.timestamp())`:
+
+```python
+# api/infrastructure/fastapi/schemas/admin/keys.py — the reference implementation
+@model_validator(mode="before")
+@classmethod
+def from_key(cls, data):
+    if isinstance(data, Key):
+        return {
+            ...,
+            "expires": int(data.expires.timestamp()) if data.expires is not None else None,
+            "created": int(data.created.timestamp()),
+        }
+    return data
+```
+
+Endpoints keep calling `Response.model_validate(entity, from_attributes=True)`; the validator recognizes the entity and does the mapping. Schemas following this pattern: `admin/keys.py`, `admin/organizations.py`, `admin/roles.py`, `admin/routers.py`, `admin/providers.py`, `admin/users.py`, `me.py`, `models.py`, `usage.py`.
+
+### Playground: local timezone, one helper
+
+`playground/app/shared/utils/timestamps.py` owns every conversion: `format_datetime`, `format_date`, `format_local_date`, `local_now`, `to_local_datetime`, `date_to_timestamp`. Feature states call it instead of writing `datetime.fromtimestamp(...)` inline. It uses `astimezone()` with no argument, which resolves the system timezone *for the instant being converted*, so offsets stay correct across DST boundaries.
+
+### Legacy schemas
+
+`api/schemas/` (the pre-clean-architecture DTOs, still used by `_identityaccessmanager.py`, `_modelregistry.py` and `/v1/admin/organizations`) already exposes `int` at the boundary, which matches the convention. Those modules are HTTP DTOs only and never cross into `api/domain`, so they keep their `int` fields and are removed resource by resource as clean-architecture migration proceeds. Their naive `datetime.now()` defaults were made UTC-explicit as part of this ADR.
+
+## Consequences
+
+**Easier**
+
+* One answer to "what timezone is this?" per layer; the boundary is the only place a conversion happens.
+* Postgres adapters became plain column mappers — the `extract(epoch)` / `to_timestamp()` round trips are gone, and `PostgresRolesRepository._row_to_role` is now used by every one of its query methods (the `TODO` on `Role` is resolved).
+* Naive-datetime bugs are structurally prevented: `UtcDatetime` normalizes on the way into an entity, and `timestamptz` columns only ever receive aware values.
+* Date arithmetic and comparison (`user.expires < datetime.now(tz=UTC)`) happen on `datetime`, not on epoch integers.
+
+**Harder / to watch**
+
+* Every new response schema that carries a timestamp needs its `@model_validator(mode="before")`. Without it, `model_validate(entity, from_attributes=True)` would hand Pydantic a `datetime` for an `int` field and fail — loudly, which is the point.
+* Sub-second precision is lost at the API boundary (`int(...timestamp())` truncates). That is the existing public contract and is unchanged by this ADR.
+
+**Unchanged**
+
+The public API is untouched: every `created`, `updated` and `expires` field is still Unix seconds as `int`, in both directions. The generated OpenAPI schema for those fields is identical before and after, type for type.

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -16,7 +16,7 @@ Before this decision, the same instant was represented differently depending on 
 
 * `api/infrastructure/fastapi/schemas/admin/keys.py` already did the right thing — accept `int`, convert to UTC `datetime` in a validator, keep `datetime` in the domain and in SQL, convert back to `int` in the response — but nothing said it was *the* convention.
 * Several domain entities (`Role`, `Router`, `Provider`, `User`, `Model`, `AuthenticatedUserView`) carried `int` timestamps, so the Postgres adapters had to flatten `timestamptz` columns to epoch seconds (`cast(func.extract("epoch", column), Integer)`) on the way out and re-inflate them (`func.to_timestamp(...)`) on the way in. `api/domain/role/entities.py` carried a `TODO` waiting for exactly this decision.
-* Several `datetime.now()` calls were naive local time. Some were harmless (`int(datetime.now().timestamp())` yields the right epoch), but some were not: `Usage(created=datetime.now())` wrote a naive local timestamp straight into a `timestamptz` column, shifting every usage record by the server's UTC offset.
+* Several `datetime.now()` calls produced naive local datetimes. None of them corrupted data — asyncpg encodes a naive value using the Python process timezone, which is what `datetime.now()` returns, so the two conversions cancel out and the stored instant is correct. But the value's meaning then depends on the process timezone rather than on the code, and a single `datetime.utcnow()` (naive *UTC*) slipping in would be silently shifted. One genuine bug did hide there: `Chunk.created` used `Field(default=datetime.now())`, evaluated once at import, so every chunk inherited the process start time.
 * The playground formatted dates with `datetime.fromtimestamp(...)`, which happens to render local time but says nothing about which timezone it assumes, and did so with a copy of the same expression in each feature state.
 
 The cost of that spread: no single place to reason about "what timezone is this value in?", conversions duplicated in adapters that should be dumb mappers, and a class of bug (naive datetime into an aware column) that only shows up outside UTC.
@@ -100,7 +100,7 @@ Endpoints keep calling `Response.model_validate(entity, from_attributes=True)`; 
 
 * One answer to "what timezone is this?" per layer; the boundary is the only place a conversion happens.
 * Postgres adapters became plain column mappers — the `extract(epoch)` / `to_timestamp()` round trips are gone, and `PostgresRolesRepository._row_to_role` is now used by every one of its query methods (the `TODO` on `Role` is resolved).
-* Naive-datetime bugs are structurally prevented: `UtcDatetime` normalizes on the way into an entity, and `timestamptz` columns only ever receive aware values.
+* Naive datetimes can no longer reach an entity ambiguously: `UtcDatetime` normalizes on the way in, and `timestamptz` columns only ever receive aware values. Note the two layers disagree on what a naive value *means* — asyncpg reads it as process-local, `UtcDatetime` reads it as UTC — which is exactly why no naive value should exist in the first place.
 * Date arithmetic and comparison (`user.expires < datetime.now(tz=UTC)`) happen on `datetime`, not on epoch integers.
 
 **Harder / to watch**

--- a/adr/README.md
+++ b/adr/README.md
@@ -18,14 +18,19 @@ Each ADR follows this structure:
 
 ## Index
 
-| ADR | Title | Status | Date |
-|-----|-------|--------|------|
-| [001](001-clean-architecture-migration.md) | Migration to Clean Architecture | In Progress | 2025-01-07 |
+| ADR                                                      | Title                                               | Status      | Date       |
+|----------------------------------------------------------|-----------------------------------------------------|-------------|------------|
+| [2026-01-07](2026-01-07-clean-architecture-migration.md) | Migration to Clean Architecture                     | In Progress | 2026-01-07 |
+| [2026-01-30](2026-01-30-es-scaling.md)                   | Elasticsearch Scaling                               | Accepted    | 2026-01-30 |
+| [2026-03-17](2026-03-17-integration-test-isolation.md)   | Integration Test Isolation via Transaction Rollback | Accepted    | 2026-03-17 |
+| [2026-05-28](2026-05-28-refactoring-model-forwarding.md) | Refactoring model forwarding                        | —           | 2026-05-28 |
+| [2026-07-01](2026-07-01-split-rag.md)                    | Extract RAG into OpenGateRAG (OGR)                  | Accepted    | 2026-07-01 |
+| [2026-08-27](2026-08-27-datetime-handling.md)            | Datetime handling across API, domain and playground | Accepted    | 2026-08-27 |
 
 ## Creating a new ADR
 
 1. Copy the template from the most recent ADR
-2. Number it sequentially (e.g., `002-your-decision-title.md`)
+2. Name it `YYYY-MM-DD-your-decision-title.md`, using the date the decision was made
 3. Fill in the sections with your architectural decision
 4. Update this README's index table
 5. Submit for review via pull request

--- a/api/domain/__init__.py
+++ b/api/domain/__init__.py
@@ -1,12 +1,21 @@
 from abc import ABC
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AfterValidator, BaseModel, ConfigDict
 
 
 class BaseModel(BaseModel):
     model_config = ConfigDict(extra="allow")
+
+
+def _to_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(tz=UTC)
+
+
+UtcDatetime = Annotated[datetime, AfterValidator(_to_utc)]
 
 
 class ForwardablePayload(BaseModel, ABC):

--- a/api/domain/key/entities.py
+++ b/api/domain/key/entities.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from api.domain import BaseModel, EntitiesPage
+from api.domain import BaseModel, EntitiesPage, UtcDatetime
 
 
 class Key(BaseModel):
@@ -8,8 +8,8 @@ class Key(BaseModel):
     name: str
     user_id: int
     value: str
-    expires: datetime | None
-    created: datetime
+    expires: UtcDatetime | None
+    created: UtcDatetime
 
     @classmethod
     def build_from_claims(cls, claims: dict):

--- a/api/domain/model/entities.py
+++ b/api/domain/model/entities.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 
 from pydantic import Field
 
-from api.domain import BaseModel
+from api.domain import BaseModel, UtcDatetime
 
 
 class ModelCosts(BaseModel):
@@ -28,7 +28,7 @@ class Model(BaseModel):
     id: str
     type: ModelType
     aliases: list[str] = []
-    created: int
+    created: UtcDatetime
     owned_by: str
     max_context_length: int | None = None
     costs: ModelCosts = Field(default_factory=ModelCosts)

--- a/api/domain/model/views.py
+++ b/api/domain/model/views.py
@@ -1,6 +1,6 @@
 from pydantic import ConfigDict, Field
 
-from api.domain import BaseModel
+from api.domain import BaseModel, UtcDatetime
 from api.domain.model.entities import ModelCosts, ModelType
 
 
@@ -13,7 +13,7 @@ class ModelView(BaseModel):
     id: str
     type: ModelType
     aliases: list[str] = []
-    created: int
+    created: UtcDatetime
     owned_by: str
     max_context_length: int | None = None
     costs: ModelCosts = Field(default_factory=ModelCosts)

--- a/api/domain/organization/entities.py
+++ b/api/domain/organization/entities.py
@@ -1,8 +1,6 @@
-from dataclasses import dataclass
-from datetime import datetime
 from enum import StrEnum
 
-from api.domain import EntitiesPage
+from api.domain import BaseModel, EntitiesPage, UtcDatetime
 
 
 class OrganizationSortField(StrEnum):
@@ -12,13 +10,12 @@ class OrganizationSortField(StrEnum):
     UPDATED = "updated"
 
 
-@dataclass
-class Organization:
+class Organization(BaseModel):
     id: int
     name: str
     users: int
-    created: datetime
-    updated: datetime
+    created: UtcDatetime
+    updated: UtcDatetime
 
 
 OrganizationPage = EntitiesPage["Organization"]

--- a/api/domain/provider/entities.py
+++ b/api/domain/provider/entities.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal
 import pycountry
 from pydantic import Field, model_validator
 
-from api.domain import BaseModel, EntitiesPage, ForwardablePayload
+from api.domain import BaseModel, EntitiesPage, ForwardablePayload, UtcDatetime
 from api.domain.model.entities import ModelJsonResponse, ModelType
 from api.domain.router.entities import Router
 from api.utils.variables import EndpointRoute
@@ -106,8 +106,8 @@ class Provider(BaseModel):
     qos_limit: float | None = None
     max_context_length: int | None = None
     vector_size: int | None = None
-    created: int
-    updated: int
+    created: UtcDatetime
+    updated: UtcDatetime
 
     def with_router_id(self, router_id: int) -> "Provider":
         return self.model_copy(update={"router_id": router_id})

--- a/api/domain/role/entities.py
+++ b/api/domain/role/entities.py
@@ -1,9 +1,9 @@
-import datetime as dt
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
-from api.domain import EntitiesPage
+from api.domain import EntitiesPage, UtcDatetime
 
 
 class PermissionType(StrEnum):
@@ -30,7 +30,9 @@ class Role(BaseModel):
     name: str
     permissions: list[PermissionType]
     limits: list[Limit]
-    # TODO: add created and updated timestamps after convert int to datetime in all the repositories
+    users: int = 0
+    created: UtcDatetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    updated: UtcDatetime = Field(default_factory=lambda: datetime.now(tz=UTC))
 
     @field_validator("permissions")
     @classmethod
@@ -41,10 +43,6 @@ class Role(BaseModel):
     @classmethod
     def unique_limits(cls, v: list["Limit"]) -> list["Limit"]:
         return list({(limit.router_id, limit.type): limit for limit in v}.values())
-
-    users: int = 0
-    created: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))
-    updated: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))
 
     def with_name(self, name: str | None) -> "Role":
         return self.model_copy(update={"name": name})

--- a/api/domain/router/entities.py
+++ b/api/domain/router/entities.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
-from api.domain import EntitiesPage
+from api.domain import EntitiesPage, UtcDatetime
 from api.domain.model.entities import ModelType as RouterType
 from api.schemas.admin.roles import LimitType
 
@@ -26,8 +26,8 @@ class Router(BaseModel):
     cost_prompt_tokens: float
     cost_completion_tokens: float
     providers: int
-    created: int
-    updated: int
+    created: UtcDatetime
+    updated: UtcDatetime
 
     def with_name(self, name: str) -> "Router":
         return self.model_copy(update={"name": name})

--- a/api/domain/usage/entities.py
+++ b/api/domain/usage/entities.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from api.domain import BaseModel, EntitiesPage
+from api.domain import BaseModel, EntitiesPage, UtcDatetime
 
 
 class EnvironmentalImpacts(BaseModel):
@@ -32,7 +30,7 @@ class UsageRecord(BaseModel):
     total_tokens: int | None
     cost: float | None
     impacts: EnvironmentalImpacts
-    created: datetime
+    created: UtcDatetime
 
 
 UsagePage = EntitiesPage["UsageRecord"]

--- a/api/domain/user/_userrepository.py
+++ b/api/domain/user/_userrepository.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any
 
 from api.domain import SortOrder
@@ -26,7 +27,7 @@ class UserRepository(ABC):
         claims: dict[str, Any] | None = None,
         organization_id: int | None = None,
         budget: float | None = None,
-        expires: int | None = None,
+        expires: datetime | None = None,
         priority: int = 0,
     ) -> User | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
         pass

--- a/api/domain/user/entities.py
+++ b/api/domain/user/entities.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from pydantic import BaseModel, SecretStr
 
-from api.domain import EntitiesPage
+from api.domain import EntitiesPage, UtcDatetime
 
 
 class UserSortField(StrEnum):
@@ -26,9 +26,9 @@ class User(BaseModel):
     role_id: int
     organization_id: int | None
     budget: float | None
-    expires: int | None
-    created: int
-    updated: int
+    expires: UtcDatetime | None
+    created: UtcDatetime
+    updated: UtcDatetime
     priority: int
     password: SecretStr | None
 

--- a/api/domain/user/views.py
+++ b/api/domain/user/views.py
@@ -1,7 +1,8 @@
-import time
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from api.domain import UtcDatetime
 from api.domain.role.entities import Limit, PermissionType
 
 
@@ -15,7 +16,7 @@ class AuthenticatedUserView(BaseModel):
     budget: float | None
     permissions: list[PermissionType]
     limits: list[Limit]
-    expires: int | None
+    expires: UtcDatetime | None
 
     @property
     def is_admin(self) -> bool:
@@ -23,7 +24,7 @@ class AuthenticatedUserView(BaseModel):
 
     @property
     def has_expired(self) -> bool:
-        return self.expires is not None and self.expires < time.time()
+        return self.expires is not None and self.expires < datetime.now(tz=UTC)
 
     @property
     def has_insufficient_budget(self) -> bool:

--- a/api/helpers/_identityaccessmanager.py
+++ b/api/helpers/_identityaccessmanager.py
@@ -559,7 +559,7 @@ class IdentityAccessManager:
         if self.playground_session_duration is None:
             expires = None
         else:
-            expires = int((datetime.now() + timedelta(seconds=self.playground_session_duration)).timestamp())
+            expires = int((datetime.now(tz=dt.UTC) + timedelta(seconds=self.playground_session_duration)).timestamp())
 
         # Create a new token
         token_id, token = await self.create_token(postgres_session, user_id, name, expires=expires)

--- a/api/helpers/_searchtool.py
+++ b/api/helpers/_searchtool.py
@@ -58,7 +58,7 @@ class Chunk(BaseModel):
     document_id: Annotated[int, Field(ge=0, default=..., description="The ID of the document the chunk belongs to.")]
     content: Annotated[str, Field(min_length=1, default=..., description="The content of the chunk.")]
     metadata: Annotated[ChunkMetadata | None, Field(default=None, description="Metadata of the chunk")]
-    created: Annotated[datetime, Field(default=datetime.now(), description="The date of the chunk creation.")]
+    created: Annotated[datetime, Field(default_factory=lambda: datetime.now(tz=UTC), description="The date of the chunk creation.")]
 
     @field_validator("metadata", mode="before")
     @classmethod

--- a/api/helpers/load_balancing/_leastbusyloadbalancingstrategy.py
+++ b/api/helpers/load_balancing/_leastbusyloadbalancingstrategy.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import logging
 import math
 import random
@@ -35,7 +35,7 @@ class LeastBusyLoadBalancingStrategy(BaseLoadBalancingStrategy):
     def apply_sync_strategy(self, candidates: list[int]) -> tuple[int, float]:
         scores = {}
         for provider_id in candidates:
-            cutoff = datetime.now() - timedelta(seconds=METRICS__TIMESERIE_RETENTION_SECONDS)
+            cutoff = datetime.now(tz=UTC) - timedelta(seconds=METRICS__TIMESERIE_RETENTION_SECONDS)
             key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{self.metric}:{provider_id}"  # currently only TTFT is supported
             try:
                 result = self.redis_client.ts().range(key, from_time=int(cutoff.timestamp() * 1000) if cutoff else 0, to_time="+")
@@ -64,7 +64,7 @@ class LeastBusyLoadBalancingStrategy(BaseLoadBalancingStrategy):
     async def apply_async_strategy(self, candidates: list[int]) -> tuple[int, float]:
         scores = {}
         for provider_id in candidates:
-            cutoff = datetime.now() - timedelta(seconds=METRICS__TIMESERIE_RETENTION_SECONDS)
+            cutoff = datetime.now(tz=UTC) - timedelta(seconds=METRICS__TIMESERIE_RETENTION_SECONDS)
             key = f"{PREFIX__REDIS_METRIC_TIMESERIE}:{self.metric}:{provider_id}"  # currently only TTFT is supported
             try:
                 result = await self.redis_client.ts().range(key, from_time=int(cutoff.timestamp() * 1000) if cutoff else 0, to_time="+")

--- a/api/helpers/models/_modelregistry.py
+++ b/api/helpers/models/_modelregistry.py
@@ -209,8 +209,8 @@ class ModelRegistry:
             ProviderTable.model_active_params,
             ProviderTable.qos_metric,
             ProviderTable.qos_limit,
-            cast(func.extract("epoch", ProviderTable.created), Integer).label("created"),
-            cast(func.extract("epoch", ProviderTable.updated), Integer).label("updated"),
+            ProviderTable.created,
+            ProviderTable.updated,
         ).order_by(text(f"{order_by} {order_direction}"))  # nosemgrep
         if offset is not None:
             query = query.offset(offset=offset)

--- a/api/infrastructure/fastapi/decorators.py
+++ b/api/infrastructure/fastapi/decorators.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator, Callable, Coroutine
-from datetime import datetime
+from datetime import UTC, datetime
 import functools
 import logging
 from typing import Any
@@ -35,7 +35,7 @@ def hooks(*, postgres_session_provider: PostgresSessionProvider):
     def decorator(endpoint_func):
         @functools.wraps(endpoint_func)
         async def wrapper(*args, **kwargs):
-            usage = Usage(created=datetime.now(), endpoint="N/A")
+            usage = Usage(created=datetime.now(tz=UTC), endpoint="N/A")
             context = request_context.get()
             if context.key is None:
                 logger.info(f"No key found in request context, skipping usage logging ({context.endpoint}).")

--- a/api/infrastructure/fastapi/schemas/admin/providers.py
+++ b/api/infrastructure/fastapi/schemas/admin/providers.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
-from api.domain.provider.entities import BasicAuth, HostingZone, ProviderType, QoSMetric
+from api.domain.provider.entities import BasicAuth, HostingZone, Provider, ProviderType, QoSMetric
 from api.schemas.core.configuration import ModelProvider
 
 
@@ -28,6 +28,30 @@ class CreateProviderResponse(BaseModel):
     qos_limit: Annotated[float | None, Field(default=None, ge=0.0, description="The value to use for the quality of service. Depends of the metric, the value can be a percentile, a threshold, etc.")]  # fmt: off
     created: Annotated[int | None, Field(default=None, description="Time of creation, as Unix timestamp.")]  # fmt: off
     updated: Annotated[int | None, Field(default=None, description="Time of last update, as Unix timestamp.")]  # fmt: off
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_provider(cls, data):
+        if isinstance(data, Provider):
+            return {
+                "id": data.id,
+                "router_id": data.router_id,
+                "user_id": data.user_id,
+                "type": data.type,
+                "url": data.url,
+                "key": data.key,
+                "basic_auth": data.basic_auth,
+                "timeout": data.timeout,
+                "model_name": data.model_name,
+                "model_hosting_zone": data.model_hosting_zone,
+                "model_total_params": data.model_total_params,
+                "model_active_params": data.model_active_params,
+                "qos_metric": data.qos_metric,
+                "qos_limit": data.qos_limit,
+                "created": int(data.created.timestamp()),
+                "updated": int(data.updated.timestamp()),
+            }
+        return data
 
 
 class UpdateProviderBody(BaseModel):
@@ -65,6 +89,29 @@ class ProviderResponse(BaseModel):
     vector_size: Annotated[int | None, Field(default=None, description="Dimension of the vectors, probed on the provider API for embeddings models only. It is the same for all the providers of a router.")]  # fmt: off
     created: Annotated[int | None, Field(default=None, description="Time of creation, as Unix timestamp.")]
     updated: Annotated[int | None, Field(default=None, description="Time of last update, as Unix timestamp.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_provider(cls, data):
+        if isinstance(data, Provider):
+            return {
+                "object": "provider",
+                "id": data.id,
+                "router_id": data.router_id,
+                "user_id": data.user_id,
+                "type": data.type,
+                "url": data.url,
+                "timeout": data.timeout,
+                "model_name": data.model_name,
+                "model_hosting_zone": data.model_hosting_zone,
+                "model_total_params": data.model_total_params,
+                "model_active_params": data.model_active_params,
+                "qos_metric": data.qos_metric,
+                "qos_limit": data.qos_limit,
+                "created": int(data.created.timestamp()),
+                "updated": int(data.updated.timestamp()),
+            }
+        return data
 
 
 class ProvidersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/providers.py
+++ b/api/infrastructure/fastapi/schemas/admin/providers.py
@@ -108,6 +108,8 @@ class ProviderResponse(BaseModel):
                 "model_active_params": data.model_active_params,
                 "qos_metric": data.qos_metric,
                 "qos_limit": data.qos_limit,
+                "max_context_length": data.max_context_length,
+                "vector_size": data.vector_size,
                 "created": int(data.created.timestamp()),
                 "updated": int(data.updated.timestamp()),
             }

--- a/api/infrastructure/fastapi/schemas/admin/roles.py
+++ b/api/infrastructure/fastapi/schemas/admin/roles.py
@@ -1,9 +1,10 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
+from api.domain.role.entities import Role
 
 
 class PermissionType(StrEnum):
@@ -40,6 +41,22 @@ class RoleResponse(BaseModel):
     users: Annotated[int, Field(..., description="Number of users assigned to the role.")]
     created: Annotated[int, Field(..., description="Time of creation, as Unix timestamp.")]
     updated: Annotated[int, Field(..., description="Time of last update, as Unix timestamp.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_role(cls, data):
+        if isinstance(data, Role):
+            return {
+                "object": "role",
+                "id": data.id,
+                "name": data.name,
+                "permissions": data.permissions,
+                "limits": [{"router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in data.limits],
+                "users": data.users,
+                "created": int(data.created.timestamp()),
+                "updated": int(data.updated.timestamp()),
+            }
+        return data
 
 
 class RolesResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/routers.py
+++ b/api/infrastructure/fastapi/schemas/admin/routers.py
@@ -1,9 +1,9 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
-from api.domain.router.entities import RouterLoadBalancingStrategy
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy
 from api.schemas.models import ModelType
 
 
@@ -38,6 +38,28 @@ class RouterResponse(BaseModel):
     providers: Annotated[int, Field(default=0, description="Number of providers in the router.")]
     created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
     updated: Annotated[int, Field(description="Time of last update, as Unix timestamp.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_router(cls, data):
+        if isinstance(data, Router):
+            return {
+                "object": "router",
+                "id": data.id,
+                "name": data.name,
+                "user_id": data.user_id,
+                "type": data.type,
+                "aliases": data.aliases,
+                "load_balancing_strategy": data.load_balancing_strategy,
+                "vector_size": data.vector_size,
+                "max_context_length": data.max_context_length,
+                "cost_prompt_tokens": data.cost_prompt_tokens,
+                "cost_completion_tokens": data.cost_completion_tokens,
+                "providers": data.providers,
+                "created": int(data.created.timestamp()),
+                "updated": int(data.updated.timestamp()),
+            }
+        return data
 
 
 class RoutersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/routers.py
+++ b/api/infrastructure/fastapi/schemas/admin/routers.py
@@ -51,8 +51,6 @@ class RouterResponse(BaseModel):
                 "type": data.type,
                 "aliases": data.aliases,
                 "load_balancing_strategy": data.load_balancing_strategy,
-                "vector_size": data.vector_size,
-                "max_context_length": data.max_context_length,
                 "cost_prompt_tokens": data.cost_prompt_tokens,
                 "cost_completion_tokens": data.cost_completion_tokens,
                 "providers": data.providers,

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -1,19 +1,21 @@
-import datetime as dt
+from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, ConfigDict, Field, StringConstraints
+from pydantic import AfterValidator, ConfigDict, Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
+from api.domain.user.entities import User
 from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
 
-def _must_be_future(expires: int) -> int:
-    if expires <= int(dt.datetime.now(tz=dt.UTC).timestamp()):
+def _must_be_future_and_convert_to_datetime(expires: int) -> datetime:
+    if expires <= int(datetime.now(tz=UTC).timestamp()):
         raise ValueError("Wrong timestamp, must be in the future.")
-    return expires
+    return datetime.fromtimestamp(timestamp=expires, tz=UTC)
 
 
-FutureTimestamp = Annotated[int, AfterValidator(_must_be_future)]
+FutureTimestamp = Annotated[int, AfterValidator(_must_be_future_and_convert_to_datetime)]
+"""Unix timestamp accepted at the API boundary and converted to a UTC datetime for the domain."""
 
 
 class CreateUserBody(BaseModel):
@@ -43,6 +45,27 @@ class UserResponse(BaseModel):
     created: Annotated[int, Field(..., description="Time of creation, as Unix timestamp.")]
     updated: Annotated[int, Field(..., description="Time of last update, as Unix timestamp.")]
     priority: Annotated[int, Field(..., description="Priority of the user. Higher value means higher priority.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_user(cls, data):
+        if isinstance(data, User):
+            return {
+                "object": "user",
+                "id": data.id,
+                "email": data.email,
+                "name": data.name,
+                "sub": data.sub,
+                "iss": data.iss,
+                "role_id": data.role_id,
+                "organization_id": data.organization_id,
+                "budget": data.budget,
+                "expires": int(data.expires.timestamp()) if data.expires is not None else None,
+                "created": int(data.created.timestamp()),
+                "updated": int(data.updated.timestamp()),
+                "priority": data.priority,
+            }
+        return data
 
 
 class UsersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/me.py
+++ b/api/infrastructure/fastapi/schemas/me.py
@@ -3,6 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
+from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.schemas.admin.roles import Limit, PermissionType
 from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
@@ -17,6 +18,23 @@ class MeResponse(BaseModel):
     permissions: Annotated[list[PermissionType], Field(description="The user permissions.")]
     limits: Annotated[list[Limit], Field(description="The user rate limits.")]
     expires: Annotated[int | None, Field(default=None, description="The user expiration timestamp. If None, the user will never expire.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_authenticated_user(cls, data):
+        if isinstance(data, AuthenticatedUserView):
+            return {
+                "object": "userInfo",
+                "id": data.id,
+                "email": data.email,
+                "name": data.name,
+                "organization_id": data.organization_id,
+                "budget": data.budget,
+                "permissions": data.permissions,
+                "limits": [{"router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in data.limits],
+                "expires": int(data.expires.timestamp()) if data.expires is not None else None,
+            }
+        return data
 
 
 class UpdateMeBody(BaseModel):

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -1,8 +1,9 @@
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from api.domain import BaseModel
+from api.domain.model.entities import Model as ModelEntity
 from api.domain.model.entities import ModelType
 
 
@@ -20,6 +21,22 @@ class Model(BaseModel):
     owned_by: Annotated[str, Field(..., description="The organization that owns the model.")]
     max_context_length: Annotated[int | None, Field(default=None, description="Maximum amount of tokens a context could contains. Makes sure it is the same for all models.")]  # fmt: off
     costs: Annotated[ModelCosts, Field(default_factory=ModelCosts, description="Costs of the model.")]
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_model(cls, data):
+        if isinstance(data, ModelEntity):
+            return {
+                "object": "model",
+                "id": data.id,
+                "type": data.type,
+                "aliases": data.aliases,
+                "created": int(data.created.timestamp()),
+                "owned_by": data.owned_by,
+                "max_context_length": data.max_context_length,
+                "costs": {"prompt_tokens": data.costs.prompt_tokens, "completion_tokens": data.costs.completion_tokens},
+            }
+        return data
 
 
 class ModelsResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -3,8 +3,8 @@ from typing import Annotated, Literal
 from pydantic import Field, model_validator
 
 from api.domain import BaseModel
-from api.domain.model.entities import Model as ModelEntity
 from api.domain.model.entities import ModelType
+from api.domain.model.views import ModelView
 
 
 class ModelCosts(BaseModel):
@@ -25,7 +25,7 @@ class Model(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def from_model(cls, data):
-        if isinstance(data, ModelEntity):
+        if isinstance(data, ModelView):
             return {
                 "object": "model",
                 "id": data.id,

--- a/api/infrastructure/postgres/_postgresauthenticateduserquery.py
+++ b/api/infrastructure/postgres/_postgresauthenticateduserquery.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, Select, cast, select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
@@ -61,7 +61,7 @@ class PostgresAuthenticatedUserQuery(AuthenticatedUserQuery):
             UserTable.name,
             UserTable.organization_id,
             UserTable.budget,
-            cast(func.extract("epoch", UserTable.expires), Integer).label("expires"),
+            UserTable.expires,
             permissions_subquery,
             limits_subquery,
         )

--- a/api/infrastructure/postgres/_postgresmodelquery.py
+++ b/api/infrastructure/postgres/_postgresmodelquery.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, Select, cast, func, literal, or_, select, text
+from sqlalchemy import Select, func, literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.model import ModelQuery
@@ -10,10 +10,6 @@ from api.sql.models import Provider as ProviderTable
 from api.sql.models import Router as RouterTable
 from api.sql.models import RouterAlias as RouterAliasTable
 from api.sql.models import User as UserTable
-
-
-def _unix_timestamp(column):
-    return cast(func.extract("epoch", column), Integer)
 
 
 class PostgresModelQuery(ModelQuery):
@@ -73,7 +69,7 @@ class PostgresModelQuery(ModelQuery):
                 aliases_subquery,
                 max_context_length_subquery,
                 func.coalesce(OrganizationTable.name, self.app_title).label("owned_by"),
-                _unix_timestamp(RouterTable.created).label("created"),
+                RouterTable.created,
             )
             .select_from(RouterTable)
             .outerjoin(UserTable, UserTable.id == RouterTable.user_id)

--- a/api/infrastructure/postgres/_postgresproviderrepository.py
+++ b/api/infrastructure/postgres/_postgresproviderrepository.py
@@ -34,8 +34,8 @@ class PostgresProviderRepository(ProviderRepository):
             max_context_length=row.max_context_length,
             vector_size=row.vector_size,
             id=row.id,
-            created=int(row.created.timestamp()),
-            updated=int(row.updated.timestamp()),
+            created=row.created,
+            updated=row.updated,
         )
 
     @with_lock(namespace="provider", key="provider.id")

--- a/api/infrastructure/postgres/_postgresrolesrepository.py
+++ b/api/infrastructure/postgres/_postgresrolesrepository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, asc, cast, delete, desc, distinct, func, insert, select, update
+from sqlalchemy import asc, delete, desc, distinct, func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -10,10 +10,6 @@ from api.domain.role.errors import RoleAlreadyExistsError, RoleNotFoundError
 from api.infrastructure.postgres.decorators import with_lock
 from api.sql.models import Role as RoleTable
 from api.sql.models import User as UserTable
-
-
-def _unix_timestamp(column):
-    return cast(func.extract("epoch", column), Integer)
 
 
 class PostgresRolesRepository(RoleRepository):
@@ -41,8 +37,8 @@ class PostgresRolesRepository(RoleRepository):
             select(
                 RoleTable.id,
                 RoleTable.name,
-                _unix_timestamp(RoleTable.created).label("created"),
-                _unix_timestamp(RoleTable.updated).label("updated"),
+                RoleTable.created,
+                RoleTable.updated,
                 func.count(distinct(UserTable.id)).label("users"),
             )
             .outerjoin(UserTable, RoleTable.id == UserTable.role_id)
@@ -69,8 +65,8 @@ class PostgresRolesRepository(RoleRepository):
                 .returning(
                     RoleTable.id,
                     RoleTable.name,
-                    _unix_timestamp(RoleTable.created).label("created"),
-                    _unix_timestamp(RoleTable.updated).label("updated"),
+                    RoleTable.created,
+                    RoleTable.updated,
                 )
             )
             row = result.one()
@@ -90,15 +86,12 @@ class PostgresRolesRepository(RoleRepository):
         row = result.one_or_none()
         if row is None:
             return RoleNotFoundError(id=role_id)
-        role_row, users_count = row  # @TODO: use _row_to_role after converting int to datetime in all the repositories
-        return Role(
-            id=role_row.id,
-            name=role_row.name,
-            permissions=[p.permission for p in role_row.permissions],
-            limits=[Limit(router_id=limit.router_id, type=limit.type, value=limit.value) for limit in role_row.limits],
+        role_row, users_count = row
+        return self._row_to_role(
+            role_row,
             users=users_count,
-            created=int(role_row.created.timestamp()),
-            updated=int(role_row.updated.timestamp()),
+            permissions=[permission.permission for permission in role_row.permissions],
+            limits=[Limit(router_id=limit.router_id, type=limit.type, value=limit.value) for limit in role_row.limits],
         )
 
     async def get_role_with_permissions_and_limits_by_name(self, role_name: str) -> Role | RoleNotFoundError:
@@ -112,15 +105,12 @@ class PostgresRolesRepository(RoleRepository):
         row = result.one_or_none()
         if row is None:
             return RoleNotFoundError(name=role_name)
-        role_row, users_count = row  # @TODO: use _row_to_role after converting int to datetime in all the repositories
-        return Role(
-            id=role_row.id,
-            name=role_row.name,
-            permissions=[p.permission for p in role_row.permissions],
-            limits=[Limit(router_id=limit.router_id, type=limit.type, value=limit.value) for limit in role_row.limits],
+        role_row, users_count = row
+        return self._row_to_role(
+            role_row,
             users=users_count,
-            created=int(role_row.created.timestamp()),
-            updated=int(role_row.updated.timestamp()),
+            permissions=[permission.permission for permission in role_row.permissions],
+            limits=[Limit(router_id=limit.router_id, type=limit.type, value=limit.value) for limit in role_row.limits],
         )
 
     @with_lock(namespace="role", key="role.id")
@@ -131,8 +121,8 @@ class PostgresRolesRepository(RoleRepository):
             .returning(
                 RoleTable.id,
                 RoleTable.name,
-                _unix_timestamp(RoleTable.created).label("created"),
-                _unix_timestamp(RoleTable.updated).label("updated"),
+                RoleTable.created,
+                RoleTable.updated,
             )
             .where(RoleTable.id == role.id)
         )
@@ -153,8 +143,8 @@ class PostgresRolesRepository(RoleRepository):
             .returning(
                 RoleTable.id,
                 RoleTable.name,
-                _unix_timestamp(RoleTable.created).label("created"),
-                _unix_timestamp(RoleTable.updated).label("updated"),
+                RoleTable.created,
+                RoleTable.updated,
             )
         )
         row = result.one_or_none()

--- a/api/infrastructure/postgres/_postgresrouterrepository.py
+++ b/api/infrastructure/postgres/_postgresrouterrepository.py
@@ -14,10 +14,6 @@ from api.sql.models import Router as RouterTable
 from api.sql.models import RouterAlias as RouterAliasTable
 
 
-def _unix_timestamp(column):
-    return cast(func.extract("epoch", column), Integer)
-
-
 class PostgresRouterRepository(RouterRepository):
     def __init__(self, postgres_session: AsyncSession):
         self.postgres_session = postgres_session
@@ -54,8 +50,8 @@ class PostgresRouterRepository(RouterRepository):
             RouterTable.cost_completion_tokens,
             PostgresRouterRepository._select_providers_statement(),
             PostgresRouterRepository._select_aliases_statement(),
-            _unix_timestamp(RouterTable.created).label("created"),
-            _unix_timestamp(RouterTable.updated).label("updated"),
+            RouterTable.created,
+            RouterTable.updated,
         )
 
     @staticmethod
@@ -155,8 +151,8 @@ class PostgresRouterRepository(RouterRepository):
                     RouterTable.cost_prompt_tokens,
                     RouterTable.cost_completion_tokens,
                     cast(literal(0), Integer).label("providers"),
-                    _unix_timestamp(RouterTable.created).label("created"),
-                    _unix_timestamp(RouterTable.updated).label("updated"),
+                    RouterTable.created,
+                    RouterTable.updated,
                 )
             )
             result = await self.postgres_session.execute(insert_router_query)
@@ -220,8 +216,8 @@ class PostgresRouterRepository(RouterRepository):
                     RouterTable.load_balancing_strategy,
                     RouterTable.cost_prompt_tokens,
                     RouterTable.cost_completion_tokens,
-                    _unix_timestamp(RouterTable.created).label("created"),
-                    _unix_timestamp(RouterTable.updated).label("updated"),
+                    RouterTable.created,
+                    RouterTable.updated,
                 )
             )
             result = await self.postgres_session.execute(update_query)

--- a/api/infrastructure/postgres/_postgresusersrepository.py
+++ b/api/infrastructure/postgres/_postgresusersrepository.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Integer, cast, delete, func, insert, select, update
+from sqlalchemy import delete, func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,11 +22,6 @@ from api.infrastructure.postgres.decorators import with_lock
 from api.sql.models import Permission as PermissionTable
 from api.sql.models import User as UserTable
 
-
-def _unix_timestamp(column):
-    return cast(func.extract("epoch", column), Integer)
-
-
 _USER_COLUMNS = (
     UserTable.id,
     UserTable.email,
@@ -37,9 +33,9 @@ _USER_COLUMNS = (
     UserTable.role_id,
     UserTable.organization_id,
     UserTable.budget,
-    _unix_timestamp(UserTable.expires).label("expires"),
-    _unix_timestamp(UserTable.created).label("created"),
-    _unix_timestamp(UserTable.updated).label("updated"),
+    UserTable.expires,
+    UserTable.created,
+    UserTable.updated,
     UserTable.priority,
 )
 
@@ -86,11 +82,9 @@ class PostgresUserRepository(UserRepository):
         claims: dict[str, Any] | None = None,
         organization_id: int | None = None,
         budget: float | None = None,
-        expires: int | None = None,
+        expires: datetime | None = None,
         priority: int = 0,
     ) -> User | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
-        expires_value = func.to_timestamp(expires) if expires is not None else None
-
         try:
             result = await self.postgres_session.execute(
                 insert(UserTable)
@@ -104,7 +98,7 @@ class PostgresUserRepository(UserRepository):
                     role_id=role_id,
                     organization_id=organization_id,
                     budget=budget,
-                    expires=expires_value,
+                    expires=expires,
                     priority=priority,
                 )
                 .returning(*_USER_COLUMNS)
@@ -185,8 +179,6 @@ class PostgresUserRepository(UserRepository):
 
     @with_lock(namespace="user", key="user.id")
     async def update_user(self, user: User) -> User | UserNotFoundError | UserAlreadyExistsError | RoleNotFoundError | OrganizationNotFoundError:
-        expires_value = func.to_timestamp(user.expires) if user.expires is not None else None
-
         statement = (
             update(table=UserTable)
             .values(
@@ -199,7 +191,7 @@ class PostgresUserRepository(UserRepository):
                 role_id=user.role_id,
                 organization_id=user.organization_id,
                 budget=user.budget,
-                expires=expires_value,
+                expires=user.expires,
                 priority=user.priority,
             )
             .returning(*_USER_COLUMNS)

--- a/api/schemas/admin/organizations.py
+++ b/api/schemas/admin/organizations.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import Field, constr
@@ -15,8 +15,8 @@ class Organization(BaseModel):
     id: int
     name: str
     users: int
-    created: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
-    updated: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
+    created: int = Field(default_factory=lambda: int(datetime.now(tz=UTC).timestamp()), description="Time of creation, as Unix timestamp.")
+    updated: int = Field(default_factory=lambda: int(datetime.now(tz=UTC).timestamp()), description="Time of last update, as Unix timestamp.")
 
 
 class Organizations(BaseModel):

--- a/api/schemas/admin/roles.py
+++ b/api/schemas/admin/roles.py
@@ -50,8 +50,8 @@ class Role(BaseModel):
     permissions: list[PermissionType]
     limits: list[Limit]
     users: int = 0
-    created: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))
-    updated: int = Field(default_factory=lambda: int(dt.datetime.now().timestamp()))
+    created: int = Field(default_factory=lambda: int(dt.datetime.now(tz=dt.UTC).timestamp()), description="Time of creation, as Unix timestamp.")
+    updated: int = Field(default_factory=lambda: int(dt.datetime.now(tz=dt.UTC).timestamp()), description="Time of last update, as Unix timestamp.")
 
 
 class Roles(BaseModel):

--- a/api/tests/integration/endpoints/admin/provider/test_create_provider.py
+++ b/api/tests/integration/endpoints/admin/provider/test_create_provider.py
@@ -70,6 +70,8 @@ class TestCreateProvider:
 
         assert response.status_code == 201, response.text
         assert isinstance(response.json()["id"], int)
+        assert isinstance(response.json()["created"], int)
+        assert isinstance(response.json()["updated"], int)
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/provider/test_get_one_provider.py
+++ b/api/tests/integration/endpoints/admin/provider/test_get_one_provider.py
@@ -43,6 +43,8 @@ class TestGetProvider:
         assert data["object"] == "provider"
         assert data["max_context_length"] == 4096
         assert data["vector_size"] == 768
+        assert data["created"] == int(provider.created.timestamp())
+        assert data["updated"] == int(provider.updated.timestamp())
         assert "key" not in data
         assert "basic_auth" not in data
 

--- a/api/tests/integration/endpoints/admin/roles/test_get_role.py
+++ b/api/tests/integration/endpoints/admin/roles/test_get_role.py
@@ -36,6 +36,8 @@ class TestGetRole:
         assert response.status_code == 200, response.text
         data = response.json()
         assert data["id"] == role.id
+        assert data["created"] == int(role.created.timestamp())
+        assert data["updated"] == int(role.updated.timestamp())
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/router/test_get_router.py
+++ b/api/tests/integration/endpoints/admin/router/test_get_router.py
@@ -34,6 +34,8 @@ class TestGetRouter:
         data = response.json()
         assert data["id"] == router.id
         assert data["object"] == "router"
+        assert data["created"] == int(router.created.timestamp())
+        assert data["updated"] == int(router.updated.timestamp())
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/users/test_create_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_create_user.py
@@ -1,13 +1,16 @@
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 from httpx import AsyncClient
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 
 from api.dependencies import create_user_use_case_factory
 from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
 from api.domain.user.errors import UserAlreadyExistsError
+from api.sql.models import User as UserTable
 from api.tests.helpers import create_key
 from api.tests.integration.factories.sql import RoleSQLFactory, UserSQLFactory
 from api.utils.variables import EndpointRoute
@@ -47,6 +50,25 @@ class TestCreateUser:
         assert data["email"] == "newuser@test.com"
         assert isinstance(data["id"], int)
         assert data["role_id"] == role.id
+        assert data["expires"] is None
+        assert isinstance(data["created"], int)
+        assert isinstance(data["updated"], int)
+
+    async def test_round_trips_expires_as_unix_timestamp(self, client: AsyncClient, db_session):
+        role = RoleSQLFactory()
+        await db_session.flush()
+        expires = int((datetime.now(tz=UTC) + timedelta(days=30)).timestamp())
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.token.token}"},
+            json=_valid_body(role_id=role.id, expires=expires),
+        )
+
+        assert response.status_code == 201, response.text
+        assert response.json()["expires"] == expires
+        stored = (await db_session.execute(select(UserTable.expires).where(UserTable.id == response.json()["id"]))).scalar_one()
+        assert stored == datetime.fromtimestamp(timestamp=expires, tz=UTC)
 
     @pytest.mark.parametrize(
         "body,expected_msg",

--- a/api/tests/integration/endpoints/admin/users/test_get_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_get_user.py
@@ -34,6 +34,9 @@ class TestGetUser:
         assert data["id"] == target_user.id
         assert data["object"] == "user"
         assert data["email"] == target_user.email
+        assert data["created"] == int(target_user.created.timestamp())
+        assert data["updated"] == int(target_user.updated.timestamp())
+        assert data["expires"] is None
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/me/test_get_me.py
+++ b/api/tests/integration/endpoints/me/test_get_me.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from httpx import AsyncClient
 import pytest
@@ -43,7 +43,8 @@ class TestGetMe:
         assert "updated" not in data
 
     async def test_allows_expired_user(self, client: AsyncClient, db_session):
-        expired_user = UserSQLFactory(role=self.user.role, expires=datetime.now() - timedelta(days=1))
+        expires = datetime.now(tz=UTC) - timedelta(days=1)
+        expired_user = UserSQLFactory(role=self.user.role, expires=expires)
         key = await create_key(db_session, name="expired_user_key", user=expired_user, never_expires=True)
 
         response = await client.get(url=URL, headers={"Authorization": f"Bearer {key.token}"})
@@ -51,6 +52,7 @@ class TestGetMe:
         assert response.status_code == 200, response.text
         assert response.json()["id"] == expired_user.id
         assert response.json()["object"] == "userInfo"
+        assert response.json()["expires"] == int(expires.timestamp())
 
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/test_models.py
+++ b/api/tests/integration/endpoints/test_models.py
@@ -60,11 +60,13 @@ class TestGetModels:
         assert sorted(models_by_id["router_1"]["aliases"]) == ["alias1_m1", "alias2_m1", "alias3_m1"]
         assert models_by_id["router_1"]["costs"] == {"prompt_tokens": 0.001, "completion_tokens": 0.002}
         assert models_by_id["router_1"]["max_context_length"] == 2048
+        assert models_by_id["router_1"]["created"] == int(router_1.created.timestamp())
 
         assert models_by_id["router_2"]["type"] == ModelType.TEXT_EMBEDDINGS_INFERENCE.value
         assert models_by_id["router_2"]["aliases"] == []
         assert models_by_id["router_2"]["costs"] == {"prompt_tokens": 0.0, "completion_tokens": 0.0}
         assert models_by_id["router_2"]["max_context_length"] == 16384
+        assert models_by_id["router_2"]["created"] == int(router_2.created.timestamp())
 
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/usage/test_get_usages.py
+++ b/api/tests/integration/endpoints/usage/test_get_usages.py
@@ -42,6 +42,7 @@ class TestGetUsages:
         assert item["usage"]["prompt_tokens"] == own_usage.prompt_tokens
         assert item["usage"]["completion_tokens"] == own_usage.completion_tokens
         assert item["usage"]["total_tokens"] == own_usage.total_tokens
+        assert item["created"] == int(own_usage.created.timestamp())
 
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",

--- a/api/tests/integration/factories/sql.py
+++ b/api/tests/integration/factories/sql.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import unicodedata
 
 import factory
@@ -27,8 +27,8 @@ class OrganizationSQLFactory(BaseSQLFactory):
         model = Organization
 
     name = factory.Sequence(lambda n: f"{fake.company()} {n}")
-    created = factory.LazyFunction(lambda: datetime.now())
-    updated = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
         administration = factory.Trait(name=factory.Sequence(lambda n: f"Administration {n}"))
@@ -40,8 +40,8 @@ class RoleSQLFactory(BaseSQLFactory):
         model = Role
 
     name = factory.Faker("bothify", text="role_????")
-    created = factory.LazyFunction(lambda: datetime.now())
-    updated = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     @factory.post_generation
     def permissions(self, create, extracted, **kwargs):
@@ -76,7 +76,7 @@ class PermissionSQLFactory(BaseSQLFactory):
     role_id = None
     role = factory.SubFactory(RoleSQLFactory)
     permission = factory.Faker("random_element", elements=list(PermissionType))
-    created = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
         admin = factory.Trait(permission=PermissionType.ADMIN, role=factory.SubFactory(RoleSQLFactory, admin=True))
@@ -101,8 +101,8 @@ class UserSQLFactory(BaseSQLFactory):
     password = "$2b$12$I7iMWv/FqLtb7Az6iX9uTuPkvGWU1xh.Gtwb3qb0.fm8kCYJkLRwq"
     priority = 0
     expires = None
-    created = factory.LazyFunction(lambda: datetime.now())
-    updated = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     @factory.lazy_attribute
     def email(self):
@@ -127,14 +127,14 @@ class KeySQLFactory(BaseSQLFactory):
     user = factory.SubFactory(UserSQLFactory)
     token = "tmp"
     name = factory.Sequence(lambda n: f"key_{n}")
-    expires = factory.LazyFunction(lambda: datetime.now() + timedelta(days=30))
-    created = factory.LazyFunction(lambda: datetime.now())
+    expires = factory.LazyFunction(lambda: datetime.now(tz=UTC) + timedelta(days=30))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
-        expired = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now() - timedelta(days=1)))
+        expired = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now(tz=UTC) - timedelta(days=1)))
         never_expires = factory.Trait(expires=None)
-        short_lived = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now() + timedelta(hours=1)))
-        long_lived = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now() + timedelta(days=365)))
+        short_lived = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now(tz=UTC) + timedelta(hours=1)))
+        long_lived = factory.Trait(expires=factory.LazyFunction(lambda: datetime.now(tz=UTC) + timedelta(days=365)))
 
 
 class RouterSQLFactory(BaseSQLFactory):
@@ -150,8 +150,8 @@ class RouterSQLFactory(BaseSQLFactory):
     load_balancing_strategy = factory.Faker("random_element", elements=list(RouterLoadBalancingStrategy))
     cost_prompt_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)
     cost_completion_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)
-    created = factory.LazyFunction(lambda: datetime.now())
-    updated = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     @factory.post_generation
     def alias(self, create, extracted, **kwargs):
@@ -207,8 +207,8 @@ class ProviderSQLFactory(BaseSQLFactory):
     qos_limit = factory.Faker("pyfloat", left_digits=2, right_digits=2, min_value=0.5, max_value=0.99)
     max_context_length = factory.Faker("random_element", elements=[2048, 4096, 8192, 16384, 32768, 128000])
     vector_size = factory.Faker("random_element", elements=[384, 768, 1024, 1536, 3072])
-    created = factory.LazyFunction(lambda: datetime.now())
-    updated = factory.LazyFunction(lambda: datetime.now())
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
 
 class LimitSQLFactory(BaseSQLFactory):
@@ -219,7 +219,7 @@ class LimitSQLFactory(BaseSQLFactory):
     id = None
     type = fuzzy.FuzzyChoice([LimitType.TPM, LimitType.TPD, LimitType.RPM, LimitType.RPD])
     value = fuzzy.FuzzyInteger(100, 10000)
-    created = factory.LazyFunction(datetime.now)
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     role = factory.SubFactory(RoleSQLFactory)
     router = factory.SubFactory(RouterSQLFactory)
@@ -249,7 +249,7 @@ class UsageSQLFactory(BaseSQLFactory):
     cost = 0.1
     kwh = 0.01
     kgco2eq = 0.02
-    created = factory.LazyFunction(datetime.now)
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
         failed = factory.Trait(status=500)

--- a/api/tests/integration/postgres/role_repository/test_get_role_by_id.py
+++ b/api/tests/integration/postgres/role_repository/test_get_role_by_id.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from api.domain.role.entities import LimitType, PermissionType, Role
@@ -82,7 +84,9 @@ class TestGetRoleById:
         result = await repository.get_role_with_permissions_and_limits_by_id(role_id=role.id)
 
         # Assert
-        assert isinstance(result.created, int)
-        assert isinstance(result.updated, int)
-        assert result.created == int(role.created.timestamp())
-        assert result.updated == int(role.updated.timestamp())
+        assert isinstance(result.created, datetime)
+        assert isinstance(result.updated, datetime)
+        assert result.created.tzinfo is not None
+        assert result.updated.tzinfo is not None
+        assert result.created == role.created
+        assert result.updated == role.updated

--- a/api/tests/integration/postgres/role_repository/test_get_role_name.py
+++ b/api/tests/integration/postgres/role_repository/test_get_role_name.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from api.domain.role.entities import LimitType, PermissionType, Role
@@ -82,7 +84,9 @@ class TestGetRoleByName:
         result = await repository.get_role_with_permissions_and_limits_by_name(role_name=role.name)
 
         # Assert
-        assert isinstance(result.created, int)
-        assert isinstance(result.updated, int)
-        assert result.created == int(role.created.timestamp())
-        assert result.updated == int(role.updated.timestamp())
+        assert isinstance(result.created, datetime)
+        assert isinstance(result.updated, datetime)
+        assert result.created.tzinfo is not None
+        assert result.updated.tzinfo is not None
+        assert result.created == role.created
+        assert result.updated == role.updated

--- a/api/tests/integration/postgres/user_repository/test_update_user.py
+++ b/api/tests/integration/postgres/user_repository/test_update_user.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 
 from pydantic import SecretStr
 import pytest
@@ -78,6 +78,25 @@ class TestUpdateUser:
         # Assert
         assert isinstance(result, User)
         assert result.expires == expires
+
+    async def test_persists_the_same_instant_when_expires_is_not_in_utc(self, repository, db_session):
+        # Arrange
+        user = UserSQLFactory(expires=None)
+        await db_session.flush()
+        existing_user = await _get_user_entity(repository, user.id)
+        paris = timezone(timedelta(hours=2))
+        expires_paris = datetime(2027, 6, 15, 14, 30, tzinfo=paris)  # same instant as 12:30 UTC
+
+        # Act
+        result = await repository.update_user(user=existing_user.model_copy(update={"expires": expires_paris}))
+
+        # Assert
+        assert isinstance(result, User)
+        assert result.expires == expires_paris  # same instant
+        assert result.expires == datetime(2027, 6, 15, 12, 30, tzinfo=UTC)  # normalized to UTC
+        assert result.expires.utcoffset() == timedelta(0)
+        stored = (await db_session.execute(select(UserTable.expires).where(UserTable.id == user.id))).scalar_one()
+        assert stored == expires_paris
 
     async def test_returns_user_not_found_error_when_user_does_not_exist(self, repository, db_session):
         # Arrange

--- a/api/tests/integration/postgres/user_repository/test_update_user.py
+++ b/api/tests/integration/postgres/user_repository/test_update_user.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from pydantic import SecretStr
 import pytest
@@ -70,7 +70,7 @@ class TestUpdateUser:
         user = UserSQLFactory(expires=None)
         await db_session.flush()
         existing_user = await _get_user_entity(repository, user.id)
-        expires = int((datetime.now() + timedelta(days=30)).timestamp())
+        expires = datetime.now(tz=UTC) + timedelta(days=30)
 
         # Act
         result = await repository.update_user(user=existing_user.model_copy(update={"expires": expires}))

--- a/api/tests/unit/domain/test_utcdatetime.py
+++ b/api/tests/unit/domain/test_utcdatetime.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from api.domain import BaseModel, UtcDatetime
+
+
+class Entity(BaseModel):
+    moment: UtcDatetime
+    optional_moment: UtcDatetime | None = None
+
+
+class TestUtcDatetime:
+    def test_should_keep_an_utc_datetime_unchanged(self):
+        # Arrange
+        moment = datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
+
+        # Act
+        entity = Entity(moment=moment)
+
+        # Assert
+        assert entity.moment == moment
+        assert entity.moment.tzinfo == UTC
+
+    def test_should_read_a_naive_datetime_as_utc(self):
+        # Act
+        entity = Entity(moment=datetime(2026, 8, 27, 12, 30))
+
+        # Assert
+        assert entity.moment == datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
+
+    def test_should_convert_an_offset_datetime_to_utc(self):
+        # Arrange
+        moment = datetime(2026, 8, 27, 14, 30, tzinfo=timezone(timedelta(hours=2)))
+
+        # Act
+        entity = Entity(moment=moment)
+
+        # Assert
+        assert entity.moment == datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
+        assert entity.moment.tzinfo == UTC
+
+    def test_should_read_an_unix_timestamp_as_utc(self):
+        # Arrange
+        moment = datetime(2026, 8, 27, 12, 30, tzinfo=UTC)
+
+        # Act
+        entity = Entity(moment=int(moment.timestamp()))
+
+        # Assert
+        assert entity.moment == moment
+
+    def test_should_round_trip_to_the_same_unix_timestamp(self):
+        # Arrange
+        timestamp = 1_756_298_000
+
+        # Act
+        entity = Entity(moment=timestamp)
+
+        # Assert
+        assert int(entity.moment.timestamp()) == timestamp
+
+    def test_should_allow_none_on_an_optional_field(self):
+        # Act
+        entity = Entity(moment=datetime(2026, 8, 27, tzinfo=UTC), optional_moment=None)
+
+        # Assert
+        assert entity.optional_moment is None
+
+    def test_should_reject_a_value_that_is_not_a_datetime(self):
+        # Act & Assert
+        with pytest.raises(ValueError):
+            Entity(moment="not-a-datetime")

--- a/api/tests/unit/domain/user/test_userviews.py
+++ b/api/tests/unit/domain/user/test_userviews.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from api.tests.unit.use_case.factories import AuthenticatedUserFactory
 
 
@@ -22,3 +24,34 @@ class TestAuthenticatedUserViewHasInsufficientBudget:
 
         # Act & Assert
         assert user.has_insufficient_budget is False
+
+
+class TestAuthenticatedUserViewHasExpired:
+    def test_has_not_expired_when_expires_is_none(self):
+        # Arrange
+        user = AuthenticatedUserFactory(no_expiration=True)
+
+        # Act & Assert
+        assert user.has_expired is False
+
+    def test_has_not_expired_when_expires_is_in_the_future(self):
+        # Arrange
+        user = AuthenticatedUserFactory(expires=datetime.now(tz=UTC) + timedelta(days=1))
+
+        # Act & Assert
+        assert user.has_expired is False
+
+    def test_has_expired_when_expires_is_in_the_past(self):
+        # Arrange
+        user = AuthenticatedUserFactory(expires=datetime.now(tz=UTC) - timedelta(days=1))
+
+        # Act & Assert
+        assert user.has_expired is True
+
+    def test_naive_expires_is_read_as_utc(self):
+        # Arrange
+        user = AuthenticatedUserFactory(expires=datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(days=1))
+
+        # Act & Assert
+        assert user.expires.tzinfo == UTC
+        assert user.has_expired is True

--- a/api/tests/unit/infrastructure/factories.py
+++ b/api/tests/unit/infrastructure/factories.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from http import HTTPMethod
 import random
 from urllib.parse import urljoin
@@ -129,7 +130,7 @@ class ProviderModelResponseFactory(factory.Factory):
 
     id = factory.Faker("bothify", text="model-????-####")
     object = "model"
-    created = factory.LazyFunction(lambda: int(fake.unix_time()))
+    created = factory.LazyFunction(lambda: datetime.fromtimestamp(timestamp=fake.unix_time(), tz=UTC))
     owned_by = factory.Faker("company")
     max_context_length = factory.Faker("random_int", min=64000, max=245600)
     aliases = factory.LazyFunction(lambda: [fake.bothify(text="model-????-latest")])

--- a/api/tests/unit/use_case/factories.py
+++ b/api/tests/unit/use_case/factories.py
@@ -115,7 +115,7 @@ class ModelViewFactory(factory.Factory):
     id = factory.Faker("bothify", text="model-????")
     type = factory.Faker("random_element", elements=list(RouterType))
     aliases = factory.LazyFunction(list)
-    created = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
     owned_by = factory.Faker("bothify", text="organization_????")
     max_context_length = None
     costs = factory.LazyFunction(ModelCosts)

--- a/api/tests/unit/use_case/factories.py
+++ b/api/tests/unit/use_case/factories.py
@@ -35,8 +35,8 @@ class RoleFactory(factory.Factory):
     name = factory.Faker("bothify", text="role_????")
     permissions = factory.LazyFunction(lambda: random.sample(list(PermissionType), k=random.randint(0, len(PermissionType))))
     limits = factory.LazyFunction(list)
-    created = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
-    updated = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
         admin = factory.Trait(name="admin", permissions=[PermissionType.ADMIN])
@@ -50,8 +50,8 @@ class OrganizationFactory(factory.Factory):
     id = factory.Sequence(lambda n: n + 1)
     name = factory.Faker("bothify", text="organization_????")
     users = 0
-    created = factory.LazyFunction(lambda: datetime.now(UTC))
-    updated = factory.LazyFunction(lambda: datetime.now(UTC))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
 
 class RouterFactory(factory.Factory):
@@ -67,8 +67,8 @@ class RouterFactory(factory.Factory):
     cost_prompt_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)
     cost_completion_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)
     providers = 0
-    created = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
-    updated = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
     class Params:
         free = factory.Trait(cost_prompt_tokens=0.0, cost_completion_tokens=0.0)
@@ -103,8 +103,8 @@ class ProviderFactory(factory.Factory):
     qos_limit = None
     max_context_length = None
     vector_size = None
-    created = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
-    updated = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
 
 class ModelViewFactory(factory.Factory):
@@ -137,8 +137,8 @@ class UserFactory(factory.Factory):
     budget = factory.Faker("pyfloat", left_digits=5, right_digits=2, positive=True)
     expires = None
     priority = 0
-    created = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
-    updated = factory.LazyFunction(lambda: int(datetime.now(UTC).timestamp()))
+    created = factory.LazyFunction(lambda: datetime.now(tz=UTC))
+    updated = factory.LazyFunction(lambda: datetime.now(tz=UTC))
 
 
 class AuthenticatedUserFactory(factory.Factory):
@@ -152,7 +152,7 @@ class AuthenticatedUserFactory(factory.Factory):
     budget = factory.Faker("pyfloat", left_digits=5, right_digits=2, positive=True)
     permissions = factory.LazyFunction(lambda: random.sample(list(PermissionType), k=random.randint(1, len(PermissionType))))
     limits = factory.LazyFunction(lambda: [LimitFactory() for _ in range(random.randint(1, 3))])
-    expires = factory.LazyFunction(lambda: int((datetime.now(UTC) + timedelta(days=365)).timestamp()))
+    expires = factory.LazyFunction(lambda: datetime.now(tz=UTC) + timedelta(days=365))
 
     class Params:
         unlimited_budget = factory.Trait(budget=None)

--- a/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
+++ b/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import create_autospec
 
 from openai.types import Embedding
@@ -39,7 +40,7 @@ def model_entity(model_id: str = DEFAULT_MODEL_ID, aliases: list[str] | None = N
     return Model(
         id=model_id,
         aliases=aliases or [],
-        created=0,
+        created=datetime(1970, 1, 1, tzinfo=UTC),
         owned_by="test",
         max_context_length=max_context_length,
         type=RouterType.TEXT_GENERATION,

--- a/api/use_cases/admin/users/_createuserusecase.py
+++ b/api/use_cases/admin/users/_createuserusecase.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from api.domain.organization.errors import OrganizationNotFoundError
 from api.domain.role.errors import RoleNotFoundError
@@ -15,7 +16,7 @@ class CreateUserCommand:
     name: str | None = None
     organization_id: int | None = None
     budget: float | None = None
-    expires: int | None = None
+    expires: datetime | None = None
     priority: int = 0
 
 

--- a/api/use_cases/admin/users/_updateuserusecase.py
+++ b/api/use_cases/admin/users/_updateuserusecase.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from pydantic import SecretStr
 
@@ -19,7 +20,7 @@ class UpdateUserCommand:
     role_id: int | None = None
     organization_id: int | None = None
     budget: float | None = None
-    expires: int | None = None
+    expires: datetime | None = None
     priority: int | None = None
 
 

--- a/api/utils/hooks_decorator.py
+++ b/api/utils/hooks_decorator.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import UTC, datetime
 import functools
 import logging
 import re
@@ -34,7 +34,7 @@ def hooks(func):
 
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
-        usage = Usage(created=datetime.now(), endpoint="N/A")
+        usage = Usage(created=datetime.now(tz=UTC), endpoint="N/A")
 
         # get the request context (initial values)
         context = request_context.get()

--- a/playground/app/features/account/components/account_info_card.py
+++ b/playground/app/features/account/components/account_info_card.py
@@ -49,6 +49,16 @@ def account_info_card() -> rx.Component:
                     spacing=SPACING_TINY,
                     width="100%",
                 ),
+                rx.vstack(
+                    rx.text("Expires", size=TEXT_SIZE_LABEL, weight="bold"),
+                    rx.input(
+                        value=AccountState.user_expires_formatted,
+                        read_only=True,
+                        width="100%",
+                    ),
+                    spacing=SPACING_TINY,
+                    width="100%",
+                ),
                 rx.hstack(
                     rx.spacer(),
                     rx.button(

--- a/playground/app/features/account/state.py
+++ b/playground/app/features/account/state.py
@@ -5,6 +5,7 @@ import reflex as rx
 
 from app.features.auth.state import AuthState
 from app.shared.components.toasts import httpx_error_toast
+from app.shared.utils.timestamps import format_datetime
 
 
 class AccountState(AuthState):
@@ -26,6 +27,11 @@ class AccountState(AuthState):
         if self.user_budget is None:
             return "Unlimited"
         return str(self.user_budget)
+
+    @rx.var
+    def user_expires_formatted(self) -> str:
+        """Format the account expiration date in the local timezone, showing 'Never' if None."""
+        return format_datetime(self.user_expires, default="Never")
 
     @rx.event
     async def change_password(self):

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -7,6 +7,7 @@ from app.core.configuration import configuration
 from app.features.keys.models import Key
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
 
 
 class KeysState(EntityState):
@@ -24,8 +25,8 @@ class KeysState(EntityState):
             id=key["id"],
             name=key["name"],
             token=key["value"],
-            expires=dt.datetime.fromtimestamp(key["expires"]).strftime("%Y-%m-%d %H:%M") if key["expires"] else "never",
-            created=dt.datetime.fromtimestamp(key["created"]).strftime("%Y-%m-%d %H:%M"),
+            expires=format_datetime(key["expires"], default="never"),
+            created=format_datetime(key["created"]),
         )
 
     @rx.var
@@ -35,11 +36,11 @@ class KeysState(EntityState):
 
     def _default_expiry_date(self) -> str:
         """Default expiry date: today + 1 year, capped at the configured maximum if any."""
-        default = dt.datetime.now() + dt.timedelta(days=365)
+        default = local_now() + dt.timedelta(days=365)
         if configuration.settings.auth_key_max_expiration_days is not None:
-            max_date = dt.datetime.now() + dt.timedelta(days=configuration.settings.auth_key_max_expiration_days - 1)
+            max_date = local_now() + dt.timedelta(days=configuration.settings.auth_key_max_expiration_days - 1)
             default = min(default, max_date)
-        return default.strftime("%Y-%m-%d")
+        return format_local_date(default)
 
     @rx.event
     async def load_entities(self):
@@ -155,13 +156,13 @@ class KeysState(EntityState):
     @rx.var
     def min_expiry_date(self) -> str:
         """Get today's date as minimum for expiry date picker."""
-        return dt.datetime.now().strftime("%Y-%m-%d")
+        return format_local_date(local_now())
 
     @rx.var
     def max_expiry_date(self) -> str:
         """Get the maximum expiry date."""
         if configuration.settings.auth_key_max_expiration_days is not None:
-            return (dt.datetime.now() + dt.timedelta(days=configuration.settings.auth_key_max_expiration_days - 1)).strftime("%Y-%m-%d")
+            return format_local_date(local_now() + dt.timedelta(days=configuration.settings.auth_key_max_expiration_days - 1))
         return ""
 
     @rx.event
@@ -185,8 +186,7 @@ class KeysState(EntityState):
         payload = {"name": self.entity_to_create.name}
 
         if self.entity_to_create.expires:
-            expires = dt.datetime.strptime(self.entity_to_create.expires, "%Y-%m-%d").timestamp()
-            payload["expires"] = expires
+            payload["expires"] = date_to_timestamp(self.entity_to_create.expires)
 
         response = None
         try:

--- a/playground/app/features/organizations/state.py
+++ b/playground/app/features/organizations/state.py
@@ -1,11 +1,10 @@
-import datetime as dt
-
 import httpx
 import reflex as rx
 
 from app.features.organizations.models import Organization
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import format_datetime
 
 
 class OrganizationsState(EntityState):
@@ -23,8 +22,8 @@ class OrganizationsState(EntityState):
             id=organization["id"],
             name=organization["name"],
             users=organization["users"],
-            created=dt.datetime.fromtimestamp(organization["created"]).strftime("%Y-%m-%d %H:%M"),
-            updated=dt.datetime.fromtimestamp(organization["updated"]).strftime("%Y-%m-%d %H:%M"),
+            created=format_datetime(organization["created"]),
+            updated=format_datetime(organization["updated"]),
         )
 
     @rx.var

--- a/playground/app/features/providers/state.py
+++ b/playground/app/features/providers/state.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import httpx
 import pycountry
 import reflex as rx
@@ -7,6 +5,7 @@ import reflex as rx
 from app.features.providers.models import Provider
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import format_datetime
 
 
 class ProvidersState(EntityState):
@@ -78,7 +77,7 @@ class ProvidersState(EntityState):
             qos_limit=provider["qos_limit"],
             max_context_length=provider["max_context_length"],
             vector_size=provider["vector_size"],
-            created=dt.datetime.fromtimestamp(provider["created"]).strftime("%Y-%m-%d %H:%M"),
+            created=format_datetime(provider["created"]),
         )
 
     @rx.var

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import datetime as dt
 
 import httpx
 import reflex as rx
@@ -7,6 +6,7 @@ import reflex as rx
 from app.features.roles.models import Role
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import format_datetime
 
 
 class RolesState(EntityState):
@@ -42,8 +42,8 @@ class RolesState(EntityState):
             permissions_provide_models=permissions_provide_models,
             limits=limits,
             users=role["users"],
-            created=dt.datetime.fromtimestamp(role["created"]).strftime("%Y-%m-%d %H:%M"),
-            updated=dt.datetime.fromtimestamp(role["updated"]).strftime("%Y-%m-%d %H:%M"),
+            created=format_datetime(role["created"]),
+            updated=format_datetime(role["updated"]),
         )
 
     def _format_limit(self, limit: dict[str, str | int]) -> list[dict[str, str | int]]:

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -1,11 +1,10 @@
-import datetime as dt
-
 import httpx
 import reflex as rx
 
 from app.features.routers.models import Router
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import format_datetime
 
 
 class RoutersState(EntityState):
@@ -53,8 +52,8 @@ class RoutersState(EntityState):
             cost_prompt_tokens=router["cost_prompt_tokens"],
             cost_completion_tokens=router["cost_completion_tokens"],
             providers=router["providers"],
-            created=dt.datetime.fromtimestamp(router["created"]).strftime("%Y-%m-%d %H:%M"),
-            updated=dt.datetime.fromtimestamp(router["updated"]).strftime("%Y-%m-%d %H:%M"),
+            created=format_datetime(router["created"]),
+            updated=format_datetime(router["updated"]),
         )
 
     @rx.var

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -9,6 +9,7 @@ import reflex as rx
 from app.features.usage.models import Usage
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
 
 
 class UsageState(EntityState):
@@ -25,7 +26,7 @@ class UsageState(EntityState):
 
     def _format_usage(self, usage: dict) -> Usage:
         return Usage(
-            created=dt.datetime.fromtimestamp(usage["created"]).strftime("%Y-%m-%d %H:%M"),
+            created=format_datetime(usage["created"]),
             endpoint=usage["endpoint"],
             model=usage["model"],
             key=usage["key"],
@@ -44,8 +45,8 @@ class UsageState(EntityState):
         self.entities_loading = True
         yield
 
-        start_time = int(dt.datetime.strptime(self.get_filter_date_from_value, "%Y-%m-%d").timestamp())
-        end_time = int(dt.datetime.strptime(self.get_filter_date_to_value, "%Y-%m-%d").timestamp())
+        start_time = date_to_timestamp(self.get_filter_date_from_value)
+        end_time = date_to_timestamp(self.get_filter_date_to_value)
 
         params = {
             "offset": (self.page - 1) * self.per_page,
@@ -127,18 +128,18 @@ class UsageState(EntityState):
     @rx.var
     def get_filter_date_from_value(self) -> str:
         if self.filter_date_from_value is None:
-            return (dt.datetime.now() - dt.timedelta(days=30)).strftime("%Y-%m-%d")
+            return format_local_date(local_now() - dt.timedelta(days=30))
         return self.filter_date_from_value
 
     @rx.var
     def get_filter_date_to_value(self) -> str:
         if self.filter_date_to_value is None:
-            return (dt.datetime.now() + dt.timedelta(days=1)).strftime("%Y-%m-%d")
+            return format_local_date(local_now() + dt.timedelta(days=1))
         return self.filter_date_to_value
 
     @rx.var
     def filter_date_to_value_max(self) -> str:
-        return (dt.datetime.now() + dt.timedelta(days=1)).strftime("%Y-%m-%d")
+        return format_local_date(local_now() + dt.timedelta(days=1))
 
     @rx.event
     def set_filter_date_from(self, value: str):

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -1,11 +1,10 @@
-import datetime as dt
-
 import httpx
 import reflex as rx
 
 from app.features.users.models import User
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
+from app.shared.utils.timestamps import date_to_timestamp, format_date, format_datetime
 
 
 class UsersState(EntityState):
@@ -44,9 +43,9 @@ class UsersState(EntityState):
             organization=organization_name,
             budget=user["budget"],
             priority=user["priority"],
-            expires=dt.datetime.fromtimestamp(user["expires"]).strftime("%Y-%m-%d") if user["expires"] else None,
-            created=dt.datetime.fromtimestamp(user["created"]).strftime("%Y-%m-%d %H:%M"),
-            updated=dt.datetime.fromtimestamp(user["updated"]).strftime("%Y-%m-%d %H:%M"),
+            expires=format_date(user["expires"]) if user["expires"] else None,
+            created=format_datetime(user["created"]),
+            updated=format_datetime(user["updated"]),
         )
 
     ############################################################
@@ -254,8 +253,7 @@ class UsersState(EntityState):
         }
 
         if self.entity_to_create.expires:
-            expires = dt.datetime.strptime(self.entity_to_create.expires, "%Y-%m-%d").timestamp()
-            payload["expires"] = expires
+            payload["expires"] = date_to_timestamp(self.entity_to_create.expires)
 
         if self.entity_to_create.budget:
             payload["budget"] = self.entity_to_create.budget
@@ -326,7 +324,7 @@ class UsersState(EntityState):
             "email": self.entity.email,
             "name": self.entity.name,
             "role_id": role_id,
-            "expires": self.entity.expires,
+            "expires": date_to_timestamp(self.entity.expires) if self.entity.expires else None,
             "priority": self.entity.priority,
         }
         if self.entity.budget == "":

--- a/playground/app/shared/utils/timestamps.py
+++ b/playground/app/shared/utils/timestamps.py
@@ -1,0 +1,52 @@
+"""Timestamp helpers for the playground.
+
+The OpenGateLLM API exposes every timestamp as Unix seconds in UTC (`created`, `updated`,
+`expires`). The playground is the presentation layer: it renders those in the viewer's local
+timezone, and converts local date-picker values back to Unix seconds when calling the API. Every
+conversion goes through this module so it stays explicit — no naive `datetime.fromtimestamp(...)`
+scattered per feature.
+
+`astimezone()` without an argument resolves the system timezone *for the instant being converted*,
+so the offset stays correct across DST boundaries.
+
+See `adr/2026-08-27-datetime-handling.md`.
+"""
+
+import datetime as dt
+
+DATE_FORMAT = "%Y-%m-%d"
+DATETIME_FORMAT = "%Y-%m-%d %H:%M"
+
+
+def local_now() -> dt.datetime:
+    """Current time, as an aware datetime in the local timezone."""
+    return dt.datetime.now(tz=dt.UTC).astimezone()
+
+
+def to_local_datetime(timestamp: int | float | None) -> dt.datetime | None:
+    """Convert a Unix timestamp (UTC seconds) to an aware datetime in the local timezone."""
+    if timestamp is None:
+        return None
+    return dt.datetime.fromtimestamp(timestamp=timestamp, tz=dt.UTC).astimezone()
+
+
+def format_datetime(timestamp: int | float | None, default: str = "") -> str:
+    """Render a Unix timestamp as a local `YYYY-MM-DD HH:MM` string, or `default` if it is None."""
+    local = to_local_datetime(timestamp)
+    return default if local is None else local.strftime(DATETIME_FORMAT)
+
+
+def format_date(timestamp: int | float | None, default: str = "") -> str:
+    """Render a Unix timestamp as a local `YYYY-MM-DD` string, or `default` if it is None."""
+    local = to_local_datetime(timestamp)
+    return default if local is None else local.strftime(DATE_FORMAT)
+
+
+def format_local_date(moment: dt.datetime) -> str:
+    """Render a datetime as a local `YYYY-MM-DD` string, for date pickers."""
+    return moment.astimezone().strftime(DATE_FORMAT)
+
+
+def date_to_timestamp(date: str) -> int:
+    """Convert a `YYYY-MM-DD` date picker value to Unix seconds, read as local midnight."""
+    return int(dt.datetime.strptime(date, DATE_FORMAT).astimezone().timestamp())


### PR DESCRIPTION
## Overview

Resolves #960.

Timestamps were represented differently depending on which file you opened: `keys.py` already did the right thing (accept `int`, convert to UTC `datetime`, convert back on the way out), but six other resources carried `int` timestamps in their domain entities, so the Postgres adapters had to flatten `timestamptz` columns to epoch seconds on read (`cast(func.extract("epoch", …), Integer)`) and re-inflate them on write (`func.to_timestamp(…)`). The playground re-implemented the same naive `datetime.fromtimestamp(...)` in each feature state.

This PR makes the `keys.py` pattern the rule, everywhere:

| Layer | Representation |
|---|---|
| HTTP request / response | Unix seconds, `int` |
| Use cases, domain entities, repository ports | timezone-aware UTC `datetime` |
| Postgres | `DateTime(timezone=True)` |
| Playground display | the viewer's local timezone |

**What changed**

- **`UtcDatetime`** added to `api/domain/__init__.py` — `Annotated[datetime, AfterValidator(_to_utc)]`, applied to `Role`, `Router`, `Provider`, `User`, `Model`, `Key`, `UsageRecord`, `AuthenticatedUserView`. An entity can no longer hold an ambiguous timestamp.
- **5 Postgres adapters** now select and write the `timestamptz` columns directly — 8 `extract(epoch)` / `to_timestamp()` conversions removed. `PostgresRolesRepository._row_to_role` is finally used by every one of its query methods, which resolves the `TODO` on `Role`.
- **6 clean-arch schemas** convert at the boundary: `@model_validator(mode="before")` on the way out, and `FutureTimestamp` (`AfterValidator`) turning the request `int` into a `datetime` on the way in.
- **Playground**: new `app/shared/utils/timestamps.py`; 8 feature states call it instead of inlining `fromtimestamp`. It uses bare `astimezone()`, which resolves the offset *for the instant being converted*, so it stays correct across DST.
- **ADR** `adr/2026-08-27-datetime-handling.md`, `adr/README.md` index (which was stale — it listed one ADR under a `001-` filename that no longer exists while five date-prefixed ones did), and a `## Domain` section in `AGENTS.md`.

**Definition of Done** — mirrors the acceptance criteria of #960:

- [x] `keys.py` remains the reference; the same validator pattern is applied to `roles.py`, `providers.py`, `models.py`, `routers.py`, `users.py` (and `me.py`)
- [x] Legacy schemas under `api/schemas/` aligned with the same boundary convention — they already exposed `int`; their naive `datetime.now()` defaults are now UTC-explicit
- [x] Domain entities use UTC `datetime` for `created` / `updated` / `expires`; repositories read and write `datetime`; the `TODO` on `Role` is resolved
- [x] API contract unchanged — verified field by field against the committed `docs/openapi.json`, see Additional Notes
- [x] The 8 playground states format timestamps in the local timezone through a shared helper
- [x] New date-prefixed ADR documents the convention; `adr/README.md` index updated
- [x] Unit and integration tests updated where datetime types changed; the timestamp contract is now asserted at the endpoint level, which it was not before

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

Every `created`, `updated` and `expires` field is still Unix seconds as `int`, in both directions. The change is internal to the layers behind the schemas.

## Check lists

### Review checklist

- [x] Updated or added documentation — the ADR, its index entry, and the `AGENTS.md` `## Domain` and `### Timestamps` sections
- [x] Updated or added unit tests — `test_utcdatetime.py`, `AuthenticatedUserView.has_expired`, factories switched to aware datetimes
- [x] Updated or added integration tests — endpoint timestamp assertions (roles, routers, providers, users, models, me, usage), an `expires` round-trip through `POST /v1/admin/users`, and a repository test persisting a `+02:00` value
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**`api/sql/models.py`** is untouched by this PR — the columns were already `DateTime(timezone=True)`. No Alembic migration is involved.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No deployment step is required.

## Additional Notes

**The API contract was verified, not assumed.** The OpenAPI schema generated from this branch was diffed against the committed `docs/openapi.json`: all 28 timestamp fields are `integer` before and after, byte-identical. The only delta is two `description` strings added to the legacy `Organization` schema. `docs/openapi.json` itself is not touched here — it is regenerated by the `Release updates` workflow.

**Timezone coverage.** The suite is green under `TZ=UTC`, `Europe/Paris` and `Asia/Tokyo`. A repository test now persists an `expires` carrying a `+02:00` offset and asserts the instant survives the round trip and comes back normalized to UTC.

**One genuine bug fixed along the way.** `Chunk.created` in `api/helpers/_searchtool.py` used `Field(default=datetime.now())`, evaluated once at import — every chunk inherited the process start time instead of its creation time. Now a `default_factory`.

**`Usage(created=datetime.now())` was *not* a data bug.** Worth stating explicitly so no one goes looking for shifted rows: asyncpg encodes a naive datetime using the Python process timezone, which is exactly what `datetime.now()` returns, so the two conversions cancel out. Measured at 0 s drift under `TZ=UTC`, `Europe/Paris`, `America/New_York` and `Asia/Tokyo`. The change to `datetime.now(tz=UTC)` is a consistency fix: the stored value no longer depends on the process timezone, and a `datetime.utcnow()` slipping in later would no longer be silently shifted.

**Slightly beyond the letter of #960**, flagged for review:
- `Organization` was the only domain entity declared as a `@dataclass`, so it validated nothing and could not carry `UtcDatetime`. It is now a `BaseModel` like the other 38 entity classes; `AGENTS.md` documents the rule.
- The `adr/README.md` index was corrected as a side effect of adding the new ADR to it.

**Known flaky test, pre-existing.** `test_log_multiple_metric[latency|ttft]` fails on roughly one full-suite run in three. Root cause: `log_metric` stamps samples at millisecond resolution with `duplicate_policy="LAST"`, so two samples in the same millisecond overwrite each other (measured: 112 losses over 300 runs). It reproduces on `main` and is unrelated to this PR — tracked in #1060, which also documents the production impact on `least_busy` routing.

**Follow-ups opened while working on this:** #1058 (response-schema mapper boilerplate), #1059 (domain importing legacy schema enums), #1060 (Redis sample collisions), #1061 (`RouterFactory` alias shape).
