### PR TITLE
refacto(admin): switch roles, routers and users update endpoints from PATCH to PUT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,18 @@ Do not reuse a `Create<Noun>Body` for an update: its optional fields carry the w
 
 Callers (playground `edit_entity`, e2e tests) must send the whole current form state, not a diff.
 
+**Because the body is a full replacement, the method is `PUT`** — `@router.put`, not `@router.patch`. `PATCH` describes a partial modification (RFC 9110 §9.3.1); a body that replaces every persisted field is a `PUT` (§9.3.4). The test is whether a client can `GET` the resource, change one field and `PUT` it back. Server metadata absent from the body (`id`, `created`, `updated`) and fields the client never sends (router `user_id`, user `sub` / `iss`) do not break that round trip. Applies to `/v1/admin/{roles,routers,users}/{id}`.
+
+`PATCH` stays only where the body genuinely cannot replace the resource:
+
+| Endpoint | Why it keeps `PATCH` |
+|---|---|
+| `/v1/admin/providers/{provider_id}` | `type`, `url`, `model_name` are set at creation but absent from `UpdateProviderBody`, so the body is not a representation of the resource |
+| `/v1/me` (and deprecated `/v1/me/info`) | partial by design — outside the full-replacement rule |
+| `/v1/admin/organizations/{id}` | legacy endpoint (`api/endpoints/`), not clean architecture |
+
+A new full-replacement update endpoint is a `PUT`. Converting an existing `PATCH` is a breaking change (old callers get `405`) — announce it, and switch the integration tests and the playground calls in the same commit.
+
 ### Timestamps
 
 - API: Unix seconds as `int` (`created`, `updated`, `expires`)
@@ -381,6 +393,7 @@ async def get_roles(
 
 - Auth: `AccessController` from `api.infrastructure.fastapi` (`only_admin=True` for admin routes, `allow_expired=True` when expired users must still reach the route, e.g. GET `/v1/me`)
 - Auth user: `authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user)` when only the user is needed. Keep `get_request_context` only when the full `RequestContext` is required.
+- Method: `GET` list / get-one, `POST` create, `PUT` update, `DELETE` delete — updates are `PUT` because the body is a full replacement (see [Update requests are full replacements](#update-requests-are-full-replacements))
 - Sort query params: `sort_by` / `sort_order`
 - Document errors: `responses=get_documentation_responses([...])`
 - `case RoleNotFoundError(id=role_id, name=name)` **captures** `None`; it does not require an id. Pass both through to the HTTP exception (which already has a generic `"Role not found."` fallback). Map the fields the use case actually returns (`id=` from FK failures, not `name=` unless that path exists).

--- a/api/infrastructure/fastapi/endpoints/admin/roles.py
+++ b/api/infrastructure/fastapi/endpoints/admin/roles.py
@@ -79,7 +79,7 @@ async def create_role(
             raise RoleAlreadyExistsHTTPException(name)
 
 
-@router.patch(
+@router.put(
     path=EndpointRoute.ADMIN_ROLES + "/{role_id}",
     dependencies=[Security(dependency=AccessController(only_admin=True))],
     status_code=200,

--- a/api/infrastructure/fastapi/endpoints/admin/routers.py
+++ b/api/infrastructure/fastapi/endpoints/admin/routers.py
@@ -192,7 +192,7 @@ async def delete_router(
             raise RouterNotFoundHTTPException(not_found_id)
 
 
-@router.patch(
+@router.put(
     path=EndpointRoute.ADMIN_ROUTERS + "/{router_id}",
     dependencies=[Security(dependency=AccessController(only_admin=True))],
     responses=get_documentation_responses(

--- a/api/infrastructure/fastapi/endpoints/admin/users.py
+++ b/api/infrastructure/fastapi/endpoints/admin/users.py
@@ -238,7 +238,7 @@ async def delete_user(
             assert_never(unreachable)
 
 
-@router.patch(
+@router.put(
     path=EndpointRoute.ADMIN_USERS + "/{user_id}",
     dependencies=[Security(dependency=AccessController(only_admin=True))],
     status_code=200,

--- a/api/tests/integration/endpoints/admin/roles/test_update_role.py
+++ b/api/tests/integration/endpoints/admin/roles/test_update_role.py
@@ -35,7 +35,7 @@ class TestUpdateRole:
         PermissionSQLFactory(role=role, permission=PermissionType.READ_METRIC)
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{role.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(
@@ -60,7 +60,7 @@ class TestUpdateRole:
         PermissionSQLFactory(role=role, permission=PermissionType.READ_METRIC)
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{role.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(permissions=[], limits=[]),
@@ -75,7 +75,7 @@ class TestUpdateRole:
         role = RoleSQLFactory()
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{role.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json={"name": "updated-role"},
@@ -103,7 +103,7 @@ class TestUpdateRole:
         mock_use_case.execute.return_value = use_case_result
         app.dependency_overrides[update_role_use_case_factory] = lambda: mock_use_case
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(),
@@ -116,7 +116,7 @@ class TestUpdateRole:
         regular_user = UserSQLFactory(regular_user=True)
         key = await create_key(db_session, name="regular_user_key", user=regular_user, never_expires=True)
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {key.token}"},
             json=_valid_body(),
@@ -134,7 +134,7 @@ class TestUpdateRole:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.patch(url=f"{URL}/1", headers=headers, json=_valid_body())
+        response = await client.put(url=f"{URL}/1", headers=headers, json=_valid_body())
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/endpoints/admin/router/test_update_router.py
+++ b/api/tests/integration/endpoints/admin/router/test_update_router.py
@@ -44,7 +44,7 @@ class TestUpdateRouter:
         router = RouterSQLFactory(user=self.admin_user, name="original-name")
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{router.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(aliases=["alias-1"], cost_prompt_tokens=0.5, cost_completion_tokens=1.5),
@@ -65,7 +65,7 @@ class TestUpdateRouter:
         router = RouterSQLFactory(user=self.admin_user, alias=["alias-1"])
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{router.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(aliases=[]),
@@ -78,7 +78,7 @@ class TestUpdateRouter:
         router = RouterSQLFactory(user=self.admin_user)
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{router.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json={"name": "updated-name"},
@@ -111,7 +111,7 @@ class TestUpdateRouter:
         mock_use_case.execute.return_value = use_case_result
         app.dependency_overrides[update_router_use_case_factory] = lambda: mock_use_case
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(),
@@ -124,7 +124,7 @@ class TestUpdateRouter:
         regular_user = UserSQLFactory(regular_user=True)
         key = await create_key(db_session, name="regular_user_key", user=regular_user, never_expires=True)
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {key.token}"},
             json=_valid_body(),
@@ -142,7 +142,7 @@ class TestUpdateRouter:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.patch(url=f"{URL}/1", headers=headers, json=_valid_body())
+        response = await client.put(url=f"{URL}/1", headers=headers, json=_valid_body())
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/endpoints/admin/users/test_update_user.py
+++ b/api/tests/integration/endpoints/admin/users/test_update_user.py
@@ -41,7 +41,7 @@ class TestUpdateUser:
         user = UserSQLFactory()
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(role_id=user.role_id, budget=50.5, priority=2),
@@ -61,7 +61,7 @@ class TestUpdateUser:
         user = UserSQLFactory(organization=organization, budget=100.0, expires=dt.datetime.now() + dt.timedelta(days=30))
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(role_id=user.role_id, name=None, organization_id=None, budget=None, expires=None),
@@ -79,7 +79,7 @@ class TestUpdateUser:
         await db_session.flush()
         expires = int((dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=5)).timestamp())
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(role_id=user.role_id, expires=expires),
@@ -93,7 +93,7 @@ class TestUpdateUser:
         current_password = user.password
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(role_id=user.role_id),
@@ -114,7 +114,7 @@ class TestUpdateUser:
         user = UserSQLFactory()
         await db_session.flush()
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/{user.id}",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=body,
@@ -157,7 +157,7 @@ class TestUpdateUser:
         mock_use_case.execute.return_value = use_case_result
         app.dependency_overrides[update_user_use_case_factory] = lambda: mock_use_case
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {self.key.token}"},
             json=_valid_body(),
@@ -170,7 +170,7 @@ class TestUpdateUser:
         regular_user = UserSQLFactory(regular_user=True)
         key = await create_key(db_session, name="regular_user_key", user=regular_user, never_expires=True)
 
-        response = await client.patch(
+        response = await client.put(
             url=f"{URL}/1",
             headers={"Authorization": f"Bearer {key.token}"},
             json=_valid_body(),
@@ -188,7 +188,7 @@ class TestUpdateUser:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.patch(url=f"{URL}/1", headers=headers, json=_valid_body())
+        response = await client.put(url=f"{URL}/1", headers=headers, json=_valid_body())
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/docs/src/content/docs/features/usage/budget.mdx
+++ b/docs/src/content/docs/features/usage/budget.mdx
@@ -75,7 +75,7 @@ By default, there value are set to 0, this means that the model requests are fre
 
 Each user has a budget defined by create user endpoint or update user endpoint. The budget is defined in the `budget` field. You need has `admin` permission to create or update a user.
 
-See POST and PATCH /v1/admin/users endpoints for more information on [API reference](/reference/).
+See POST and PUT /v1/admin/users endpoints for more information on [API reference](/reference/).
 
 ## Budget monitoring
 

--- a/playground/app/features/roles/state.py
+++ b/playground/app/features/roles/state.py
@@ -204,7 +204,7 @@ class RolesState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.patch(
+                response = await client.put(
                     url=f"{self.opengatellm_url}/v1/admin/roles/{role.id}",
                     json=payload,
                     headers={"Authorization": f"Bearer {self.api_key}"},
@@ -312,7 +312,7 @@ class RolesState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.patch(
+                response = await client.put(
                     f"{self.opengatellm_url}/v1/admin/roles/{role.id}",
                     json=payload,
                     headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
@@ -390,7 +390,7 @@ class RolesState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.patch(
+                response = await client.put(
                     url=f"{self.opengatellm_url}/v1/admin/roles/{self.entity.id}",
                     json=payload,
                     headers={"Authorization": f"Bearer {self.api_key}"},

--- a/playground/app/features/routers/state.py
+++ b/playground/app/features/routers/state.py
@@ -277,7 +277,7 @@ class RoutersState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.patch(
+                response = await client.put(
                     url=f"{self.opengatellm_url}/v1/admin/routers/{self.entity.id}",
                     json=payload,
                     headers={"Authorization": f"Bearer {self.api_key}"},

--- a/playground/app/features/users/state.py
+++ b/playground/app/features/users/state.py
@@ -332,7 +332,7 @@ class UsersState(EntityState):
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.patch(
+                response = await client.put(
                     url=f"{self.opengatellm_url}/v1/admin/users/{self.entity.id}",
                     json=payload,
                     headers={"Authorization": f"Bearer {self.api_key}"},


### PR DESCRIPTION
## Overview

Resolves #1036.

#919 turned the migrated admin update endpoints into **full-payload** operations: every persisted field must be sent, and `null` sets a field to `null` instead of meaning "skip". That is replacement semantics, which is what `PUT` describes — `PATCH` is for partial modification (the MDN page linked in the issue).

The RFC 9110 §9.3.4 test is whether a client can `GET` a resource, change a field and `PUT` it back. Applied endpoint by endpoint:

| Endpoint | Resource fields absent from the update body | Converted? |
|---|---|---|
| `roles/{role_id}` | `id`, `created`, `updated`, `users` — all server-controlled | **yes** |
| `routers/{router_id}` | same + `user_id` (owner, set at creation) | **yes** |
| `users/{user_id}` | same + `sub`, `iss` (managed by the SSO flow) | **yes** |
| `providers/{provider_id}` | same + **`type`, `url`, `model_name`** — client-supplied at creation | **no, stays `PATCH`** |

`id` / `created` / `updated` are server metadata and are legitimately absent from a `PUT` body. `providers` is different: `type`, `url` and `model_name` are in `CreateProviderBody` but not in `UpdateProviderBody`, so its body is not a representation of the resource and `PUT` would be inaccurate. It keeps `PATCH` deliberately — see Additional Notes.

**What changed**

- `@router.patch` → `@router.put` on `admin/roles.py`, `admin/routers.py`, `admin/users.py`. No handler logic, schema or use case is touched.
- 20 integration test calls switched to `client.put`.
- 5 playground calls switched to `client.put` (3 in `roles/state.py` — limit creation, limit update, role edit — plus one each in `routers` and `users`).
- `docs/features/usage/budget.mdx` referenced "POST and PATCH /v1/admin/users".

**Out of scope, unchanged**

`PATCH /v1/me` (its body is not a full user representation and was never in #919's scope), `PATCH /v1/me/info` (deprecated alias) and `PATCH /v1/admin/organizations/{id}` (legacy endpoint).

**Definition of Done**

#1036 carries no acceptance criteria — it is a one-line issue pointing at the MDN `PATCH` page — so these are derived from that intent and from the RFC check above:

- [x] Update endpoints whose body is a complete representation use `PUT`
- [x] Endpoints whose body is partial keep `PATCH`, with the reason recorded
- [x] Method semantics verified against RFC 9110 §9.3.4, not just the MDN summary
- [x] Idempotency (§9.2.2) holds: the use cases apply a full replacement, and the password branch returns before any write
- [x] Clients of the API — tests and playground — updated in the same change
- [x] Documentation reference updated
- [x] No behaviour change beyond the method: handlers, schemas and use cases are untouched

**Breaking changes:**

- [ ] No breaking changes
- [x] This PR contains breaking changes (explain below)

`PATCH /v1/admin/{roles,routers,users}/{id}` now returns **405 Method Not Allowed**. Clients must switch to `PUT`; the request body and the responses are unchanged. This follows the #919 break (required fields) on the same endpoints — the two are best announced together in the release notes.

## Check lists

### Review checklist

- [x] Updated or added documentation — `docs/features/usage/budget.mdx`
- [ ] Updated or added unit tests — *N/A: no unit-testable behaviour changed; the HTTP method is exercised at the integration layer*
- [x] Updated or added integration tests — the 20 update-endpoint calls now use `PUT`
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**`api/sql/models.py`** is untouched. No Alembic migration is involved.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No deployment step is required, but the breaking change must reach API consumers before rollout.

## Additional Notes

**Why `providers` is inconsistent on purpose.** Leaving one admin update endpoint on `PATCH` makes the API heterogeneous, which is a real cost. The alternative — converting it too — would advertise `PUT` on a body that cannot replace the resource, so a `GET` → `PUT` round trip would fail. Making it a genuine `PUT` means adding `type` / `url` / `model_name` to `UpdateProviderBody`, which pulls in `Provider.with_*` helpers, the `update_provider` values clause and the `unique_provider_router_id_url_model_name` constraint. That is a separate piece of work, not a rename.

**The 405 response advertises the wrong methods.** `PATCH /v1/admin/users/1` now answers `405` with `Allow: GET`, while `PUT` and `DELETE` are both available. This is a pre-existing, API-wide defect — 17 of the 18 multi-method paths are affected, including `providers/{provider_id}` which this PR does not touch — caused by FastAPI registering one route object per decorator while Starlette scopes `Allow` to the route it matched. Tracked in **#1064**. It is worth noting here because this PR makes `PATCH` the most likely wrong-method call from existing clients, so they will hit the misleading header on the main path.

**Verification.** 1287 tests pass; `pre-commit` passes on the 10 changed files. The generated OpenAPI confirms the split:

```
PUT    /v1/admin/roles/{role_id}
PUT    /v1/admin/routers/{router_id}
PUT    /v1/admin/users/{user_id}
PATCH  /v1/admin/providers/{provider_id}
PATCH  /v1/me   ·   PATCH /v1/me/info   ·   PATCH /v1/admin/organizations/{id}
```

**Known flaky test, unrelated.** `test_log_multiple_metric[latency|ttft]` fails on roughly one run in three, on `main` as well. Root cause and measurements in #1060.
