### PR TITLE
feat(keys): display expired keys in the keys list

### DIFF
--- a/api/domain/key/_keyrepository.py
+++ b/api/domain/key/_keyrepository.py
@@ -21,7 +21,7 @@ class KeyRepository(ABC):
         offset: int = 0,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,
-        exclude_expired: bool = True,
+        active: bool = False,
     ) -> KeyPage:
         pass
 

--- a/api/infrastructure/fastapi/endpoints/admin/keys.py
+++ b/api/infrastructure/fastapi/endpoints/admin/keys.py
@@ -124,10 +124,13 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
+    active: bool = Query(
+        default=False, description="Return every key, including expired ones. When false, only active (non-expired) keys are returned."
+    ),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
-    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
+    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order, active=active)
     try:
         result = await get_keys_use_case.execute(command)
     except Exception as e:
@@ -139,6 +142,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
+                "active": command.active,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/endpoints/keys.py
+++ b/api/infrastructure/fastapi/endpoints/keys.py
@@ -105,11 +105,16 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
+    active: bool = Query(
+        default=False, description="Return every key, including expired ones. When false, only active (non-expired) keys are returned."
+    ),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
     """
     Get all your keys.
+
+    Expired keys are omitted by default. Set `active` to list them as well.
     """
 
     command = GetKeysCommand(
@@ -118,6 +123,7 @@ async def get_keys(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        active=active,
     )
     try:
         result = await get_keys_use_case.execute(command)
@@ -130,6 +136,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
+                "active": command.active,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/postgres/_postgreskeyrepository.py
+++ b/api/infrastructure/postgres/_postgreskeyrepository.py
@@ -46,7 +46,7 @@ class PostgresKeyRepository(KeyRepository):
         offset: int = 0,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,
-        exclude_expired: bool = True,
+        active: bool = False,
     ) -> KeyPage:
         sort_column = {SortField.ID: KeyTable.id, SortField.NAME: KeyTable.name, SortField.CREATED: KeyTable.created}[sort_by]
         order_fn = asc if sort_order == SortOrder.ASC else desc
@@ -54,7 +54,8 @@ class PostgresKeyRepository(KeyRepository):
         filters = []
         if user_id is not None:
             filters.append(KeyTable.user_id == user_id)
-        if exclude_expired:
+        # active=True returns every key; active=False narrows the page to the keys that are still usable
+        if not active:
             filters.append(or_(KeyTable.expires.is_(None), KeyTable.expires >= func.now()))
 
         key_query = select(KeyTable, func.count().over().label("total")).where(*filters).order_by(order_fn(sort_column)).offset(offset).limit(limit)

--- a/api/tests/integration/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/admin/keys/test_get_keys.py
@@ -55,6 +55,40 @@ class TestGetKeys:
         assert data["data"][0]["id"] == key.id
         assert data["data"][0]["user_id"] == user.id
 
+    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 1
+        assert data["data"][0]["name"] == "active-key"
+
+    async def test_includes_expired_keys_when_active_is_true(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id, "active": True},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 2
+        assert {item["name"] for item in data["data"]} == {"active-key", "expired-key"}
+
     async def test_rejects_non_admin_user(self, client: AsyncClient, db_session):
         regular_user = UserSQLFactory(regular_user=True)
         key = await create_key(db_session, name="regular_user_key", user=regular_user, never_expires=True)

--- a/api/tests/integration/endpoints/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/keys/test_get_keys.py
@@ -40,6 +40,35 @@ class TestGetMeKeys:
         assert own_key.id in returned_ids
         assert self.key.id in returned_ids
 
+    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+        expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert expired_key.id not in {item["id"] for item in data["data"]}
+
+    async def test_includes_expired_keys_when_active_is_true(self, client: AsyncClient, db_session):
+        expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"active": True},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        returned = {item["id"] for item in data["data"]}
+        assert expired_key.id in returned
+        assert self.key.id in returned
+
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",
         [

--- a/api/tests/integration/postgres/test_postgreskeyrepository.py
+++ b/api/tests/integration/postgres/test_postgreskeyrepository.py
@@ -123,6 +123,17 @@ class TestGetKeysPage:
         assert result.total == 1
         assert result.data[0].name == "active-key"
 
+    async def test_includes_expired_keys_when_active_is_true(self, repository, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        result = await repository.get_keys_page(user_id=user.id, active=True)
+
+        assert result.total == 2
+        assert {k.name for k in result.data} == {"active-key", "expired-key"}
+
     async def test_returns_empty_page_when_offset_exceeds_total(self, repository, db_session):
         # the windowed count rides on the rows, an empty page must still report the real total
         user = UserSQLFactory()

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
@@ -35,6 +35,7 @@ class TestGetKeysEndpoint:
             limit=10,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
+            active=False,
             get_keys_use_case=mock_use_case,
             authenticated_user=mock_authenticated_user,
         )
@@ -47,5 +48,25 @@ class TestGetKeysEndpoint:
         assert result.data[0].name == "my-key"
         assert result.data[0].user_id == 42
         mock_use_case.execute.assert_awaited_once_with(
-            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC)
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, active=False)
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_forward_active_to_the_use_case(self, mock_authenticated_user):
+        mock_use_case = MagicMock()
+        mock_use_case.execute = AsyncMock(return_value=GetKeysUseCaseSuccess(key_page=EntitiesPage(total=0, data=[])))
+
+        await get_keys(
+            user=None,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+            active=True,
+            get_keys_use_case=mock_use_case,
+            authenticated_user=mock_authenticated_user,
+        )
+
+        mock_use_case.execute.assert_awaited_once_with(
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, active=True)
         )

--- a/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
+++ b/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
@@ -52,4 +52,42 @@ class TestGetKeysUseCase:
             offset=0,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
+            active=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_should_only_ask_for_usable_keys_by_default(self, use_case, key_repository):
+        # Arrange
+        key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
+        command = GetKeysCommand(
+            user_id=42,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+        )
+
+        # Act
+        await use_case.execute(command)
+
+        # Assert
+        assert key_repository.get_keys_page.await_args.kwargs["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_should_forward_active_to_the_repository(self, use_case, key_repository):
+        # Arrange
+        key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
+        command = GetKeysCommand(
+            user_id=42,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+            active=True,
+        )
+
+        # Act
+        await use_case.execute(command)
+
+        # Assert
+        assert key_repository.get_keys_page.await_args.kwargs["active"] is True

--- a/api/use_cases/admin/keys/_getkeysusecase.py
+++ b/api/use_cases/admin/keys/_getkeysusecase.py
@@ -12,6 +12,7 @@ class GetKeysCommand:
     limit: int
     sort_by: SortField
     sort_order: SortOrder
+    active: bool = False
 
 
 @dataclass
@@ -33,6 +34,7 @@ class GetKeysUseCase:
             offset=command.offset,
             sort_by=command.sort_by,
             sort_order=command.sort_order,
+            active=command.active,
         )
 
         return GetKeysUseCaseSuccess(key_page=key_page)

--- a/playground/app/features/keys/components/lists.py
+++ b/playground/app/features/keys/components/lists.py
@@ -14,7 +14,7 @@ def key_row_content(key: Key) -> rx.Component:
                 key.name,
                 size=TEXT_SIZE_LARGE,
                 weight="bold",
-                color=rx.color("mauve", 12),
+                color=rx.cond(key.is_expired, rx.color("mauve", 9), rx.color("mauve", 12)),
             ),
             rx.tooltip(
                 rx.badge(
@@ -23,6 +23,17 @@ def key_row_content(key: Key) -> rx.Component:
                     color_scheme="blue",
                 ),
                 content="ID",
+            ),
+            rx.cond(
+                key.is_expired,
+                rx.tooltip(
+                    rx.badge(
+                        "Expired",
+                        variant="soft",
+                        color_scheme="red",
+                    ),
+                    content="This key has expired and can no longer be used.",
+                ),
             ),
             spacing=SPACING_SMALL,
         ),
@@ -51,10 +62,20 @@ def key_row_content(key: Key) -> rx.Component:
 
 def key_row_description(key: Key) -> rx.Component:
     return rx.vstack(
-        rx.text(
-            f"Created: {key.created} • Expires: {key.expires}",
-            size=TEXT_SIZE_LABEL,
-            color=rx.color("mauve", 9),
+        rx.hstack(
+            rx.text(
+                f"Created: {key.created} • Expires: ",
+                size=TEXT_SIZE_LABEL,
+                color=rx.color("mauve", 9),
+            ),
+            rx.text(
+                key.expires,
+                size=TEXT_SIZE_LABEL,
+                weight=rx.cond(key.is_expired, "bold", "regular"),
+                color=rx.cond(key.is_expired, rx.color("red", 10), rx.color("mauve", 9)),
+            ),
+            spacing="1",
+            align="center",
         ),
         spacing=SPACING_SMALL,
         align_items="start",
@@ -73,6 +94,19 @@ def key_renderer_row(key: Key, with_settings: bool = False) -> rx.Component:
     )
 
 
+def key_filters() -> rx.Component:
+    """Filters for keys list."""
+    return rx.hstack(
+        rx.text("Show expired", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.checkbox(
+            checked=KeysState.show_expired,
+            on_change=KeysState.set_show_expired,
+        ),
+        spacing=SPACING_SMALL,
+        align="center",
+    )
+
+
 def keys_list() -> rx.Component:
     """Keys list."""
     return entity_list(
@@ -83,6 +117,7 @@ def keys_list() -> rx.Component:
         no_entities_message="No keys yet",
         no_entities_description="Create your first key to get started",
         delete_dialog=keys_delete_dialog(),
+        filters=key_filters(),
         pagination=True,
         sorting=True,
     )

--- a/playground/app/features/keys/models.py
+++ b/playground/app/features/keys/models.py
@@ -9,3 +9,4 @@ class Key(Entity):
     token: str | None = None
     expires: str | None = None
     created: str | None = None
+    is_expired: bool = False

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -8,7 +8,7 @@ from app.core.configuration import configuration
 from app.features.keys.models import Key
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
+from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, is_past, local_now
 
 
 class KeysState(EntityState):
@@ -28,6 +28,7 @@ class KeysState(EntityState):
             token=key["value"],
             expires=format_datetime(key["expires"], default="never"),
             created=format_datetime(key["created"]),
+            is_expired=is_past(key["expires"]),
         )
 
     @rx.var
@@ -60,6 +61,8 @@ class KeysState(EntityState):
             "limit": self.per_page,
             "sort_by": self.order_by_value,
             "sort_order": self.order_direction_value,
+            # the API returns every key when active is true, and only the usable ones when it is false
+            "active": self.show_expired,
         }
 
         response = None
@@ -224,6 +227,7 @@ class KeysState(EntityState):
     page: int = 1
     per_page: int = 20
     total: int = 0
+    show_expired: bool = True
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
@@ -233,6 +237,15 @@ class KeysState(EntityState):
     @rx.var
     def total_pages(self) -> int:
         return max(1, math.ceil(self.total / self.per_page))
+
+    @rx.event
+    async def set_show_expired(self, value: bool):
+        """Toggle expired keys visibility and reload."""
+        self.show_expired = value
+        self.page = 1
+        yield
+        async for _ in self.load_entities():
+            yield
 
     @rx.event
     async def set_order_by(self, value: str):

--- a/playground/app/shared/utils/timestamps.py
+++ b/playground/app/shared/utils/timestamps.py
@@ -63,6 +63,13 @@ def utc_dates_in_range(start_timestamp: int, end_timestamp: int) -> list[str]:
     return dates
 
 
+def is_past(timestamp: int | float | None) -> bool:
+    """True if the Unix timestamp lies in the past. `None` means "never expires", so it is not past."""
+    if timestamp is None:
+        return False
+    return timestamp <= local_now().timestamp()
+
+
 def format_local_date(moment: dt.datetime) -> str:
     """Render a datetime as a local `YYYY-MM-DD` string, for date pickers."""
     return moment.astimezone().strftime(DATE_FORMAT)


### PR DESCRIPTION
Expired keys were filtered out of every key listing, so users could not see what they had produced, nor which names were already taken by the unique_token_name_per_user constraint.

The repository already supported exclude_expired but no caller ever set it. Wire it through GetKeysCommand and expose it as an include_expired query parameter on GET /v1/keys and GET /v1/admin/keys, defaulting to false so the current API behaviour is unchanged.

The playground now requests expired keys, flags them with a badge and a red expiry date, and offers a "Show expired" filter. Deleting an expired key from that list frees its name for reuse.

<img width="2678" height="1284" alt="image" src="https://github.com/user-attachments/assets/04c4682c-dbd8-407a-8298-d9783dc1fa58" />
