### PR TITLE
feat(keys): add status filter and display expired keys

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.78%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.82%", "color": "green"}

--- a/api/domain/key/_keyrepository.py
+++ b/api/domain/key/_keyrepository.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pydantic import FutureDatetime
 
 from api.domain import SortField, SortOrder
-from api.domain.key.entities import Key, KeyPage
+from api.domain.key.entities import Key, KeyPage, KeyStatus
 from api.domain.key.errors import KeyAlreadyExistsError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 
@@ -21,7 +21,7 @@ class KeyRepository(ABC):
         offset: int = 0,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,
-        exclude_expired: bool = True,
+        status: KeyStatus | None = None,
     ) -> KeyPage:
         pass
 

--- a/api/domain/key/entities.py
+++ b/api/domain/key/entities.py
@@ -1,6 +1,12 @@
 from datetime import UTC, datetime
+from enum import StrEnum
 
 from api.domain import BaseModel, EntitiesPage, UtcDatetime
+
+
+class KeyStatus(StrEnum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
 
 
 class Key(BaseModel):
@@ -10,6 +16,7 @@ class Key(BaseModel):
     value: str
     expires: UtcDatetime | None
     created: UtcDatetime
+    status: KeyStatus | None = None
 
     @classmethod
     def build_from_claims(cls, claims: dict):
@@ -38,6 +45,15 @@ class Key(BaseModel):
         if expires is None:
             return None
         return int(expires.timestamp())
+
+    @staticmethod
+    def compute_status(expires: UtcDatetime | None) -> KeyStatus:
+        if expires is not None and expires < datetime.now(tz=UTC):
+            return KeyStatus.EXPIRED
+        return KeyStatus.ACTIVE
+
+    def with_computed_status(self) -> "Key":
+        return self.model_copy(update={"status": self.compute_status(self.expires)})
 
 
 KeyPage = EntitiesPage["Key"]

--- a/api/infrastructure/fastapi/endpoints/admin/keys.py
+++ b/api/infrastructure/fastapi/endpoints/admin/keys.py
@@ -124,10 +124,11 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
+    include_expired: bool = Query(default=False, description="Include expired keys in the results."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
-    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order)
+    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order, exclude_expired=not include_expired)
     try:
         result = await get_keys_use_case.execute(command)
     except Exception as e:
@@ -139,6 +140,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
+                "exclude_expired": command.exclude_expired,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/endpoints/admin/keys.py
+++ b/api/infrastructure/fastapi/endpoints/admin/keys.py
@@ -4,6 +4,7 @@ from fastapi import Body, Depends, Path, Query, Security
 
 from api.dependencies import create_key_use_case_factory, delete_key_use_case_factory, get_keys_use_case_factory, get_one_key_use_case_factory
 from api.domain import SortField, SortOrder
+from api.domain.key.entities import KeyStatus
 from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.domain.user.views import AuthenticatedUserView
@@ -124,11 +125,11 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
-    include_expired: bool = Query(default=False, description="Include expired keys in the results."),
+    status: KeyStatus | None = Query(default=None, description="Filter keys by status. Omit to return all keys."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
-    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order, exclude_expired=not include_expired)
+    command = GetKeysCommand(user_id=user, offset=offset, limit=limit, sort_by=sort_by, sort_order=sort_order, status=status)
     try:
         result = await get_keys_use_case.execute(command)
     except Exception as e:
@@ -140,7 +141,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
-                "exclude_expired": command.exclude_expired,
+                "status": command.status,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/endpoints/keys.py
+++ b/api/infrastructure/fastapi/endpoints/keys.py
@@ -105,11 +105,14 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
+    include_expired: bool = Query(default=False, description="Include expired keys in the results."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
     """
     Get all your keys.
+
+    Expired keys are omitted by default. Set `include_expired` to list them as well.
     """
 
     command = GetKeysCommand(
@@ -118,6 +121,7 @@ async def get_keys(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        exclude_expired=not include_expired,
     )
     try:
         result = await get_keys_use_case.execute(command)
@@ -130,6 +134,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
+                "exclude_expired": command.exclude_expired,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/endpoints/keys.py
+++ b/api/infrastructure/fastapi/endpoints/keys.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Body, Depends, Path, Query, Security
 
 from api.dependencies import create_me_key_use_case_factory, delete_key_use_case_factory, get_keys_use_case_factory, get_one_key_use_case_factory
 from api.domain import SortField, SortOrder
+from api.domain.key.entities import KeyStatus
 from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.domain.user.views import AuthenticatedUserView
@@ -105,14 +106,12 @@ async def get_keys(
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of keys to return."),
     sort_by: SortField = Query(default=SortField.ID, description="Field to sort by."),
     sort_order: SortOrder = Query(default=SortOrder.ASC, description="Sort order."),
-    include_expired: bool = Query(default=False, description="Include expired keys in the results."),
+    status: KeyStatus | None = Query(default=None, description="Filter keys by status. Omit to return all keys."),
     get_keys_use_case: GetKeysUseCase = Depends(get_keys_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> KeysResponse:
     """
     Get all your keys.
-
-    Expired keys are omitted by default. Set `include_expired` to list them as well.
     """
 
     command = GetKeysCommand(
@@ -121,7 +120,7 @@ async def get_keys(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
-        exclude_expired=not include_expired,
+        status=status,
     )
     try:
         result = await get_keys_use_case.execute(command)
@@ -134,7 +133,7 @@ async def get_keys(
                 "limit": command.limit,
                 "sort_by": command.sort_by,
                 "sort_order": command.sort_order,
-                "exclude_expired": command.exclude_expired,
+                "status": command.status,
                 "error_type": type(e).__name__,
             },
         )

--- a/api/infrastructure/fastapi/schemas/admin/keys.py
+++ b/api/infrastructure/fastapi/schemas/admin/keys.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints, field_validator, model_validator
 
 from api.domain import BaseModel
-from api.domain.key.entities import Key
+from api.domain.key.entities import Key, KeyStatus
 
 
 class CreateKeyBody(BaseModel):
@@ -33,6 +33,7 @@ class KeyResponse(BaseModel):
     user: Annotated[int, Field(description="ID of the user that owns the key.")]
     expires: Annotated[int | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]
     created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
+    status: Annotated[KeyStatus, Field(description="Whether the key is active or expired.")]
 
     @model_validator(mode="before")
     @classmethod
@@ -46,6 +47,7 @@ class KeyResponse(BaseModel):
                 "user": data.user_id,
                 "expires": int(data.expires.timestamp()) if data.expires is not None else None,
                 "created": int(data.created.timestamp()),
+                "status": data.status or Key.compute_status(data.expires),
             }
         return data
 

--- a/api/infrastructure/postgres/_postgreskeyrepository.py
+++ b/api/infrastructure/postgres/_postgreskeyrepository.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain import SortField, SortOrder
 from api.domain.key import KeyEncoder, KeyRepository
-from api.domain.key.entities import Key, KeyPage
+from api.domain.key.entities import Key, KeyPage, KeyStatus
 from api.domain.key.errors import KeyAlreadyExistsError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.infrastructure.postgres._pagination import fetch_page_with_total
@@ -46,7 +46,7 @@ class PostgresKeyRepository(KeyRepository):
         offset: int = 0,
         sort_by: SortField = SortField.ID,
         sort_order: SortOrder = SortOrder.ASC,
-        exclude_expired: bool = True,
+        status: KeyStatus | None = None,
     ) -> KeyPage:
         sort_column = {SortField.ID: KeyTable.id, SortField.NAME: KeyTable.name, SortField.CREATED: KeyTable.created}[sort_by]
         order_fn = asc if sort_order == SortOrder.ASC else desc
@@ -54,8 +54,11 @@ class PostgresKeyRepository(KeyRepository):
         filters = []
         if user_id is not None:
             filters.append(KeyTable.user_id == user_id)
-        if exclude_expired:
+        if status == KeyStatus.ACTIVE:
             filters.append(or_(KeyTable.expires.is_(None), KeyTable.expires >= func.now()))
+        elif status == KeyStatus.EXPIRED:
+            filters.append(KeyTable.expires.isnot(None))
+            filters.append(KeyTable.expires < func.now())
 
         key_query = select(KeyTable, func.count().over().label("total")).where(*filters).order_by(order_fn(sort_column)).offset(offset).limit(limit)
         count_query = select(func.count()).select_from(KeyTable).where(*filters)

--- a/api/tests/integration/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/admin/keys/test_get_keys.py
@@ -55,7 +55,43 @@ class TestGetKeys:
         assert data["data"][0]["id"] == key.id
         assert data["data"][0]["user"] == user.id
 
-    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+    async def test_filters_active_keys_by_default(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id, "status": "active"},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 1
+        assert data["data"][0]["name"] == "active-key"
+        assert data["data"][0]["status"] == "active"
+
+    async def test_filters_expired_keys_when_requested(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id, "status": "expired"},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 1
+        assert data["data"][0]["name"] == "expired-key"
+        assert data["data"][0]["status"] == "expired"
+
+    async def test_returns_all_keys_when_status_is_omitted(self, client: AsyncClient, db_session):
         user = UserSQLFactory()
         KeySQLFactory(user=user, name="active-key", never_expires=True)
         KeySQLFactory(user=user, name="expired-key", expired=True)
@@ -64,23 +100,6 @@ class TestGetKeys:
         response = await client.get(
             url=URL,
             params={"user": user.id},
-            headers={"Authorization": f"Bearer {self.key.token}"},
-        )
-
-        assert response.status_code == 200, response.text
-        data = response.json()
-        assert data["total"] == 1
-        assert data["data"][0]["name"] == "active-key"
-
-    async def test_includes_expired_keys_when_requested(self, client: AsyncClient, db_session):
-        user = UserSQLFactory()
-        KeySQLFactory(user=user, name="active-key", never_expires=True)
-        KeySQLFactory(user=user, name="expired-key", expired=True)
-        await db_session.flush()
-
-        response = await client.get(
-            url=URL,
-            params={"user": user.id, "include_expired": True},
             headers={"Authorization": f"Bearer {self.key.token}"},
         )
 

--- a/api/tests/integration/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/admin/keys/test_get_keys.py
@@ -55,6 +55,40 @@ class TestGetKeys:
         assert data["data"][0]["id"] == key.id
         assert data["data"][0]["user"] == user.id
 
+    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 1
+        assert data["data"][0]["name"] == "active-key"
+
+    async def test_includes_expired_keys_when_requested(self, client: AsyncClient, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"user": user.id, "include_expired": True},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 2
+        assert {item["name"] for item in data["data"]} == {"active-key", "expired-key"}
+
     async def test_rejects_non_admin_user(self, client: AsyncClient, db_session):
         regular_user = UserSQLFactory(regular_user=True)
         key = await create_key(db_session, name="regular_user_key", user=regular_user, never_expires=True)

--- a/api/tests/integration/endpoints/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/keys/test_get_keys.py
@@ -40,26 +40,43 @@ class TestGetMeKeys:
         assert own_key.id in returned_ids
         assert self.key.id in returned_ids
 
-    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+    async def test_filters_active_keys_when_requested(self, client: AsyncClient, db_session):
         expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
         await db_session.flush()
 
         response = await client.get(
             url=URL,
+            params={"status": "active"},
             headers={"Authorization": f"Bearer {self.key.token}"},
         )
 
         assert response.status_code == 200, response.text
         data = response.json()
         assert expired_key.id not in {item["id"] for item in data["data"]}
+        assert all(item["status"] == "active" for item in data["data"])
 
-    async def test_includes_expired_keys_when_requested(self, client: AsyncClient, db_session):
+    async def test_filters_expired_keys_when_requested(self, client: AsyncClient, db_session):
         expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
         await db_session.flush()
 
         response = await client.get(
             url=URL,
-            params={"include_expired": True},
+            params={"status": "expired"},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        returned = {item["id"] for item in data["data"]}
+        assert expired_key.id in returned
+        assert all(item["status"] == "expired" for item in data["data"])
+
+    async def test_returns_all_keys_when_status_is_omitted(self, client: AsyncClient, db_session):
+        expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
             headers={"Authorization": f"Bearer {self.key.token}"},
         )
 

--- a/api/tests/integration/endpoints/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/keys/test_get_keys.py
@@ -40,6 +40,35 @@ class TestGetMeKeys:
         assert own_key.id in returned_ids
         assert self.key.id in returned_ids
 
+    async def test_excludes_expired_keys_by_default(self, client: AsyncClient, db_session):
+        expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert expired_key.id not in {item["id"] for item in data["data"]}
+
+    async def test_includes_expired_keys_when_requested(self, client: AsyncClient, db_session):
+        expired_key = KeySQLFactory(user=self.user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        response = await client.get(
+            url=URL,
+            params={"include_expired": True},
+            headers={"Authorization": f"Bearer {self.key.token}"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        returned = {item["id"] for item in data["data"]}
+        assert expired_key.id in returned
+        assert self.key.id in returned
+
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",
         [

--- a/api/tests/integration/postgres/test_postgreskeyrepository.py
+++ b/api/tests/integration/postgres/test_postgreskeyrepository.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import select
 
 from api.domain import EntitiesPage, SortField, SortOrder
-from api.domain.key.entities import Key
+from api.domain.key.entities import Key, KeyStatus
 from api.domain.key.errors import KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.infrastructure.jwt import JwtKeyEncoder
@@ -112,24 +112,45 @@ class TestGetKeysPage:
         assert result.total == 1
         assert result.data[0].name == "user-key"
 
-    async def test_excludes_expired_keys(self, repository, db_session):
+    async def test_returns_keys_without_status_from_repository(self, repository, db_session):
         user = UserSQLFactory()
         KeySQLFactory(user=user, name="active-key", never_expires=True)
-        KeySQLFactory(user=user, name="expired-key", expired=True)
         await db_session.flush()
 
         result = await repository.get_keys_page(user_id=user.id)
 
         assert result.total == 1
-        assert result.data[0].name == "active-key"
+        assert result.data[0].status is None
 
-    async def test_includes_expired_keys_when_not_excluded(self, repository, db_session):
+    async def test_filters_active_keys_by_status(self, repository, db_session):
         user = UserSQLFactory()
         KeySQLFactory(user=user, name="active-key", never_expires=True)
         KeySQLFactory(user=user, name="expired-key", expired=True)
         await db_session.flush()
 
-        result = await repository.get_keys_page(user_id=user.id, exclude_expired=False)
+        result = await repository.get_keys_page(user_id=user.id, status=KeyStatus.ACTIVE)
+
+        assert result.total == 1
+        assert result.data[0].name == "active-key"
+
+    async def test_filters_expired_keys_by_status(self, repository, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        result = await repository.get_keys_page(user_id=user.id, status=KeyStatus.EXPIRED)
+
+        assert result.total == 1
+        assert result.data[0].name == "expired-key"
+
+    async def test_returns_all_keys_when_status_is_none(self, repository, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        result = await repository.get_keys_page(user_id=user.id, status=None)
 
         assert result.total == 2
         assert {k.name for k in result.data} == {"active-key", "expired-key"}

--- a/api/tests/integration/postgres/test_postgreskeyrepository.py
+++ b/api/tests/integration/postgres/test_postgreskeyrepository.py
@@ -123,6 +123,17 @@ class TestGetKeysPage:
         assert result.total == 1
         assert result.data[0].name == "active-key"
 
+    async def test_includes_expired_keys_when_not_excluded(self, repository, db_session):
+        user = UserSQLFactory()
+        KeySQLFactory(user=user, name="active-key", never_expires=True)
+        KeySQLFactory(user=user, name="expired-key", expired=True)
+        await db_session.flush()
+
+        result = await repository.get_keys_page(user_id=user.id, exclude_expired=False)
+
+        assert result.total == 2
+        assert {k.name for k in result.data} == {"active-key", "expired-key"}
+
     async def test_returns_empty_page_when_offset_exceeds_total(self, repository, db_session):
         # the windowed count rides on the rows, an empty page must still report the real total
         user = UserSQLFactory()

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from api.domain import EntitiesPage, SortField, SortOrder
-from api.domain.key.entities import Key
+from api.domain.key.entities import Key, KeyStatus
 from api.infrastructure.fastapi.endpoints.admin.keys import get_keys
 from api.infrastructure.fastapi.schemas.admin.keys import KeysResponse
 from api.use_cases.admin.keys import GetKeysCommand, GetKeysUseCaseSuccess
@@ -25,6 +25,7 @@ class TestGetKeysEndpoint:
             value="sk-masked...value",
             expires=None,
             created=datetime(2030, 1, 1, tzinfo=UTC),
+            status=KeyStatus.ACTIVE,
         )
         mock_use_case = MagicMock()
         mock_use_case.execute = AsyncMock(return_value=GetKeysUseCaseSuccess(key_page=EntitiesPage(total=1, data=[key])))
@@ -35,7 +36,7 @@ class TestGetKeysEndpoint:
             limit=10,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
-            include_expired=False,
+            status=None,
             get_keys_use_case=mock_use_case,
             authenticated_user=mock_authenticated_user,
         )
@@ -47,12 +48,13 @@ class TestGetKeysEndpoint:
         assert len(result.data) == 1
         assert result.data[0].name == "my-key"
         assert result.data[0].user == 42
+        assert result.data[0].status == KeyStatus.ACTIVE
         mock_use_case.execute.assert_awaited_once_with(
-            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, exclude_expired=True)
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, status=None)
         )
 
     @pytest.mark.asyncio
-    async def test_should_not_exclude_expired_keys_when_include_expired_is_set(self, mock_authenticated_user):
+    async def test_should_forward_status_filter_to_the_use_case(self, mock_authenticated_user):
         mock_use_case = MagicMock()
         mock_use_case.execute = AsyncMock(return_value=GetKeysUseCaseSuccess(key_page=EntitiesPage(total=0, data=[])))
 
@@ -62,11 +64,11 @@ class TestGetKeysEndpoint:
             limit=10,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
-            include_expired=True,
+            status=KeyStatus.EXPIRED,
             get_keys_use_case=mock_use_case,
             authenticated_user=mock_authenticated_user,
         )
 
         mock_use_case.execute.assert_awaited_once_with(
-            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, exclude_expired=False)
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, status=KeyStatus.EXPIRED)
         )

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
@@ -35,6 +35,7 @@ class TestGetKeysEndpoint:
             limit=10,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
+            include_expired=False,
             get_keys_use_case=mock_use_case,
             authenticated_user=mock_authenticated_user,
         )
@@ -47,5 +48,25 @@ class TestGetKeysEndpoint:
         assert result.data[0].name == "my-key"
         assert result.data[0].user == 42
         mock_use_case.execute.assert_awaited_once_with(
-            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC)
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, exclude_expired=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_not_exclude_expired_keys_when_include_expired_is_set(self, mock_authenticated_user):
+        mock_use_case = MagicMock()
+        mock_use_case.execute = AsyncMock(return_value=GetKeysUseCaseSuccess(key_page=EntitiesPage(total=0, data=[])))
+
+        await get_keys(
+            user=None,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+            include_expired=True,
+            get_keys_use_case=mock_use_case,
+            authenticated_user=mock_authenticated_user,
+        )
+
+        mock_use_case.execute.assert_awaited_once_with(
+            GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC, exclude_expired=False)
         )

--- a/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
+++ b/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from api.domain import EntitiesPage, SortField, SortOrder
-from api.domain.key.entities import Key
+from api.domain.key.entities import Key, KeyStatus
 from api.use_cases.admin.keys import GetKeysCommand, GetKeysUseCase, GetKeysUseCaseSuccess
 
 
@@ -20,7 +20,7 @@ def use_case(key_repository):
 
 class TestGetKeysUseCase:
     @pytest.mark.asyncio
-    async def test_should_return_keys_page(self, use_case, key_repository):
+    async def test_should_return_keys_page_with_computed_status(self, use_case, key_repository):
         # Arrange
         key = Key(
             id=1,
@@ -45,18 +45,19 @@ class TestGetKeysUseCase:
         # Assert
         assert isinstance(result, GetKeysUseCaseSuccess)
         assert result.key_page.total == 1
-        assert result.key_page.data == [key]
+        assert len(result.key_page.data) == 1
+        assert result.key_page.data[0].status == KeyStatus.ACTIVE
         key_repository.get_keys_page.assert_awaited_once_with(
             user_id=42,
             limit=10,
             offset=0,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
-            exclude_expired=True,
+            status=None,
         )
 
     @pytest.mark.asyncio
-    async def test_should_exclude_expired_keys_by_default(self, use_case, key_repository):
+    async def test_should_forward_status_filter_to_the_repository(self, use_case, key_repository):
         # Arrange
         key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
         command = GetKeysCommand(
@@ -65,29 +66,11 @@ class TestGetKeysUseCase:
             limit=10,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
+            status=KeyStatus.EXPIRED,
         )
 
         # Act
         await use_case.execute(command)
 
         # Assert
-        assert key_repository.get_keys_page.await_args.kwargs["exclude_expired"] is True
-
-    @pytest.mark.asyncio
-    async def test_should_forward_exclude_expired_to_the_repository(self, use_case, key_repository):
-        # Arrange
-        key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
-        command = GetKeysCommand(
-            user_id=42,
-            offset=0,
-            limit=10,
-            sort_by=SortField.ID,
-            sort_order=SortOrder.ASC,
-            exclude_expired=False,
-        )
-
-        # Act
-        await use_case.execute(command)
-
-        # Assert
-        assert key_repository.get_keys_page.await_args.kwargs["exclude_expired"] is False
+        assert key_repository.get_keys_page.await_args.kwargs["status"] == KeyStatus.EXPIRED

--- a/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
+++ b/api/tests/unit/use_case/admin/keys/test_getkeysusecase.py
@@ -52,4 +52,42 @@ class TestGetKeysUseCase:
             offset=0,
             sort_by=SortField.ID,
             sort_order=SortOrder.ASC,
+            exclude_expired=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_should_exclude_expired_keys_by_default(self, use_case, key_repository):
+        # Arrange
+        key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
+        command = GetKeysCommand(
+            user_id=42,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+        )
+
+        # Act
+        await use_case.execute(command)
+
+        # Assert
+        assert key_repository.get_keys_page.await_args.kwargs["exclude_expired"] is True
+
+    @pytest.mark.asyncio
+    async def test_should_forward_exclude_expired_to_the_repository(self, use_case, key_repository):
+        # Arrange
+        key_repository.get_keys_page.return_value = EntitiesPage(total=0, data=[])
+        command = GetKeysCommand(
+            user_id=42,
+            offset=0,
+            limit=10,
+            sort_by=SortField.ID,
+            sort_order=SortOrder.ASC,
+            exclude_expired=False,
+        )
+
+        # Act
+        await use_case.execute(command)
+
+        # Assert
+        assert key_repository.get_keys_page.await_args.kwargs["exclude_expired"] is False

--- a/api/tests/unit/use_case/admin/keys/test_getonekeyusecase.py
+++ b/api/tests/unit/use_case/admin/keys/test_getonekeyusecase.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.key.entities import Key
+from api.domain.key.entities import Key, KeyStatus
 from api.domain.key.errors import KeyNotFoundError
 from api.use_cases.admin.keys import GetOneKeyCommand, GetOneKeyUseCase, GetOneKeyUseCaseSuccess
 
@@ -42,7 +42,7 @@ class TestGetOneKeyUseCase:
 
         # Assert
         assert isinstance(result, GetOneKeyUseCaseSuccess)
-        assert result.key == key
+        assert result.key.status == KeyStatus.ACTIVE
         key_repository.get_key_by_id.assert_awaited_once_with(42)
 
     @pytest.mark.asyncio
@@ -56,7 +56,7 @@ class TestGetOneKeyUseCase:
 
         # Assert
         assert isinstance(result, GetOneKeyUseCaseSuccess)
-        assert result.key == key
+        assert result.key.status == KeyStatus.ACTIVE
         key_repository.get_key_by_id.assert_awaited_once_with(42)
 
     @pytest.mark.asyncio

--- a/api/use_cases/admin/keys/_getkeysusecase.py
+++ b/api/use_cases/admin/keys/_getkeysusecase.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from api.domain import SortField, SortOrder
 from api.domain.key import KeyRepository
-from api.domain.key.entities import KeyPage
+from api.domain.key.entities import KeyPage, KeyStatus
 
 
 @dataclass
@@ -12,7 +12,7 @@ class GetKeysCommand:
     limit: int
     sort_by: SortField
     sort_order: SortOrder
-    exclude_expired: bool = True
+    status: KeyStatus | None = None
 
 
 @dataclass
@@ -34,7 +34,12 @@ class GetKeysUseCase:
             offset=command.offset,
             sort_by=command.sort_by,
             sort_order=command.sort_order,
-            exclude_expired=command.exclude_expired,
+            status=command.status,
         )
 
-        return GetKeysUseCaseSuccess(key_page=key_page)
+        return GetKeysUseCaseSuccess(
+            key_page=KeyPage(
+                total=key_page.total,
+                data=[key.with_computed_status() for key in key_page.data],
+            )
+        )

--- a/api/use_cases/admin/keys/_getkeysusecase.py
+++ b/api/use_cases/admin/keys/_getkeysusecase.py
@@ -12,6 +12,7 @@ class GetKeysCommand:
     limit: int
     sort_by: SortField
     sort_order: SortOrder
+    exclude_expired: bool = True
 
 
 @dataclass
@@ -33,6 +34,7 @@ class GetKeysUseCase:
             offset=command.offset,
             sort_by=command.sort_by,
             sort_order=command.sort_order,
+            exclude_expired=command.exclude_expired,
         )
 
         return GetKeysUseCaseSuccess(key_page=key_page)

--- a/api/use_cases/admin/keys/_getonekeyusecase.py
+++ b/api/use_cases/admin/keys/_getonekeyusecase.py
@@ -32,4 +32,4 @@ class GetOneKeyUseCase:
         if command.user_id is not None and result.user_id != command.user_id:
             return KeyNotFoundError(id=command.key_id)
 
-        return GetOneKeyUseCaseSuccess(key=result)
+        return GetOneKeyUseCaseSuccess(key=result.with_computed_status())

--- a/playground/app/features/keys/components/lists.py
+++ b/playground/app/features/keys/components/lists.py
@@ -14,7 +14,7 @@ def key_row_content(key: Key) -> rx.Component:
                 key.name,
                 size=TEXT_SIZE_LARGE,
                 weight="bold",
-                color=rx.color("mauve", 12),
+                color=rx.cond(key.is_expired, rx.color("mauve", 9), rx.color("mauve", 12)),
             ),
             rx.tooltip(
                 rx.badge(
@@ -23,6 +23,17 @@ def key_row_content(key: Key) -> rx.Component:
                     color_scheme="blue",
                 ),
                 content="ID",
+            ),
+            rx.cond(
+                key.is_expired,
+                rx.tooltip(
+                    rx.badge(
+                        "Expired",
+                        variant="soft",
+                        color_scheme="red",
+                    ),
+                    content="This key has expired and can no longer be used.",
+                ),
             ),
             spacing=SPACING_SMALL,
         ),
@@ -51,10 +62,20 @@ def key_row_content(key: Key) -> rx.Component:
 
 def key_row_description(key: Key) -> rx.Component:
     return rx.vstack(
-        rx.text(
-            f"Created: {key.created} • Expires: {key.expires}",
-            size=TEXT_SIZE_LABEL,
-            color=rx.color("mauve", 9),
+        rx.hstack(
+            rx.text(
+                f"Created: {key.created} • Expires: ",
+                size=TEXT_SIZE_LABEL,
+                color=rx.color("mauve", 9),
+            ),
+            rx.text(
+                key.expires,
+                size=TEXT_SIZE_LABEL,
+                weight=rx.cond(key.is_expired, "bold", "regular"),
+                color=rx.cond(key.is_expired, rx.color("red", 10), rx.color("mauve", 9)),
+            ),
+            spacing="1",
+            align="center",
         ),
         spacing=SPACING_SMALL,
         align_items="start",
@@ -73,6 +94,19 @@ def key_renderer_row(key: Key, with_settings: bool = False) -> rx.Component:
     )
 
 
+def key_filters() -> rx.Component:
+    """Filters for keys list."""
+    return rx.hstack(
+        rx.text("Show expired", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.checkbox(
+            checked=KeysState.show_expired,
+            on_change=KeysState.set_show_expired,
+        ),
+        spacing=SPACING_SMALL,
+        align="center",
+    )
+
+
 def keys_list() -> rx.Component:
     """Keys list."""
     return entity_list(
@@ -83,6 +117,7 @@ def keys_list() -> rx.Component:
         no_entities_message="No keys yet",
         no_entities_description="Create your first key to get started",
         delete_dialog=keys_delete_dialog(),
+        filters=key_filters(),
         pagination=True,
         sorting=True,
     )

--- a/playground/app/features/keys/components/lists.py
+++ b/playground/app/features/keys/components/lists.py
@@ -1,6 +1,6 @@
 import reflex as rx
 
-from app.core.variables import SPACING_SMALL, TEXT_SIZE_LABEL, TEXT_SIZE_LARGE
+from app.core.variables import SELECT_MEDIUM_WIDTH, SPACING_SMALL, TEXT_SIZE_LABEL, TEXT_SIZE_LARGE
 from app.features.keys.components.dialogs import keys_delete_dialog
 from app.features.keys.models import Key
 from app.features.keys.state import KeysState
@@ -97,10 +97,12 @@ def key_renderer_row(key: Key, with_settings: bool = False) -> rx.Component:
 def key_filters() -> rx.Component:
     """Filters for keys list."""
     return rx.hstack(
-        rx.text("Show expired", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-        rx.checkbox(
-            checked=KeysState.show_expired,
-            on_change=KeysState.set_show_expired,
+        rx.text("Status", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.select(
+            KeysState.status_filter_options,
+            on_change=KeysState.set_status_filter,
+            value=KeysState.status_filter_value,
+            width=SELECT_MEDIUM_WIDTH,
         ),
         spacing=SPACING_SMALL,
         align="center",

--- a/playground/app/features/keys/models.py
+++ b/playground/app/features/keys/models.py
@@ -9,3 +9,4 @@ class Key(Entity):
     token: str | None = None
     expires: str | None = None
     created: str | None = None
+    is_expired: bool = False

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -7,7 +7,7 @@ from app.core.configuration import configuration
 from app.features.keys.models import Key
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, is_past, local_now
+from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
 
 
 class KeysState(EntityState):
@@ -27,7 +27,7 @@ class KeysState(EntityState):
             token=key["value"],
             expires=format_datetime(key["expires"], default="never"),
             created=format_datetime(key["created"]),
-            is_expired=is_past(key["expires"]),
+            is_expired=key.get("status") == "expired",
         )
 
     @rx.var
@@ -60,8 +60,9 @@ class KeysState(EntityState):
             "limit": self.per_page,
             "sort_by": self.order_by_value,
             "sort_order": self.order_direction_value,
-            "include_expired": self.show_expired,
         }
+        if self.status_filter_param is not None:
+            params["status"] = self.status_filter_param
 
         response = None
         try:
@@ -224,17 +225,25 @@ class KeysState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
-    show_expired: bool = True
+    status_filter_value: str = "All"
+    status_filter_options: list[str] = ["All", "Active", "Expired"]
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created"]
 
+    @rx.var
+    def status_filter_param(self) -> str | None:
+        """API status query param derived from the UI filter."""
+        if self.status_filter_value == "All":
+            return None
+        return self.status_filter_value.lower()
+
     @rx.event
-    async def set_show_expired(self, value: bool):
-        """Toggle expired keys visibility and reload."""
-        self.show_expired = value
+    async def set_status_filter(self, value: str):
+        """Set status filter and reload."""
+        self.status_filter_value = value
         self.page = 1
         self.has_more_page = False
         yield

--- a/playground/app/features/keys/state.py
+++ b/playground/app/features/keys/state.py
@@ -7,7 +7,7 @@ from app.core.configuration import configuration
 from app.features.keys.models import Key
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
+from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, is_past, local_now
 
 
 class KeysState(EntityState):
@@ -27,6 +27,7 @@ class KeysState(EntityState):
             token=key["value"],
             expires=format_datetime(key["expires"], default="never"),
             created=format_datetime(key["created"]),
+            is_expired=is_past(key["expires"]),
         )
 
     @rx.var
@@ -59,6 +60,7 @@ class KeysState(EntityState):
             "limit": self.per_page,
             "sort_by": self.order_by_value,
             "sort_order": self.order_direction_value,
+            "include_expired": self.show_expired,
         }
 
         response = None
@@ -222,11 +224,22 @@ class KeysState(EntityState):
     ############################################################
     page: int = 1
     per_page: int = 20
+    show_expired: bool = True
     order_by_value: str = "id"
     order_direction: str = "asc"
     order_direction_options: list[str] = ["asc", "desc"]
     order_direction_value: str = "asc"
     order_by_options: list[str] = ["id", "name", "created"]
+
+    @rx.event
+    async def set_show_expired(self, value: bool):
+        """Toggle expired keys visibility and reload."""
+        self.show_expired = value
+        self.page = 1
+        self.has_more_page = False
+        yield
+        async for _ in self.load_entities():
+            yield
 
     @rx.event
     async def set_order_by(self, value: str):

--- a/playground/app/shared/utils/timestamps.py
+++ b/playground/app/shared/utils/timestamps.py
@@ -42,6 +42,13 @@ def format_date(timestamp: int | float | None, default: str = "") -> str:
     return default if local is None else local.strftime(DATE_FORMAT)
 
 
+def is_past(timestamp: int | float | None) -> bool:
+    """True if the Unix timestamp lies in the past. `None` means "never expires", so it is not past."""
+    if timestamp is None:
+        return False
+    return timestamp <= local_now().timestamp()
+
+
 def format_local_date(moment: dt.datetime) -> str:
     """Render a datetime as a local `YYYY-MM-DD` string, for date pickers."""
     return moment.astimezone().strftime(DATE_FORMAT)


### PR DESCRIPTION
## Summary
- Replace the `include_expired` boolean on `GET /v1/keys` and `GET /v1/admin/keys` with an optional `status` filter (`active`, `expired`, or omitted for all keys).
- Add a derived `status` field on key responses, computed by the use case from `expires` (repository returns `status=None`).
- Update the playground keys page to show expired keys with a status dropdown filter and visual indicators.

## Test plan
- [x] Unit tests for `GetKeysUseCase`, `GetOneKeyUseCase`, and admin `get_keys` endpoint
- [ ] Integration tests: `pytest api/tests/integration/endpoints/keys/test_get_keys.py`
- [ ] Integration tests: `pytest api/tests/integration/endpoints/admin/keys/test_get_keys.py`
- [ ] Integration tests: `pytest api/tests/integration/postgres/test_postgreskeyrepository.py`
- [ ] Manual: playground keys page — filter by All / Active / Expired and verify expired badge styling


Made with [Cursor](https://cursor.com)