### PR TITLE
refacto(pydantic): adopt pydantic v3 annotated syntax in all basemodel classes

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.71%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.72%", "color": "green"}

--- a/api/domain/audio/entities.py
+++ b/api/domain/audio/entities.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import Field
 
@@ -29,19 +29,19 @@ class AudioTranscriptionsResponseFormat(StrEnum):
 
 
 class Segment(BaseModel):
-    id: int = Field(default=..., description="A unique identifier for the segment.")
-    type: str = Field(default="transcript.text.segment", description="The type of the segment.")
-    text: str = Field(default=..., description="The segment text.")
-    start: float = Field(default=..., description="Start time of the segment in seconds.")
-    end: float = Field(default=..., description="End time of the segment in seconds.")
-    speaker: str | None = Field(default=None, description="Speaker label assigned by diarization, if available.")
+    id: Annotated[int, Field(default=..., description="A unique identifier for the segment.")]
+    type: Annotated[str, Field(default="transcript.text.segment", description="The type of the segment.")]
+    text: Annotated[str, Field(default=..., description="The segment text.")]
+    start: Annotated[float, Field(default=..., description="Start time of the segment in seconds.")]
+    end: Annotated[float, Field(default=..., description="End time of the segment in seconds.")]
+    speaker: Annotated[str | None, Field(default=None, description="Speaker label assigned by diarization, if available.")]
 
 
 class AudioTranscriptions(ModelJsonResponse):
     id: str
     model: str
     text: str
-    usage: Usage = Field(default_factory=Usage)
+    usage: Annotated[Usage, Field(default_factory=Usage)]
 
     def get_completions(self) -> list[str]:
         return [self.text]

--- a/api/domain/chat/entities.py
+++ b/api/domain/chat/entities.py
@@ -1,6 +1,6 @@
 import json
 from json import JSONDecodeError
-from typing import Literal
+from typing import Annotated, Literal
 
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from pydantic import Field
@@ -9,8 +9,8 @@ from api.domain.usage.entities import Usage
 
 
 class ChatCompletion(ChatCompletion):
-    id: str = Field(default=None, description="A unique identifier for the chat completion.")
-    usage: Usage = Field(default_factory=Usage, description="Usage information for the request.")
+    id: Annotated[str, Field(default=None, description="A unique identifier for the chat completion.")]
+    usage: Annotated[Usage, Field(default_factory=Usage, description="Usage information for the request.")]
 
     @staticmethod
     def extract_response_content(response: dict) -> str:

--- a/api/domain/embeddings/entities.py
+++ b/api/domain/embeddings/entities.py
@@ -1,7 +1,7 @@
 import array
 import base64
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from openai.types import CreateEmbeddingResponse
 from openai.types.chat import ChatCompletionContentPartParam
@@ -55,7 +55,7 @@ class Embeddings(CreateEmbeddingResponse, ModelJsonResponse):
     object: Literal["list"] = "list"
     id: str
     model: str
-    usage: Usage = Field(default_factory=Usage)
+    usage: Annotated[Usage, Field(default_factory=Usage)]
 
     @classmethod
     def _from_provider_response(

--- a/api/domain/model/views.py
+++ b/api/domain/model/views.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from pydantic import ConfigDict, Field
 
 from api.domain import BaseModel, UtcDatetime
@@ -16,4 +18,4 @@ class ModelView(BaseModel):
     created: UtcDatetime
     owned_by: str
     max_context_length: int | None = None
-    costs: ModelCosts = Field(default_factory=ModelCosts)
+    costs: Annotated[ModelCosts, Field(default_factory=ModelCosts)]

--- a/api/domain/ocr/entities.py
+++ b/api/domain/ocr/entities.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
@@ -86,7 +86,7 @@ class OCR(ModelJsonResponse):
     model: str
     document_annotation: str | None = None
     pages: list[OCRPageObject]
-    usage: Usage = Field(default_factory=Usage)
+    usage: Annotated[Usage, Field(default_factory=Usage)]
     usage_info: OCRUsage | None = None
 
     def get_completions(self) -> list[str]:

--- a/api/domain/rerank/entities.py
+++ b/api/domain/rerank/entities.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from pydantic import Field
 
 from api.domain import BaseModel, ForwardablePayload
@@ -24,7 +26,7 @@ class Rerank(ModelJsonResponse):
     id: str
     model: str
     results: list[RerankResult]
-    usage: Usage = Field(default_factory=Usage)
+    usage: Annotated[Usage, Field(default_factory=Usage)]
 
     def get_completions(self) -> list[str]:
         return []

--- a/api/domain/role/entities.py
+++ b/api/domain/role/entities.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Annotated
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -20,9 +21,9 @@ class LimitType(StrEnum):
 
 
 class Limit(BaseModel):
-    router_id: int = Field(description="The router ID.")
-    type: LimitType = Field(description="The limit type.")
-    value: int | None = Field(default=None, ge=0, description="The limit value.")
+    router_id: Annotated[int, Field(description="The router ID.")]
+    type: Annotated[LimitType, Field(description="The limit type.")]
+    value: Annotated[int | None, Field(default=None, ge=0, description="The limit value.")]
 
 
 class Role(BaseModel):
@@ -31,8 +32,8 @@ class Role(BaseModel):
     permissions: list[PermissionType]
     limits: list[Limit]
     users: int = 0
-    created: UtcDatetime = Field(default_factory=lambda: datetime.now(tz=UTC))
-    updated: UtcDatetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    created: Annotated[UtcDatetime, Field(default_factory=lambda: datetime.now(tz=UTC))]
+    updated: Annotated[UtcDatetime, Field(default_factory=lambda: datetime.now(tz=UTC))]
 
     @field_validator("permissions")
     @classmethod

--- a/api/domain/router/entities.py
+++ b/api/domain/router/entities.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -81,10 +82,10 @@ class RpdRateLimitState(BaseModel):
 
 
 class RouterRateLimitState(BaseModel):
-    tpm: TpmRateLimitState = Field(default_factory=TpmRateLimitState)
-    tpd: TpdRateLimitState = Field(default_factory=TpdRateLimitState)
-    rpm: RpmRateLimitState = Field(default_factory=RpmRateLimitState)
-    rpd: RpdRateLimitState = Field(default_factory=RpdRateLimitState)
+    tpm: Annotated[TpmRateLimitState, Field(default_factory=TpmRateLimitState)]
+    tpd: Annotated[TpdRateLimitState, Field(default_factory=TpdRateLimitState)]
+    rpm: Annotated[RpmRateLimitState, Field(default_factory=RpmRateLimitState)]
+    rpd: Annotated[RpdRateLimitState, Field(default_factory=RpdRateLimitState)]
 
     @property
     def exceeded_limits(self) -> list[LimitType]:

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -10,8 +10,8 @@ from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
 class CreateUserBody(BaseModel):
     email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The user email.")]
-    name: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None, Field(default=None, description="The user name.")]
-    password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)], Field(description="The user password.")]  # fmt: off
+    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1), Field(default=None, description="The user name.")]
+    password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(description="The user password.")]  # fmt: off
     role_id: Annotated[int, Field(..., description="The role ID.")]
     organization_id: Annotated[int | None, Field(default=None, description="The organization ID.")]
     budget: Annotated[float | None, Field(default=None, description="The budget.")]
@@ -74,9 +74,9 @@ class UsersResponse(BaseModel):
 
 class UserUpdateRequest(BaseModel):
     email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The new user email.")]
-    name: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None, Field(..., description="The new user name. If null, the user name is removed.")]  # fmt: off
-    current_password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None, Field(default=None, description="The current user password. Only required to change the password.")]  # fmt: off
-    password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None, Field(default=None, description="The new user password. If omitted, the user password is not changed.")]  # fmt: off
+    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1), Field(..., description="The new user name. If null, the user name is removed.")]  # fmt: off
+    current_password: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(default=None, description="The current user password. Only required to change the password.")]  # fmt: off
+    password: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(default=None, description="The new user password. If omitted, the user password is not changed.")]  # fmt: off
     role_id: Annotated[int, Field(..., description="The new role ID.")]
     organization_id: Annotated[int | None, Field(..., description="The new organization ID. If null, the user is removed from the organization if he was in one.")]  # fmt: off
     budget: Annotated[float | None, Field(..., description="The new budget. If null, the user will have no budget.")]

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -10,13 +10,13 @@ from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
 class CreateUserBody(BaseModel):
     email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The user email.")]
-    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None = Field(default=None, description="The user name.")
+    name: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None, Field(default=None, description="The user name.")]
     password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)], Field(description="The user password.")]  # fmt: off
-    role_id: int = Field(..., description="The role ID.")
-    organization_id: int | None = Field(default=None, description="The organization ID.")
-    budget: float | None = Field(default=None, description="The budget.")
-    expires: int | None = Field(default=None, description="The expiration timestamp.")
-    priority: int = Field(default=0, ge=0, description="The user priority. Higher value means higher priority.")
+    role_id: Annotated[int, Field(..., description="The role ID.")]
+    organization_id: Annotated[int | None, Field(default=None, description="The organization ID.")]
+    budget: Annotated[float | None, Field(default=None, description="The budget.")]
+    expires: Annotated[int | None, Field(default=None, description="The expiration timestamp.")]
+    priority: Annotated[int, Field(default=0, ge=0, description="The user priority. Higher value means higher priority.")]
 
     @field_validator("expires", mode="after")
     def convert_expires_to_datetime(cls, expires) -> None | datetime:
@@ -74,14 +74,14 @@ class UsersResponse(BaseModel):
 
 class UserUpdateRequest(BaseModel):
     email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The new user email.")]
-    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None = Field(..., description="The new user name. If null, the user name is removed.")  # fmt: off
-    current_password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The current user password. Only required to change the password.")  # fmt: off
-    password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The new user password. If omitted, the user password is not changed.")  # fmt: off
-    role_id: int = Field(..., description="The new role ID.")  # fmt: off
-    organization_id: int | None = Field(..., description="The new organization ID. If null, the user is removed from the organization if he was in one.")  # fmt: off
-    budget: float | None = Field(..., description="The new budget. If null, the user will have no budget.")  # fmt: off
-    expires: int | None = Field(..., description="The new expiration timestamp. If null, the user will never expire.")  # fmt: off
-    priority: int = Field(..., ge=0, description="The new user priority. Higher value means higher priority.")  # fmt: off
+    name: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None, Field(..., description="The new user name. If null, the user name is removed.")]  # fmt: off
+    current_password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None, Field(default=None, description="The current user password. Only required to change the password.")]  # fmt: off
+    password: Annotated[Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None, Field(default=None, description="The new user password. If omitted, the user password is not changed.")]  # fmt: off
+    role_id: Annotated[int, Field(..., description="The new role ID.")]
+    organization_id: Annotated[int | None, Field(..., description="The new organization ID. If null, the user is removed from the organization if he was in one.")]  # fmt: off
+    budget: Annotated[float | None, Field(..., description="The new budget. If null, the user will have no budget.")]
+    expires: Annotated[int | None, Field(..., description="The new expiration timestamp. If null, the user will never expire.")]
+    priority: Annotated[int, Field(..., ge=0, description="The new user priority. Higher value means higher priority.")]
 
     @field_validator("expires", mode="after")
     def convert_expires_to_datetime(cls, expires) -> None | datetime:

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -73,7 +73,7 @@ class UsersResponse(BaseModel):
 
 
 class UserUpdateRequest(BaseModel):
-    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254)] = Field(..., description="The new user email.")  # fmt: off
+    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The new user email.")]
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | None = Field(..., description="The new user name. If null, the user name is removed.")  # fmt: off
     current_password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The current user password. Only required to change the password.")  # fmt: off
     password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)] | None = Field(default=None, description="The new user password. If omitted, the user password is not changed.")  # fmt: off

--- a/api/infrastructure/fastapi/schemas/audio.py
+++ b/api/infrastructure/fastapi/schemas/audio.py
@@ -30,20 +30,20 @@ PLAIN_TEXT_SUBTITLE_FORMATS = {
 
 
 class Segment(BaseModel):
-    id: Annotated[int, Field(default=..., description="A unique identifier for the segment.")] = Field(default=..., description="A unique identifier for the segment.")  # fmt: off
-    type: Annotated[str, Field(default="transcript.text.segment", description="The type of the segment.")] = Field(default="transcript.text.segment", description="The type of the segment.")  # fmt: off
-    text: Annotated[str, Field(default=..., description="The segment text.")] = Field(default=..., description="The segment text.")
-    start: Annotated[float, Field(default=..., description="Start time of the segment in seconds.")] = Field(default=..., description="Start time of the segment in seconds.")  # fmt: off
-    end: Annotated[float, Field(default=..., description="End time of the segment in seconds.")] = Field(default=..., description="End time of the segment in seconds.")  # fmt: off
-    speaker: Annotated[str | None, Field(default=None, description="Speaker label assigned by diarization, if available.")] = Field(default=None, description="Speaker label assigned by diarization, if available.")  # fmt: off
+    id: Annotated[int, Field(default=..., description="A unique identifier for the segment.")]
+    type: Annotated[str, Field(default="transcript.text.segment", description="The type of the segment.")]
+    text: Annotated[str, Field(default=..., description="The segment text.")]
+    start: Annotated[float, Field(default=..., description="Start time of the segment in seconds.")]
+    end: Annotated[float, Field(default=..., description="End time of the segment in seconds.")]
+    speaker: Annotated[str | None, Field(default=None, description="Speaker label assigned by diarization, if available.")]
 
 
 class AudioTranscriptionsResponse(BaseModel):
-    id: Annotated[str, Field(default=..., description="A unique identifier for the audio transcription.")] = Field(default=..., description="A unique identifier for the audio transcription.")  # fmt: off
-    text: Annotated[str, Field(default=..., description="The transcription text.")] = Field(default=..., description="The transcription text.")
-    model: Annotated[str, Field(default=..., description="The model used to generate the transcription.")] = Field(default=..., description="The model used to generate the transcription.")  # fmt: off
-    segments: Annotated[list[Segment] | None, Field(default=None, description="Diarized segments, only set when `response_format=diarized_json`.")] = Field(default=None, description="Diarized segments, only set when `response_format=diarized_json`.")  # fmt: off
-    usage: Annotated[Usage, Field(default_factory=Usage, description="Usage information for the request.")] = Field(default_factory=Usage, description="Usage information for the request.")  # fmt: off
+    id: Annotated[str, Field(default=..., description="A unique identifier for the audio transcription.")]
+    text: Annotated[str, Field(default=..., description="The transcription text.")]
+    model: Annotated[str, Field(default=..., description="The model used to generate the transcription.")]
+    segments: Annotated[list[Segment] | None, Field(default=None, description="Diarized segments, only set when `response_format=diarized_json`.")]
+    usage: Annotated[Usage, Field(default_factory=Usage, description="Usage information for the request.")]
 
 
 class CreateAudioTranscriptionsForm(BaseModel):

--- a/api/infrastructure/fastapi/schemas/embeddings.py
+++ b/api/infrastructure/fastapi/schemas/embeddings.py
@@ -22,7 +22,7 @@ class EmbeddingMessage(BaseModel):
 
 class CreateEmbeddingsBody(BaseModel):
     model: Annotated[str, StringConstraints(min_length=1), Field(default=..., description="ID of the model to use. Call `/v1/models` endpoint to get the list of available models, only `text-embeddings-inference` model type is supported.")]  # fmt: off
-    input: Annotated[list[int] | list[Annotated[list[int], Field(min_length=1)]] | str | list[str], Field(min_length=1)] | None = Field(default=None, description="Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (call `/v1/models` endpoint to get the `max_context_length` by model) and cannot be an empty string.")  # fmt: off
+    input: Annotated[Annotated[list[int] | list[Annotated[list[int], Field(min_length=1)]] | str | list[str], Field(min_length=1)] | None, Field(default=None, description="Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (call `/v1/models` endpoint to get the `max_context_length` by model) and cannot be an empty string.")]  # fmt: off
     messages: Annotated[SkipJsonSchema[list[EmbeddingMessage]] | None, Field(default=None)]
     dimensions: Annotated[int | None, Field(default=None, gt=0, description="The number of dimensions the resulting output embeddings should have.")]  # fmt: off
     encoding_format: Annotated[EncodingFormat, Field(default=EncodingFormat.FLOAT, description="The format of the output embeddings.")]  # fmt: off

--- a/api/infrastructure/fastapi/schemas/embeddings.py
+++ b/api/infrastructure/fastapi/schemas/embeddings.py
@@ -22,7 +22,7 @@ class EmbeddingMessage(BaseModel):
 
 class CreateEmbeddingsBody(BaseModel):
     model: Annotated[str, StringConstraints(min_length=1), Field(default=..., description="ID of the model to use. Call `/v1/models` endpoint to get the list of available models, only `text-embeddings-inference` model type is supported.")]  # fmt: off
-    input: Annotated[Annotated[list[int] | list[Annotated[list[int], Field(min_length=1)]] | str | list[str], Field(min_length=1)] | None, Field(default=None, description="Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (call `/v1/models` endpoint to get the `max_context_length` by model) and cannot be an empty string.")]  # fmt: off
+    input: Annotated[list[int] | list[Annotated[list[int], Field(min_length=1)]] | str | list[str] | None, Field(default=None, min_length=1, description="Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (call `/v1/models` endpoint to get the `max_context_length` by model) and cannot be an empty string.")]  # fmt: off
     messages: Annotated[SkipJsonSchema[list[EmbeddingMessage]] | None, Field(default=None)]
     dimensions: Annotated[int | None, Field(default=None, gt=0, description="The number of dimensions the resulting output embeddings should have.")]  # fmt: off
     encoding_format: Annotated[EncodingFormat, Field(default=EncodingFormat.FLOAT, description="The format of the output embeddings.")]  # fmt: off

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -8,8 +8,8 @@ from api.domain.model.views import ModelView
 
 
 class ModelCosts(BaseModel):
-    prompt_tokens: float = Field(default=0.0, ge=0.0, description="Cost of a million prompt tokens (decrease user budget)")
-    completion_tokens: float = Field(default=0.0, ge=0.0, description="Cost of a million completion tokens (decrease user budget)")
+    prompt_tokens: Annotated[float, Field(default=0.0, ge=0.0, description="Cost of a million prompt tokens (decrease user budget)")]
+    completion_tokens: Annotated[float, Field(default=0.0, ge=0.0, description="Cost of a million completion tokens (decrease user budget)")]
 
 
 class Model(BaseModel):

--- a/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
+++ b/api/infrastructure/http/adapters/rerank/tei/_teireranksadapter.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import Field, ValidationError
 
@@ -10,11 +10,11 @@ from api.infrastructure.http.adapters.rerank import RerankAdapter
 
 
 class TeiCreateRerankBody(BaseModel):
-    query: str = Field(..., examples=["What is Deep Learning?"])
-    raw_scores: bool = Field(False, examples=[False])
-    return_text: bool = Field(False, examples=[False])
-    texts: list[str] = Field(..., examples=[["Deep Learning is ..."]])
-    truncate: bool | None = Field(False, examples=[False])
+    query: Annotated[str, Field(..., examples=["What is Deep Learning?"])]
+    raw_scores: Annotated[bool, Field(False, examples=[False])]
+    return_text: Annotated[bool, Field(False, examples=[False])]
+    texts: Annotated[list[str], Field(..., examples=[["Deep Learning is ..."]])]
+    truncate: Annotated[bool | None, Field(False, examples=[False])]
     truncation_direction: Literal["left", "right"] = "right"
 
 


### PR DESCRIPTION
Closes #878.

## Overview

The refactored domain and infrastructure layers mixed Pydantic V2 assignment syntax (`type = Field(...)`, `Annotated[type] = Field(...)`) with V3 annotated syntax. This PR converts all `Field` declarations across 13 files (8 in `api/domain/`, 5 in `api/infrastructure/`) to the `Annotated[type, Field(...)]` form, and flattens nested `Annotated[Annotated[...]]` declarations. Pure syntax refactor: no defaults, aliases, or validation behavior changed.

- [x] All `Field` declarations in refactored domain and infrastructure `BaseModel`s use `Annotated[type, Field()]`
- [x] No `type = Field(...)` assignments in refactored domain / infrastructure models
- [x] No `Annotated[type] = Field(...)` (Field as a default) remaining
- [x] Out of scope respected: leftover `api/schemas/` modules untouched

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [ ] Updated or added documentation — *N/A: syntax-only refactor, no API or behavior change*
- [ ] Updated or added unit tests — *N/A: no behavior change; existing unit domain tests pass (43 passed)*
- [ ] Updated or added integration tests — *N/A: same reason*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified:** N/A — not modified.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

## Additional Notes

**Reviewer focus:**

- `ChatCompletion.id` in `api/domain/chat/entities.py` is typed `str` but defaults to `None`. This oddity is **pre-existing on `main`** and was deliberately preserved to keep this PR behavior-neutral (flagged in commit 0500cee8). It deserves a follow-up issue rather than a fix here.

- Does the flattening make sense? (tested locally but needs second opinion)
