### PR TITLE
refacto(postgres): delete providers in one query and test delete_all_routers

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.68%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.71%", "color": "green"}

--- a/api/infrastructure/postgres/_postgresproviderrepository.py
+++ b/api/infrastructure/postgres/_postgresproviderrepository.py
@@ -147,13 +147,11 @@ class PostgresProviderRepository(ProviderRepository):
 
     @with_lock(namespace="provider", key="provider_id")
     async def delete_provider(self, provider_id: int) -> Provider | ProviderNotFoundError:
-        select_query = select(ProviderTable).where(ProviderTable.id == provider_id)
-        result = await self.postgres_session.execute(select_query)
+        result = await self.postgres_session.execute(delete(ProviderTable).where(ProviderTable.id == provider_id).returning(ProviderTable))
         row = result.scalar_one_or_none()
         if row is None:
             return ProviderNotFoundError(id=provider_id)
-        delete_query = delete(ProviderTable).where(ProviderTable.id == provider_id)
-        await self.postgres_session.execute(delete_query)
+
         return self._row_to_provider(row)
 
     async def get_all_providers(self) -> list[Provider]:

--- a/api/infrastructure/postgres/_postgresrouterrepository.py
+++ b/api/infrastructure/postgres/_postgresrouterrepository.py
@@ -184,10 +184,13 @@ class PostgresRouterRepository(RouterRepository):
 
     @with_lock(namespace="router", key="router_id")
     async def delete_router(self, router_id: int) -> Router | RouterNotFoundError:
+        # retrieve the router first to return aliases, permissions and limits
         router = await self.get_router_by_id(router_id)
         if isinstance(router, RouterNotFoundError):
             return RouterNotFoundError(id=router_id)
+
         await self.postgres_session.execute(delete(RouterTable).where(RouterTable.id == router_id))
+
         return router
 
     async def delete_all_routers(self) -> list[Router]:

--- a/api/tests/integration/postgres/test_postgresrouterrepository.py
+++ b/api/tests/integration/postgres/test_postgresrouterrepository.py
@@ -482,6 +482,49 @@ class TestDeleteRouter:
 
 
 @pytest.mark.asyncio(loop_scope="session")
+class TestDeleteAllRouters:
+    async def test_delete_all_routers_should_return_the_deleted_routers(self, repository, db_session):
+        # Arrange
+        user = UserSQLFactory()
+        router_1 = RouterSQLFactory(user=user, name="router_1", alias=["alias1"], providers=1)
+        router_2 = RouterSQLFactory(user=user, name="router_2", alias=["alias2"], providers=2)
+        await db_session.flush()
+
+        # Act
+        result = await repository.delete_all_routers()
+
+        # Assert
+        assert len(result) == 2
+        result_by_name = {router.name: router for router in result}
+        assert result_by_name["router_1"].id == router_1.id
+        assert result_by_name["router_1"].aliases == ["alias1"]
+        assert result_by_name["router_1"].providers == 1
+        assert result_by_name["router_2"].id == router_2.id
+        assert result_by_name["router_2"].aliases == ["alias2"]
+        assert result_by_name["router_2"].providers == 2
+
+    async def test_delete_all_routers_should_delete_cascade_router_aliases_and_providers_from_database(self, repository, db_session):
+        # Arrange
+        user = UserSQLFactory()
+        router_1 = RouterSQLFactory(user=user, name="router_1", alias=["alias1"], providers=2)
+        router_2 = RouterSQLFactory(user=user, name="router_2", alias=["alias2"], providers=1)
+        await db_session.flush()
+        router_ids = [router_1.id, router_2.id]
+
+        # Act
+        await repository.delete_all_routers()
+
+        # Assert
+        await db_session.flush()
+        routers_after_delete = (await db_session.execute(select(RouterTable).where(RouterTable.id.in_(router_ids)))).scalars().all()
+        aliases = (await db_session.execute(select(RouterAliasTable).where(RouterAliasTable.router_id.in_(router_ids)))).scalars().all()
+        providers = (await db_session.execute(select(ProviderTable).where(ProviderTable.router_id.in_(router_ids)))).scalars().all()
+        assert routers_after_delete == []
+        assert aliases == []
+        assert providers == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
 class TestUpdateRouter:
     async def test_update_router_should_return_router_with_updated_name(self, repository, db_session):
         # Arrange


### PR DESCRIPTION
## Overview

Resolves [#876](https://github.com/etalab-ia/OpenGateLLM/issues/876): avoid a SELECT-then-DELETE for providers, and document why routers cannot follow the same pattern.

- `delete_provider` now uses a single `DELETE … RETURNING` (all fields live on `provider`, same as roles).
- `delete_router` still loads the router first so aliases and provider counts can be returned before `ON DELETE CASCADE`.
- Adds Postgres integration tests for `delete_all_routers` (returned snapshot + cascade).

**Definition of Done:**

- [x] Provider delete is a single SQL statement
- [x] Router delete still returns aliases / providers after delete
- [x] `delete_all_routers` is covered by repository integration tests

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [ ] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

For each of the following items, please confirm if the PR concerns the deployment of the changes:

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

## Additional Notes

Router delete cannot collapse to `DELETE … RETURNING`: related aliases and provider counts are cascade-deleted in the same statement, so they would come back empty. `delete_all_routers` keeps the SELECT first for the same reason (bootstrap does not use the return value, but the repository contract still returns the snapshot).

Made with [Cursor](https://cursor.com)