### PR TITLE
test(postgres): lock the updated column onupdate behaviour

### DIFF
--- a/api/tests/unit/infrastructure/postgres/test_updated_column_onupdate.py
+++ b/api/tests/unit/infrastructure/postgres/test_updated_column_onupdate.py
@@ -1,0 +1,67 @@
+"""`updated` must be bumped by every Core UPDATE.
+
+The columns rely on `onupdate=func.now()` (`api/sql/models.py`) rather than on each
+repository spelling `updated=func.now()` in its `.values()`. That works — SQLAlchemy
+injects the column default into the SET clause of any `update()` construct — but
+nothing pinned it, so removing `onupdate`, or issuing a raw `text()` UPDATE, would
+silently leave `updated` equal to `created`.
+
+These tests assert on the compiled statement rather than on a round trip: Postgres
+`now()` is transaction-scoped, so a create and an update executed inside a single
+transaction — which is what the integration harness does, see
+`adr/2026-03-17-integration-test-isolation.md` — always share the same timestamp.
+A round-trip assertion would fail for that reason alone, whatever the code does.
+"""
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.dialects import postgresql
+
+from api.sql.models import Organization, Provider, Role, Router, User
+
+
+def _set_clause(statement) -> str:
+    compiled = str(statement.compile(dialect=postgresql.dialect()))
+    return compiled.split("SET", 1)[1].split("WHERE", 1)[0]
+
+
+class TestUpdatedColumnIsBumpedByCoreUpdate:
+    @pytest.mark.parametrize(
+        "table,values",
+        [
+            (Role, {"name": "x"}),
+            (User, {"email": "x@y.z"}),
+            (Router, {"name": "x"}),
+            (Provider, {"timeout": 60}),
+            (Organization, {"name": "x"}),
+        ],
+        ids=["role", "user", "router", "provider", "organization"],
+    )
+    def test_should_set_updated_on_every_core_update(self, table, values):
+        # Act
+        clause = _set_clause(update(table).values(**values))
+
+        # Assert
+        assert "updated=now()" in clause.replace(" ", ""), f"UPDATE {table.__tablename__} does not bump `updated`: SET{clause}"
+
+    @pytest.mark.parametrize(
+        "table",
+        [Role, User, Router, Provider, Organization],
+        ids=["role", "user", "router", "provider", "organization"],
+    )
+    def test_should_declare_onupdate_on_the_updated_column(self, table):
+        # Act
+        column = table.__table__.c["updated"]
+
+        # Assert
+        assert column.onupdate is not None, f"{table.__tablename__}.updated lost its onupdate default"
+
+    def test_should_not_touch_updated_when_the_statement_sets_it_explicitly(self):
+        # Arrange — the budget deduction in the request hooks sets `updated` itself
+        from sqlalchemy import func
+
+        # Act
+        clause = _set_clause(update(User).values(budget=1.0, updated=func.now()))
+
+        # Assert — a single assignment, not a duplicated one
+        assert clause.count("updated=") == 1


### PR DESCRIPTION
## Overview

Follow-up to #877, which was **closed as not planned**: the reported bug does not exist. `onupdate=func.now()` is a column default that SQLAlchemy injects into the SET clause of any Core `update()`, so all four adapters already bump `updated`. Verified on compiled SQL, end to end against a real database with a commit between create and update, manually through the playground, and by applying the issue's own suggested fix and observing no change.

One point from that issue was legitimate: **nothing pinned the behaviour**. Removing `onupdate` from a column, or introducing a raw `text()` UPDATE, would silently leave `updated` equal to `created` with no test to catch it. This PR adds that missing coverage. No production code changes.

`api/tests/unit/infrastructure/postgres/test_updated_column_onupdate.py` — 11 cases over the 5 tables carrying `updated` (`Role`, `User`, `Router`, `Provider`, `Organization`):

- the compiled `UPDATE` emits `updated=now()`
- the column still declares `onupdate`
- a statement that sets `updated` itself — the budget deduction in the request hooks — produces a single assignment, not a duplicated one

**Definition of Done:**

- [x] The behaviour asserted in #877 is locked by a test
- [x] All five tables carrying `updated` are covered, not only the four adapters named in the issue
- [x] The test is falsifiable — removing `onupdate` from `Role.updated` fails two cases immediately
- [x] The reason the assertion is made on compiled SQL rather than a round trip is documented in the module docstring
- [x] No production code touched

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation — *N/A: the rationale lives in the test module docstring; no user-facing behaviour changed*
- [x] Updated or added unit tests — this PR is the test
- [ ] Updated or added integration tests — *N/A: see Additional Notes, a round-trip assertion cannot work here*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**`api/sql/models.py`** is untouched. No Alembic migration is involved.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No deployment step is required.

## Additional Notes

**Why the assertion is on compiled SQL and not on a round trip.** The obvious integration test — update a row, assert `updated > created` — fails, and not because of the product:

```
assert 1787930233 > 1787930233
```

Postgres `now()` is **transaction-scoped**; only `clock_timestamp()` advances within a transaction. Integration tests wrap each case in a single transaction that is rolled back at the end (`adr/2026-03-17-integration-test-isolation.md`), so the factory INSERT and the endpoint UPDATE share the same `now()` and land on identical timestamps. In production the two operations are separate HTTP requests, therefore separate transactions, and the values differ.

The same property is why the fix proposed in #877 is a no-op: inside one transaction, `func.now()` returns exactly the value `onupdate` had already written. Asserting on the compiled statement sidesteps the whole problem and is deterministic.
