### PR TITLE
test(models): autospec the port doubles in the provider request forwarding use-case tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,7 +491,27 @@ Mirror an existing test for the same verb (`test_get_roles.py`, `test_create_key
 
 ### Unit use case
 
-`AsyncMock` repositories. Cover:
+Port doubles are autospecced against the **domain port**, never bare `MagicMock()` / `AsyncMock()`:
+
+```python
+@pytest.fixture
+def mock_router_repository():
+    return create_autospec(RouterRepository, instance=True, spec_set=True)
+```
+
+`create_autospec` derives the double from the ABC under `api/domain/`, so an unknown attribute raises
+`AttributeError` and a call that does not match the port signature raises `TypeError`. A bare mock accepts
+both silently, and the test stops pinning down the boundary it exists to protect. Spec the port, never an
+`api/infrastructure/` adapter. Async port methods become `AsyncMock` children on their own — keep using
+`assert_awaited_once_with`.
+
+If the autospec rejects a call, fix the call — or the port declaration if that is what is wrong (a missing
+`self` on an abstract method silently shifts every parameter). Never loosen the spec to make a test pass.
+
+`api/tests/unit/use_case/test_providerrequestforwadingusecase.py` is the reference. Tests still on bare
+mocks are migrated when they are next touched.
+
+Cover:
 
 - Happy path (assert calls **and** payloads: `assert_awaited_once_with`, expire timestamps)
 - Each early return and each `match` arm that is a **different** branch (`try/except`, create vs update error)
@@ -506,12 +526,12 @@ Entity helpers used by the use case belong in domain unit tests, not extra use-c
 ```python
 @pytest.fixture
 def mock_model_tokenizer():
-    tokenizer = MagicMock()
+    tokenizer = create_autospec(ModelTokenizer, instance=True, spec_set=True)
     tokenizer.compute_tokens.side_effect = lambda texts: len(texts)
     return tokenizer
 ```
 
-Assert usage from the texts actually passed (`len(get_prompts())`, `len(get_completions())`). Rerank / embeddings return `[]` completions → `completion_tokens=0` (see `test_creatererankusecase.py`, `test_createembeddingsusecase.py`). OCR / audio have real completions — use `side_effect = [prompt_count, completion_count]` when the two calls need different values.
+Assert usage from the texts actually passed (`len(get_prompts())`, `len(get_completions())`). Rerank / embeddings return `[]` completions → `completion_tokens=0`. OCR / audio have real completions — use `side_effect = [prompt_count, completion_count]` when the two calls need different values.
 
 ### Integration endpoint
 

--- a/api/domain/model/_modelenvironmentalimpactscomputer.py
+++ b/api/domain/model/_modelenvironmentalimpactscomputer.py
@@ -7,6 +7,7 @@ from api.schemas.admin.providers import ProviderCarbonFootprintZone
 class ModelEnvironmentalImpactsComputer(ABC):
     @abstractmethod
     def compute(
+        self,
         model_active_params: int,
         model_total_params: int,
         model_zone: ProviderCarbonFootprintZone,

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -1,13 +1,21 @@
 from http import HTTPMethod
-from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
+from unittest.mock import AsyncMock, create_autospec, patch
 
 import pytest
 
 from api.domain import ForwardablePayload
+from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
 from api.domain.model.entities import ModelJsonResponse
 from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import TooBusyModelError
-from api.domain.provider import ProviderAdapter
+from api.domain.provider import (
+    ProviderAdapter,
+    ProviderAdapterBuilder,
+    ProviderClient,
+    ProviderLoadBalancer,
+    ProviderMetricsLogger,
+    ProviderRepository,
+)
 from api.domain.provider.entities import (
     ProviderFormattedRequest,
     ProviderFormattedResponse,
@@ -16,6 +24,7 @@ from api.domain.provider.entities import (
 )
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import Limit, LimitType
+from api.domain.router import RouterRateLimiter, RouterRepository
 from api.domain.router.entities import RouterRateLimitState, RpmRateLimitState
 from api.domain.router.errors import (
     RouterHasNoProvidersError,
@@ -61,16 +70,51 @@ class ForwardingTestUseCase(ProviderRequestForwardingUseCase[ForwardingTestComma
 
 @pytest.fixture
 def model_tokenizer():
-    tokenizer = MagicMock()
+    tokenizer = create_autospec(ModelTokenizer, instance=True, spec_set=True)
     tokenizer.compute_tokens.side_effect = lambda texts: len(texts)
     return tokenizer
 
 
 @pytest.fixture
 def model_environmental_impacts_computer():
-    computer = MagicMock()
+    computer = create_autospec(ModelEnvironmentalImpactsComputer, instance=True, spec_set=True)
     computer.compute.return_value = EnvironmentalImpacts(kgCO2eq=1.0, kWh=2.0)
     return computer
+
+
+@pytest.fixture
+def provider_adapter_builder():
+    return create_autospec(ProviderAdapterBuilder, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def provider_client():
+    return create_autospec(ProviderClient, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def provider_load_balancer():
+    return create_autospec(ProviderLoadBalancer, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def provider_metrics_logger():
+    return create_autospec(ProviderMetricsLogger, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def provider_repository():
+    return create_autospec(ProviderRepository, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def router_rate_limiter():
+    return create_autospec(RouterRateLimiter, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def router_repository():
+    return create_autospec(RouterRepository, instance=True, spec_set=True)
 
 
 @pytest.fixture
@@ -127,18 +171,25 @@ def user_with_router_access():
 def use_case(
     model_environmental_impacts_computer,
     model_tokenizer,
+    provider_adapter_builder,
+    provider_client,
+    provider_load_balancer,
+    provider_metrics_logger,
+    provider_repository,
+    router_rate_limiter,
+    router_repository,
     usage_recorder,
 ) -> ForwardingTestUseCase:
     return ForwardingTestUseCase(
         model_environmental_impacts_computer=model_environmental_impacts_computer,
         model_tokenizer=model_tokenizer,
-        provider_adapter_builder=MagicMock(),
-        provider_client=AsyncMock(),
-        provider_load_balancer=AsyncMock(),
-        provider_metrics_logger=AsyncMock(),
-        provider_repository=AsyncMock(),
-        router_rate_limiter=AsyncMock(),
-        router_repository=AsyncMock(),
+        provider_adapter_builder=provider_adapter_builder,
+        provider_client=provider_client,
+        provider_load_balancer=provider_load_balancer,
+        provider_metrics_logger=provider_metrics_logger,
+        provider_repository=provider_repository,
+        router_rate_limiter=router_rate_limiter,
+        router_repository=router_repository,
         usage_recorder=usage_recorder,
     )
 


### PR DESCRIPTION
## Overview

Resolves #988.

The forwarding use-case tests built their port doubles with bare `MagicMock()` / `AsyncMock()`. A bare mock accepts any attribute and any call signature, so a test could call a port method with an argument the port never declared — or that no longer exists — and still pass. The suite silently stopped pinning down the very boundary it exists to protect.

Every port double used by `ProviderRequestForwardingUseCase` is now derived from the domain port itself, so an unknown attribute or a wrong signature raises at call time:

```python
# before
provider_repository=AsyncMock(),
router_repository=AsyncMock(),

# after
@pytest.fixture
def provider_repository():
    return create_autospec(ProviderRepository, instance=True, spec_set=True)
```

**Where the fixtures actually live.** The issue points at `test_createocrusecase.py`, `test_createembeddingsusecase.py` and `test_creatererankusecase.py`. Since it was written, `e53e5adf` (#1008) deduplicated them: the three files each held the *same* 9 bare port fixtures and ~15 tests of the inherited forwarding logic (~770 lines apiece), which became a single 20-test suite in `api/tests/unit/use_case/test_providerrequestforwadingusecase.py` (-2297 / +557 lines), driven by a `ForwardingTestUseCase` stub instead of three concrete use cases. That consolidated file holds exactly the 9 bare port doubles the issue counts, alongside the already-migrated `usage_recorder` and `_mock_adapter`, and is what this PR changes. The three original files need no edit and satisfy the "no infrastructure class" criterion trivially: they have no fixtures left at all.

`AGENTS.md` is updated in the same breath, so the documented convention matches what the code now does.

**Definition of Done:**

- [x] The 9 remaining port doubles use `create_autospec(<Port>, instance=True, spec_set=True)`: `ModelTokenizer`, `ModelEnvironmentalImpactsComputer`, `ProviderAdapterBuilder`, `ProviderClient`, `ProviderLoadBalancer`, `ProviderMetricsLogger`, `ProviderRepository`, `RouterRateLimiter`, `RouterRepository`
- [x] Each double is specced against the **domain port** under `api/domain/`; no fixture in the file references `api/infrastructure/`
- [x] The 7 doubles that were inline in the `use_case` fixture became named fixtures, matching the existing `usage_recorder` style
- [x] The single call site the autospec rejected was fixed at its source — a missing `self` on a port declaration — not worked around by loosening the spec
- [x] `pytest api/tests/unit` passes: **659 passed**, same 20 tests in the migrated file
- [x] Mutation check: renaming a parameter on a specced port method now fails the corresponding tests (evidence below)
- [x] `AGENTS.md` documents autospec as the port-double convention for unit use-case tests

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [x] Updated or added documentation — `AGENTS.md` "Unit use case" section
- [x] Updated or added unit tests
- [ ] Updated or added integration tests — *N/A: no runtime behaviour changed. Run anyway to confirm: **649 passed, 1 skipped**.*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks — `pre-commit run --files $(git diff origin/main...HEAD --name-only)` → ruff and ruff format passed

**`api/sql/models.py` is not modified by this PR** — no schema change, no Alembic revision needed.

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

None of these apply: no migration, no configuration change, no new or changed environment variable. Nothing to do at deploy time.

## Additional Notes

**1. A latent defect the autospec surfaced.** `ModelEnvironmentalImpactsComputer.compute` was declared **without `self`**:

```python
@abstractmethod
def compute(model_active_params: int, model_total_params: int, ...) -> EnvironmentalImpacts:
```

`create_autospec` drops the first parameter as the receiver, so `model_active_params` was being consumed in place of `self` and every real call site was rejected. `EcologitModelEnvironmentalImpactsComputer.compute` already had `self` — only the port declaration was wrong, which is why nothing broke at runtime and no test could see it. Fixed in `2c921c1d`: one line, no behaviour change. This is exactly the class of drift the issue targets.

**2. Mutation evidence.** The issue cites `_build_target_url`, which lives on the HTTP adapters under `api/infrastructure/` and is not one of the ports specced here. The check was therefore run on two ports this PR does spec. Both mutations were reverted afterwards; the working tree is clean.

| Mutation on the port | Before this PR | After this PR |
|---|---|---|
| `RouterRepository.get_router_by_name_or_alias`: `name_or_alias` → `name_or_alias_renamed` | 20 passed | **8 failed**, 12 passed |
| `ModelEnvironmentalImpactsComputer.compute`: `model_zone` → `model_zone_renamed` | 20 passed | **2 failed**, 18 passed |

**3. Deliberately out of scope.** `api/tests/unit/use_case/audio/test_createaudiotranscriptionsusecase.py` builds the same 9 ports with bare mocks for `CreateAudioTranscriptionsUseCase`, itself a `ProviderRequestForwardingUseCase` subclass. Its tests stub `_resolve_router` / `_check_rate_limits` / `_send_request` wholesale, so no port is ever called through those doubles and autospeccing them would protect nothing today. Not named in the issue; left as a follow-up.
