### PR TITLE
feat(rate-limiting): reject oversized prompt requests before the provider call

### DIFF
--- a/api/domain/router/_routerratelimiter.py
+++ b/api/domain/router/_routerratelimiter.py
@@ -6,7 +6,7 @@ from api.domain.router.entities import RouterRateLimitState
 
 class RouterRateLimiter(ABC):
     @abstractmethod
-    async def get_rate_limit_state(self, user_id: int, router_limits: list[Limit], router_id: int, prompt_tokens: int) -> RouterRateLimitState:
+    async def get_rate_limit_state(self, user_id: int, router_limits: list[Limit], router_id: int) -> RouterRateLimitState:
         pass
 
     @abstractmethod

--- a/api/domain/router/entities.py
+++ b/api/domain/router/entities.py
@@ -87,9 +87,13 @@ class RouterRateLimitState(BaseModel):
     rpm: Annotated[RpmRateLimitState, Field(default_factory=RpmRateLimitState)]
     rpd: Annotated[RpdRateLimitState, Field(default_factory=RpdRateLimitState)]
 
-    @property
-    def exceeded_limits(self) -> list[LimitType]:
-        return [limit.value for limit in LimitType if getattr(self, limit.value).remaining <= 0 and getattr(self, limit.value).value is not None]
+    def exceeded_limits(self, prompt_tokens: int) -> list[LimitType]:
+        # floor at 1 so a zero-token request is still blocked by a value == 0 limit
+        token_cost = max(prompt_tokens, 1)
+        costs = {LimitType.TPM: token_cost, LimitType.TPD: token_cost, LimitType.RPM: 1, LimitType.RPD: 1}
+        return [
+            limit.value for limit in LimitType if getattr(self, limit.value).value is not None and getattr(self, limit.value).remaining < costs[limit]
+        ]
 
     @classmethod
     def admin_rate_limit_state(cls) -> "RouterRateLimitState":

--- a/api/infrastructure/redis/_redisrouterratelimiter.py
+++ b/api/infrastructure/redis/_redisrouterratelimiter.py
@@ -28,7 +28,7 @@ class RedisRouterRateLimiter(RouterRateLimiter):
             case LimitingStrategy.SLIDING_WINDOW:
                 self.strategy = strategies.SlidingWindowCounterRateLimiter(storage=self.redis_storage)
 
-    async def get_rate_limit_state(self, user_id: int, router_limits: list[Limit], router_id: int, prompt_tokens: int) -> RouterRateLimitState:
+    async def get_rate_limit_state(self, user_id: int, router_limits: list[Limit], router_id: int) -> RouterRateLimitState:
         state = RouterRateLimitState(rpm=RpmRateLimitState(), rpd=RpdRateLimitState(), tpm=TpmRateLimitState(), tpd=TpdRateLimitState())
 
         for limit in router_limits:

--- a/api/tests/integration/endpoints/test_embeddings.py
+++ b/api/tests/integration/endpoints/test_embeddings.py
@@ -18,7 +18,7 @@ from api.schemas.models import ModelType
 from api.tests.helpers import INVALID_API_KEY, create_key
 from api.tests.integration.conftest import override_global_context
 from api.tests.integration.endpoints.utils import DEFAULT_PROVIDER_URL, mock_embeddings_responses
-from api.tests.integration.factories.sql import LimitSQLFactory, RouterSQLFactory, UserSQLFactory
+from api.tests.integration.factories.sql import RouterSQLFactory, UserSQLFactory
 from api.tests.integration.factories.tei import TeiEmbeddingsResponseFactory
 from api.utils.variables import EndpointRoute
 
@@ -26,7 +26,6 @@ URL = f"/v1{EndpointRoute.EMBEDDINGS}"
 
 DEFAULT_MODEL_NAME = "embeddings-router"
 DEFAULT_INPUT = "The sun is shining."
-MOCKED_PROMPT_TOKENS = 10
 SAMPLE_VALIDATION_ERRORS = [{"type": "missing", "loc": ["input"], "msg": "Field required", "input": {}}]
 
 
@@ -39,12 +38,6 @@ def _valid_body(**overrides) -> dict:
     return body
 
 
-def _allow_requests(role, router) -> None:
-    # set both high to leave TPM the only gate
-    LimitSQLFactory(role=role, router=router, type=LimitType.RPM, value=1000)
-    LimitSQLFactory(role=role, router=router, type=LimitType.RPD, value=1000)
-
-
 @pytest.mark.asyncio(loop_scope="session")
 class TestCreateEmbeddings:
     @pytest_asyncio.fixture(autouse=True)
@@ -54,7 +47,7 @@ class TestCreateEmbeddings:
         self.router_owner = UserSQLFactory(name="Bob", email="bob@example.com", admin_user=True)
 
         mock_tokenizer = MagicMock()
-        mock_tokenizer.encode.return_value = [0] * MOCKED_PROMPT_TOKENS
+        mock_tokenizer.encode.return_value = [0] * 10
         with override_global_context(redis_pool=test_redis_pool, _tokenizer=mock_tokenizer):
             yield
 
@@ -121,70 +114,6 @@ class TestCreateEmbeddings:
         provider_json = json.loads(route.calls[0].request.content)
         assert "dimensions" not in provider_json
         assert None not in provider_json.values()
-
-    @respx.mock
-    async def test_prompt_larger_than_remaining_tokens_returns_429(self, client: AsyncClient, db_session):
-        router = RouterSQLFactory(
-            user=self.router_owner,
-            name=DEFAULT_MODEL_NAME,
-            type=ModelType.TEXT_EMBEDDINGS_INFERENCE,
-            providers=1,
-            providers__type=ProviderType.TEI,
-            providers__url=DEFAULT_PROVIDER_URL,
-        )
-        _allow_requests(role=self.user.role, router=router)
-        # one token short of what the mocked tokenizer charges for the prompt, so the fresh window cannot fit it
-        LimitSQLFactory(role=self.user.role, router=router, type=LimitType.TPM, value=MOCKED_PROMPT_TOKENS - 1)
-        await db_session.flush()
-
-        # the provider answers 200 here, so a 429 can only come from a rejection made before the forward
-        route = mock_embeddings_responses(
-            respx_mock=respx,
-            provider_type=ProviderType.TEI,
-            body=TeiEmbeddingsResponseFactory(),
-            status_code=TeiEmbeddingsResponseFactory._status_code,
-        )
-
-        response = await client.post(
-            url=URL,
-            headers={"Authorization": f"Bearer {self.key.token}"},
-            json=_valid_body(),
-        )
-
-        assert response.status_code == 429, response.text
-        assert response.json().get("detail") == "Token limit per minute exceeded."
-        assert not route.called
-
-    @respx.mock
-    async def test_prompt_larger_than_window_left_by_a_previous_request_returns_429(self, client: AsyncClient, db_session):
-        router = RouterSQLFactory(
-            user=self.router_owner,
-            name=DEFAULT_MODEL_NAME,
-            type=ModelType.TEXT_EMBEDDINGS_INFERENCE,
-            providers=1,
-            providers__type=ProviderType.TEI,
-            providers__url=DEFAULT_PROVIDER_URL,
-        )
-        _allow_requests(role=self.user.role, router=router)
-        # room for one prompt but not for two, so only the window left by the first request can reject the second
-        LimitSQLFactory(role=self.user.role, router=router, type=LimitType.TPM, value=2 * MOCKED_PROMPT_TOKENS - 1)
-        await db_session.flush()
-
-        route = mock_embeddings_responses(
-            respx_mock=respx,
-            provider_type=ProviderType.TEI,
-            body=TeiEmbeddingsResponseFactory(),
-            status_code=TeiEmbeddingsResponseFactory._status_code,
-        )
-        headers = {"Authorization": f"Bearer {self.key.token}"}
-
-        first_response = await client.post(url=URL, headers=headers, json=_valid_body())
-        second_response = await client.post(url=URL, headers=headers, json=_valid_body())
-
-        assert first_response.status_code == 200, first_response.text
-        assert second_response.status_code == 429, second_response.text
-        assert second_response.json().get("detail") == "Token limit per minute exceeded."
-        assert route.call_count == 1
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/test_embeddings.py
+++ b/api/tests/integration/endpoints/test_embeddings.py
@@ -11,14 +11,14 @@ from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider.entities import ProviderType
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
+from api.domain.role.entities import LimitType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
-from api.schemas.admin.roles import LimitType
 from api.schemas.models import ModelType
 from api.tests.helpers import INVALID_API_KEY, create_key
 from api.tests.integration.conftest import override_global_context
 from api.tests.integration.endpoints.utils import DEFAULT_PROVIDER_URL, mock_embeddings_responses
-from api.tests.integration.factories.sql import RouterSQLFactory, UserSQLFactory
+from api.tests.integration.factories.sql import LimitSQLFactory, RouterSQLFactory, UserSQLFactory
 from api.tests.integration.factories.tei import TeiEmbeddingsResponseFactory
 from api.utils.variables import EndpointRoute
 
@@ -26,6 +26,7 @@ URL = f"/v1{EndpointRoute.EMBEDDINGS}"
 
 DEFAULT_MODEL_NAME = "embeddings-router"
 DEFAULT_INPUT = "The sun is shining."
+MOCKED_PROMPT_TOKENS = 10
 SAMPLE_VALIDATION_ERRORS = [{"type": "missing", "loc": ["input"], "msg": "Field required", "input": {}}]
 
 
@@ -38,6 +39,12 @@ def _valid_body(**overrides) -> dict:
     return body
 
 
+def _allow_requests(role, router) -> None:
+    # set both high to leave TPM the only gate
+    LimitSQLFactory(role=role, router=router, type=LimitType.RPM, value=1000)
+    LimitSQLFactory(role=role, router=router, type=LimitType.RPD, value=1000)
+
+
 @pytest.mark.asyncio(loop_scope="session")
 class TestCreateEmbeddings:
     @pytest_asyncio.fixture(autouse=True)
@@ -47,7 +54,7 @@ class TestCreateEmbeddings:
         self.router_owner = UserSQLFactory(name="Bob", email="bob@example.com", admin_user=True)
 
         mock_tokenizer = MagicMock()
-        mock_tokenizer.encode.return_value = [0] * 10
+        mock_tokenizer.encode.return_value = [0] * MOCKED_PROMPT_TOKENS
         with override_global_context(redis_pool=test_redis_pool, _tokenizer=mock_tokenizer):
             yield
 
@@ -114,6 +121,70 @@ class TestCreateEmbeddings:
         provider_json = json.loads(route.calls[0].request.content)
         assert "dimensions" not in provider_json
         assert None not in provider_json.values()
+
+    @respx.mock
+    async def test_prompt_larger_than_remaining_tokens_returns_429(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(
+            user=self.router_owner,
+            name=DEFAULT_MODEL_NAME,
+            type=ModelType.TEXT_EMBEDDINGS_INFERENCE,
+            providers=1,
+            providers__type=ProviderType.TEI,
+            providers__url=DEFAULT_PROVIDER_URL,
+        )
+        _allow_requests(role=self.user.role, router=router)
+        # one token short of what the mocked tokenizer charges for the prompt, so the fresh window cannot fit it
+        LimitSQLFactory(role=self.user.role, router=router, type=LimitType.TPM, value=MOCKED_PROMPT_TOKENS - 1)
+        await db_session.flush()
+
+        # the provider answers 200 here, so a 429 can only come from a rejection made before the forward
+        route = mock_embeddings_responses(
+            respx_mock=respx,
+            provider_type=ProviderType.TEI,
+            body=TeiEmbeddingsResponseFactory(),
+            status_code=TeiEmbeddingsResponseFactory._status_code,
+        )
+
+        response = await client.post(
+            url=URL,
+            headers={"Authorization": f"Bearer {self.key.token}"},
+            json=_valid_body(),
+        )
+
+        assert response.status_code == 429, response.text
+        assert response.json().get("detail") == "Token limit per minute exceeded."
+        assert not route.called
+
+    @respx.mock
+    async def test_prompt_larger_than_window_left_by_a_previous_request_returns_429(self, client: AsyncClient, db_session):
+        router = RouterSQLFactory(
+            user=self.router_owner,
+            name=DEFAULT_MODEL_NAME,
+            type=ModelType.TEXT_EMBEDDINGS_INFERENCE,
+            providers=1,
+            providers__type=ProviderType.TEI,
+            providers__url=DEFAULT_PROVIDER_URL,
+        )
+        _allow_requests(role=self.user.role, router=router)
+        # room for one prompt but not for two, so only the window left by the first request can reject the second
+        LimitSQLFactory(role=self.user.role, router=router, type=LimitType.TPM, value=2 * MOCKED_PROMPT_TOKENS - 1)
+        await db_session.flush()
+
+        route = mock_embeddings_responses(
+            respx_mock=respx,
+            provider_type=ProviderType.TEI,
+            body=TeiEmbeddingsResponseFactory(),
+            status_code=TeiEmbeddingsResponseFactory._status_code,
+        )
+        headers = {"Authorization": f"Bearer {self.key.token}"}
+
+        first_response = await client.post(url=URL, headers=headers, json=_valid_body())
+        second_response = await client.post(url=URL, headers=headers, json=_valid_body())
+
+        assert first_response.status_code == 200, first_response.text
+        assert second_response.status_code == 429, second_response.text
+        assert second_response.json().get("detail") == "Token limit per minute exceeded."
+        assert route.call_count == 1
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/redis/test_redisrouterratelimiter.py
+++ b/api/tests/integration/redis/test_redisrouterratelimiter.py
@@ -63,8 +63,8 @@ class TestRedisRouterRateLimiter:
         assert result.tpm.value == 50
         assert result.tpm.remaining == 50
         assert result.tpm.reset > time.time()
-        assert LimitType.RPM.value in result.exceeded_limits
-        assert LimitType.TPM.value not in result.exceeded_limits
+        assert LimitType.RPM.value in result.exceeded_limits(prompt_tokens=0)
+        assert LimitType.TPM.value not in result.exceeded_limits(prompt_tokens=0)
 
     async def test_update_rate_limit_state_decrements_rpm_remaining(self, rate_limiter: RedisRouterRateLimiter):
         # Arrange
@@ -124,7 +124,7 @@ class TestRedisRouterRateLimiter:
         # Assert
         assert result.rpm.remaining == 0
         assert result.rpm.reset > time.time()
-        assert LimitType.RPM.value in result.exceeded_limits
+        assert LimitType.RPM.value in result.exceeded_limits(prompt_tokens=0)
 
     async def test_reset_clears_rate_limit_state(self, rate_limiter: RedisRouterRateLimiter, redis_client: AsyncRedis):
         # Arrange

--- a/api/tests/integration/redis/test_redisrouterratelimiter.py
+++ b/api/tests/integration/redis/test_redisrouterratelimiter.py
@@ -40,7 +40,7 @@ class TestRedisRouterRateLimiter:
         limits = limits_factory(router_id=router_id, rpm=10)
 
         # Act
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.rpm.value == 10
@@ -54,7 +54,7 @@ class TestRedisRouterRateLimiter:
         limits = limits_factory(router_id=router_id, rpm=0, tpm=50)
 
         # Act
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.rpm.value == 0
@@ -74,7 +74,7 @@ class TestRedisRouterRateLimiter:
 
         # Act
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.rpm.remaining == 4
@@ -88,7 +88,7 @@ class TestRedisRouterRateLimiter:
 
         # Act
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.rpm.remaining == 9
@@ -104,7 +104,7 @@ class TestRedisRouterRateLimiter:
 
         # Act
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=12)
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.tpm.remaining == 38
@@ -119,7 +119,7 @@ class TestRedisRouterRateLimiter:
         # Act
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.rpm.remaining == 0
@@ -134,7 +134,7 @@ class TestRedisRouterRateLimiter:
         await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=30)
 
         # Act
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=25)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert result.tpm.remaining == 20
@@ -151,7 +151,7 @@ class TestRedisRouterRateLimiter:
 
         # Act
         await rate_limiter.reset()
-        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=0)
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id)
 
         # Assert
         assert await redis_client.keys("LIMITS*") == []

--- a/api/tests/integration/redis/test_redisrouterratelimiter.py
+++ b/api/tests/integration/redis/test_redisrouterratelimiter.py
@@ -126,6 +126,21 @@ class TestRedisRouterRateLimiter:
         assert result.rpm.reset > time.time()
         assert LimitType.RPM.value in result.exceeded_limits(prompt_tokens=0)
 
+    async def test_get_rate_limit_state_exceeds_tpm_when_prompt_is_larger_than_remaining(self, rate_limiter: RedisRouterRateLimiter):
+        # Arrange
+        user_id = 1008
+        router_id = 2008
+        limits = limits_factory(router_id=router_id, rpm=10, tpm=50)
+        await rate_limiter.update_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=30)
+
+        # Act
+        result = await rate_limiter.get_rate_limit_state(user_id=user_id, router_limits=limits, router_id=router_id, prompt_tokens=25)
+
+        # Assert
+        assert result.tpm.remaining == 20
+        assert LimitType.TPM.value in result.exceeded_limits(prompt_tokens=25)
+        assert LimitType.RPM.value not in result.exceeded_limits(prompt_tokens=25)
+
     async def test_reset_clears_rate_limit_state(self, rate_limiter: RedisRouterRateLimiter, redis_client: AsyncRedis):
         # Arrange
         user_id = 1007

--- a/api/tests/unit/domain/router/test_routerentities.py
+++ b/api/tests/unit/domain/router/test_routerentities.py
@@ -1,3 +1,5 @@
+from api.domain.role.entities import LimitType
+from api.domain.router.entities import RouterRateLimitState, TpdRateLimitState, TpmRateLimitState
 from api.tests.unit.use_case.factories import RouterFactory
 
 
@@ -29,3 +31,54 @@ class TestRouterIsBillable:
 
         # Act & Assert
         assert router.is_billable is True
+
+
+class TestRouterRateLimitStateExceededLimits:
+    @staticmethod
+    def _state_with_tpm(remaining: int) -> RouterRateLimitState:
+        # start with admin state - no limits
+        state = RouterRateLimitState.admin_rate_limit_state()
+        # set user's TPM limits to 100, and remaining to arg value
+        state.tpm = TpmRateLimitState(value=100, remaining=remaining)
+        return state
+
+    @staticmethod
+    def _state_with_tpd(remaining: int) -> RouterRateLimitState:
+        state = RouterRateLimitState.admin_rate_limit_state()
+        state.tpd = TpdRateLimitState(value=1_000, remaining=remaining)
+        return state
+
+    def test_should_report_tpm_when_the_prompt_is_larger_than_the_remaining_tokens(self):
+        # Arrange
+        state = self._state_with_tpm(remaining=9)
+
+        # Act & Assert
+        assert state.exceeded_limits(prompt_tokens=10) == [LimitType.TPM]
+
+    def test_should_report_nothing_when_the_prompt_is_worth_exactly_the_remaining_tokens(self):
+        # Arrange
+        state = self._state_with_tpm(remaining=10)
+
+        # Act & Assert
+        assert state.exceeded_limits(prompt_tokens=10) == []
+
+    def test_should_report_tpm_when_a_prompt_worth_no_token_meets_an_empty_window(self):
+        # Arrange
+        state = self._state_with_tpm(remaining=0)
+
+        # Act & Assert
+        assert state.exceeded_limits(prompt_tokens=0) == [LimitType.TPM]
+
+    def test_should_report_tpd_when_the_prompt_is_larger_than_the_remaining_daily_tokens(self):
+        # Arrange
+        state = self._state_with_tpd(remaining=9)
+
+        # Act & Assert
+        assert state.exceeded_limits(prompt_tokens=10) == [LimitType.TPD]
+
+    def test_should_report_nothing_when_no_limit_is_configured(self):
+        # Arrange
+        state = RouterRateLimitState.admin_rate_limit_state()
+
+        # Act & Assert
+        assert state.exceeded_limits(prompt_tokens=10_000) == []

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -25,13 +25,8 @@ from api.domain.provider.entities import (
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import Limit, LimitType
 from api.domain.router import RouterRateLimiter, RouterRepository
-from api.domain.router.entities import RouterRateLimitState, RpmRateLimitState
-from api.domain.router.errors import (
-    RouterHasNoProvidersError,
-    RouterHasWrongTypeError,
-    RouterNotFoundError,
-    RouterRateLimitExceededError,
-)
+from api.domain.router.entities import RouterRateLimitState, RpmRateLimitState, TpmRateLimitState
+from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.usage import UsageRecorder
 from api.domain.usage.entities import EnvironmentalImpacts, Usage
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
@@ -385,6 +380,30 @@ class TestCheckRateLimits:
             prompt_tokens=1,
         )
         use_case.router_rate_limiter.update_rate_limit_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_return_rate_limit_exceeded_error_without_updating_state_when_prompt_exceeds_remaining_tokens(
+        self, use_case, user_with_router_access, router
+    ):
+        # Arrange
+        rate_limit_state = RouterRateLimitState.admin_rate_limit_state()
+        rate_limit_state.tpm = TpmRateLimitState(value=100, remaining=9, reset=0)
+        use_case.router_rate_limiter.get_rate_limit_state.return_value = rate_limit_state
+
+        # Act
+        result = await use_case._check_rate_limits(authenticated_user=user_with_router_access, router=router, prompt_tokens=10)
+
+        # Assert
+        assert isinstance(result, RouterRateLimitExceededError)
+        assert result.id == router.id
+        assert result.limit_type == LimitType.TPM
+        assert result.headers == rate_limit_state.build_limit_headers
+        use_case.router_rate_limiter.get_rate_limit_state.assert_awaited_once_with(
+            user_id=user_with_router_access.id,
+            router_limits=[Limit(router_id=1, type=LimitType.RPM, value=100)],
+            router_id=router.id,
+            prompt_tokens=10,
+        )
 
     @pytest.mark.asyncio
     async def test_should_update_rate_limit_state_when_non_admin_user_is_within_limits(self, use_case, user_with_router_access, router):

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -377,7 +377,6 @@ class TestCheckRateLimits:
             user_id=user_with_router_access.id,
             router_limits=[Limit(router_id=1, type=LimitType.RPM, value=100)],
             router_id=router.id,
-            prompt_tokens=1,
         )
         use_case.router_rate_limiter.update_rate_limit_state.assert_not_awaited()
 
@@ -402,7 +401,6 @@ class TestCheckRateLimits:
             user_id=user_with_router_access.id,
             router_limits=[Limit(router_id=1, type=LimitType.RPM, value=100)],
             router_id=router.id,
-            prompt_tokens=10,
         )
 
     @pytest.mark.asyncio

--- a/api/use_cases/_providerrequestforwardingusecase.py
+++ b/api/use_cases/_providerrequestforwardingusecase.py
@@ -135,7 +135,7 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
                 router_id=router.id,
                 prompt_tokens=prompt_tokens,
             )
-            exceeded_limits = rate_limit_state.exceeded_limits
+            exceeded_limits = rate_limit_state.exceeded_limits(prompt_tokens=prompt_tokens)
             if exceeded_limits:
                 limit_type = exceeded_limits[0]
                 return RouterRateLimitExceededError(id=router.id, limit_type=limit_type, headers=rate_limit_state.build_limit_headers)

--- a/api/use_cases/_providerrequestforwardingusecase.py
+++ b/api/use_cases/_providerrequestforwardingusecase.py
@@ -133,7 +133,6 @@ class ProviderRequestForwardingUseCase[TCommand: ForwardingCommand, TData]:
                 user_id=authenticated_user.id,
                 router_limits=limits,
                 router_id=router.id,
-                prompt_tokens=prompt_tokens,
             )
             exceeded_limits = rate_limit_state.exceeded_limits(prompt_tokens=prompt_tokens)
             if exceeded_limits:


### PR DESCRIPTION
## Overview

Resolves #997.

TPM/TPD pre-checks only rejected a request when `remaining <= 0`. A request whose `prompt_tokens` were larger than the remaining budget still reached the provider and was only charged afterwards, past the quota.

`RouterRateLimitState.exceeded_limits` now takes the current request's `prompt_tokens` and treats a token limit as exceeded when the prompt does not fit in the remaining budget (`remaining < cost`). Each limit type now carries a cost: the prompt's token count for TPM/TPD, and `1` for RPM/RPD (request limits behave exactly as before). The token cost is floored at `1`, which keeps a zero-token prompt blocked by a limit set to `0`.

The check lives in the domain entity rather than the limiter: the unused `prompt_tokens` parameter of `get_rate_limit_state` was therefore removed from the Redis adapter.

OCR, embeddings, rerank and audio transcriptions are all thin subclasses of `ProviderRequestForwardingUseCase`, so they inherit the new check from its single pre-check call site: no per-endpoint change was needed.

- [x] A non-admin request with `prompt_tokens > tpm.remaining` (or `tpd.remaining`) returns
      `RouterRateLimitExceededError` / HTTP 429 **before** `provider_client.forward_request`
- [x] A request with `prompt_tokens <= remaining` still passes and proceeds as today
- [x] `prompt_tokens` is actually used in the rate-limit check path (`exceeded_limits`), and the dead
      parameter is gone from the read path
- [x] Request limits (RPM/RPD) behave exactly as before: they still block only once the user has no
      requests left in the window
- [x] No changes to the legacy `Limiter` / `hooks_decorator`
- [x] Compatible with #996: the pre-check reads the state and is independent of the update call, so it
      still prevents oversized-prompt overshoot once the update moves to hooks
- [x] Unit tests on the state and on the shared forwarding use case; integration tests on the Redis
      limiter and end-to-end on `/v1/embeddings`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

No change to the HTTP contract, the configuration or the database schema.

## Check lists

### Review checklist

- [ ] Updated or added documentation — `docs/.../rate_limiting.mdx` does not document the
      overshoot semantics (its "Setup router rate limits" section is still marked under construction),
      so there was nothing to correct. No OpenAPI change either: no schema was touched.
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If `api/sql/models.py` has been modified, please confirm that the following steps have been completed:**

`api/sql/models.py` is not modified by this PR — no migration is required.

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

None of the above apply: no migration, no configuration change, no new environment variable.

## Additional Notes

Worth a closer look during review:

- **The `max(prompt_tokens, 1)` floor** in `exceeded_limits`. It preserves today's behaviour for a zero-token request meeting a limit configured to `0`. Without it such a request would slip through (`0 < 0` is false). 
Covered by `test_should_report_tpm_when_a_prompt_worth_no_token_meets_an_empty_window`
