### PR TITLE
fix(ci): bump oauth2-proxy and refresh expired Trivy ignores

### DIFF
--- a/.github/.trivyignore
+++ b/.github/.trivyignore
@@ -1,39 +1,23 @@
-# gnutls DTLS zero-length fragment DoS — no upstream Debian fix yet
-# Pulled transitively by nginx in playground image. Re-evaluate after 2026-08-01.
-CVE-2026-33845 exp:2026-08-01
-
-# gnutls authentication bypass via NUL character in username — no upstream Debian fix yet
-# Reported in libgnutls30t64 from base image. Re-evaluate after 2026-09-01.
-CVE-2026-42010 exp:2026-09-01
-
-# libssh2 integer overflow with large username/password — no upstream Debian fix yet
-# Reported in libssh2-1t64 from base image. Re-evaluate after 2026-09-01.
-CVE-2026-7598 exp:2026-09-01
-
-# Python XML Expat hash-flooding protection weakness — full fix needs libexpat >= 2.8.0 and a Python patch
-# Reported from Python/base image stack. Re-evaluate after 2026-09-01.
-CVE-2026-7210 exp:2026-09-01
-
 # Perl Archive::Tar symlink extraction weakness — no upstream Debian fix yet
-# Reported in perl-base from base image. Re-evaluate after 2026-09-01.
-CVE-2026-42496 exp:2026-09-01
+# Reported in perl-base from base image. Re-evaluate after 2026-10-01.
+CVE-2026-42496 exp:2026-10-01
 
 # Perl heap buffer overflow during compilation — no upstream Debian fix yet
-# Reported in perl-base from base image. Re-evaluate after 2026-09-01.
-CVE-2026-8376 exp:2026-09-01
+# Reported in perl-base from base image. Re-evaluate after 2026-10-01.
+CVE-2026-8376 exp:2026-10-01
 
 # Perl regex trie overflow (incorrect matches with >65535 alternation branches) — no upstream Debian fix yet
-# Reported in perl-base from base image. Upstream fix is in Perl 5.43.10 only. Re-evaluate after 2026-09-01.
-CVE-2026-13221 exp:2026-09-01
+# Reported in perl-base from base image. Upstream fix is in Perl 5.43.10 only. Re-evaluate after 2026-10-01.
+CVE-2026-13221 exp:2026-10-01
 
 # Perl Storable signed integer overflow on crafted SX_HOOK — no upstream Debian fix yet
-# Reported in perl-base from base image. Fixed upstream in Storable 3.41. Re-evaluate after 2026-09-01.
-CVE-2026-57433 exp:2026-09-01
+# Reported in perl-base from base image. Fixed upstream in Storable 3.41. Re-evaluate after 2026-10-01.
+CVE-2026-57433 exp:2026-10-01
 
-# libssh2 Out-of-Bounds Write via Unchecked — no upstream Debian fix yet
-# Reported in libssh2-1t64 from base image. Re-evaluate after 2026-09-01.
-CVE-2026-55200 exp:2026-09-01
+# Python XML Expat hash-flooding protection weakness — full fix needs libexpat >= 2.8.0 and a Python patch
+# Reported from Python/base image stack. Re-evaluate after 2026-10-01.
+CVE-2026-7210 exp:2026-10-01
 
 # Python tarfile.extractall() with the 'data' or 'tar' filter could be bypasse — no upstream Debian fix yet
-# Reported in libpython3.13-minimal from base image. Re-evaluate after 2026-09-01.
-CVE-2026-11940 exp:2026-09-01
+# Reported in libpython3.13-minimal from base image. Re-evaluate after 2026-10-01.
+CVE-2026-11940 exp:2026-10-01

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -37,7 +37,7 @@ FROM python:3.12-slim
 
 WORKDIR /playground
 
-ARG OAUTH2_PROXY_VERSION=v7.15.3
+ARG OAUTH2_PROXY_VERSION=v7.15.4
 ARG TARGETARCH=amd64
 
 RUN apt-get update && \


### PR DESCRIPTION
## Overview

Unblock the playground Trivy CRITICAL scan after ignore expirations on 2026-09-01.

- Bump oauth2-proxy `v7.15.3` → `v7.15.4` so the binary ships `golang.org/x/crypto` 0.55.0 (fixes CVE-2026-56854).
- Extend Trivy ignores for Perl/Python CVEs that still have no Debian Trixie package (`perl-base` 5.40.1-6; sid/forky only).
- Drop gnutls and libssh2 ignores that Trixie now patches.

- [x] Trivy CRITICAL findings from the playground image are either fixed or re-ignored with a new expiry
- [x] oauth2-proxy version bump is the smallest change that remediates CVE-2026-56854

**Breaking changes:**

- [x] No breaking changes

## Check lists

### Review checklist

- [ ] Updated or added documentation
- [ ] Updated or added unit tests
- [ ] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

Playground image rebuild is required so the new oauth2-proxy binary is picked up.

## Additional Notes

Perl CVEs (CVE-2026-13221, CVE-2026-42496, CVE-2026-8376, CVE-2026-57433) remain unfixed in Trixie; `perl-base` is pulled by nginx/supervisor. Re-evaluate after 2026-10-01.


Made with [Cursor](https://cursor.com)