### PR TITLE
refacto(schemas): map domain entities to responses with from_attributes only

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.95%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.75%", "color": "green"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ Every response includes `object`:
 
 **Single resource:**
 ```json
-{ "object": "key", "id": 1, "name": "my-key", "user": 42, "created": 1704067200 }
+{ "object": "key", "id": 1, "name": "my-key", "user_id": 42, "created": 1704067200 }
 ```
 
 **Paginated list:**
@@ -213,16 +213,14 @@ Never return a bare array. Items inside `data` keep their own `object` discrimin
 | Domain entity | `*_id` | `user_id`, `role_id`, `router_id` |
 | Path params | `*_id` | `role_id`, `router_id`, `user_id` |
 | Query filters | `*_id` | `?role_id=1`, `?organization_id=2` |
-| Response FK fields | `*_id` (usually) | `user_id` in `RouterResponse`, `organization_id` in `UserResponse` |
-| Request body FK | often shortened | `CreateKeyBody.user`, `CreateUserBody.role` |
+| Response FK fields | `*_id` — always | `user_id` in `RouterResponse` and `KeyResponse`, `organization_id` in `UserResponse` |
+| Request body FK | sometimes shortened | `CreateKeyBody.user` (`CreateUserBody` uses `role_id`) |
 
-Map at the boundary:
+Responses never shorten a FK name: they carry the entity's `*_id` so `from_attributes` maps them without a mapper. Only request bodies shorten,
+and the endpoint expands them when building the command:
 ```python
 # endpoint → command
 CreateKeyCommand(user_id=body.user, ...)
-
-# domain → response (@model_validator)
-"user": data.user_id  # Key entity → KeyResponse
 ```
 
 ### Update requests are full replacements
@@ -244,7 +242,7 @@ Callers (playground `edit_entity`, e2e tests) must send the whole current form s
 - API: Unix seconds as `int` (`created`, `updated`, `expires`)
 - Domain and Postgres: timezone-aware UTC `datetime` — annotate entity fields with `UtcDatetime` from `api/domain/__init__.py`, and always build "now" with `datetime.now(tz=UTC)`
 - Repositories select and write the `timestamptz` columns directly — no `extract(epoch)` / `to_timestamp()`
-- Convert at the boundary only: `@field_validator` (request) or `@model_validator(mode="before")` (response). Request validators keep the field typed `int` (OpenAPI) and return a UTC `datetime` for the command. Keys also reject past timestamps (`CreateKeyBody`); user `expires` converts without that check so a past value expires the user — see `CreateUserBody` / `UserUpdateRequest` / `KeyResponse`. Command timestamp fields are typed `UtcDatetime` to match the entity; the dataclass does not convert.
+- Convert at the boundary only: `@field_validator` (request) or the `UnixTimestamp` annotated type (response, from `api/infrastructure/fastapi/schemas/__init__.py`). Both keep the field typed `int`, so the OpenAPI schema still documents an integer. Request validators return a UTC `datetime` for the command; keys also reject past timestamps (`CreateKeyBody`), while user `expires` converts without that check so a past value expires the user — see `CreateUserBody` / `UserUpdateRequest`. Command timestamp fields are typed `UtcDatetime` to match the entity; the dataclass does not convert.
 - Playground displays local time through `playground/app/shared/utils/timestamps.py`
 
 Full rationale: `adr/2026-08-27-datetime-handling.md`.
@@ -258,8 +256,22 @@ router_type: Annotated[ModelType, Field(alias="type", ...)]
 
 ### Mapping domain → API
 
-- Names align → `Response.model_validate(entity, from_attributes=True)`
-- Names differ → `@model_validator(mode="before")` (see `KeyResponse.from_key` in `api/infrastructure/fastapi/schemas/admin/keys.py`)
+Always `Response.model_validate(entity, from_attributes=True)` — never a hand-written `from_<noun>()` mapper. A mapper that re-lists every
+field is a second, implicit declaration of the schema: it drifts, and a field forgotten in it silently falls back to its default instead of
+raising. Declare the difference on the field instead:
+
+| Difference | Declare it as |
+|---|---|
+| `datetime` → Unix seconds | `Annotated[UnixTimestamp, Field(...)]` (or `UnixTimestamp \| None`) |
+| `object` discriminator | the field's own `Literal` default — `object: Annotated[Literal["key"], Field(default="key", ...)]` |
+| JSON key ≠ entity attribute | `Field(alias="type")` — `from_attributes` reads the attribute named by the alias |
+| Nested value object | declare the nested schema; `from_attributes` propagates (`RoleResponse.limits`, `Model.costs`) |
+
+The response never renames a field just to shorten it — name it after the entity attribute (`user_id`, not `user`).
+
+Last resort: a `@model_validator(mode="before")` when the response **restructures** the entity rather than renaming it. The single case
+today is `UsageResponse`, which nests `UsageRecord`'s flat counters under `usage`; it passes the record itself down instead of re-listing
+the other fields, so `from_attributes` still does all the field work.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ Callers (playground `edit_entity`, e2e tests) must send the whole current form s
 - Convert at the boundary only: `@field_validator` (request) or the `UnixTimestamp` annotated type (response, from `api/infrastructure/fastapi/schemas/__init__.py`). Both keep the field typed `int`, so the OpenAPI schema still documents an integer. Request validators return a UTC `datetime` for the command; keys also reject past timestamps (`CreateKeyBody`), while user `expires` converts without that check so a past value expires the user — see `CreateUserBody` / `UserUpdateRequest`. Command timestamp fields are typed `UtcDatetime` to match the entity; the dataclass does not convert.
 - Playground displays local time through `playground/app/shared/utils/timestamps.py`
 
-Full rationale: `adr/2026-08-27-datetime-handling.md`.
+Full rationale: `adr/2026-08-27-datetime-handling.md`, and `adr/2026-09-04-response-schema-mapping.md` for the response side.
 
 ### Aliases
 
@@ -272,6 +272,8 @@ The response never renames a field just to shorten it — name it after the enti
 Last resort: a `@model_validator(mode="before")` when the response **restructures** the entity rather than renaming it. The single case
 today is `UsageResponse`, which nests `UsageRecord`'s flat counters under `usage`; it passes the record itself down instead of re-listing
 the other fields, so `from_attributes` still does all the field work.
+
+Full rationale: `adr/2026-09-04-response-schema-mapping.md`.
 
 ---
 

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -6,6 +6,7 @@
 * **Related:**
   * [#960 — [clean-architecture] Standardize datetime handling across API and playground](https://github.com/etalab-ia/OpenGateLLM/issues/960)
   * [ADR 2026-01-07 — Migration to Clean Architecture](2026-01-07-clean-architecture-migration.md)
+  * [#1058 — [clean-architecture] Reduce response schema mapper boilerplate](https://github.com/etalab-ia/OpenGateLLM/issues/1058) — amends the response side of this ADR
 * **Decision Outcome:** Unix timestamps (`int`) at the HTTP boundary only, timezone-aware UTC `datetime` in the domain and in Postgres, local-timezone rendering in the playground.
 
 ---
@@ -69,23 +70,20 @@ def must_be_future_and_convert_to_datetime(cls, expires) -> None | datetime:
 
 User `expires` uses the same conversion without the future check, so a past timestamp expires the account immediately (and a full-replacement PATCH can resubmit an already-expired user).
 
-**Response** — a `@model_validator(mode="before")` maps the domain entity to the wire shape, converting each `datetime` with `int(value.timestamp())`:
+**Response** — the field is annotated `UnixTimestamp`, the API-boundary counterpart of `UtcDatetime`:
 
 ```python
-# api/infrastructure/fastapi/schemas/admin/keys.py — the reference implementation
-@model_validator(mode="before")
-@classmethod
-def from_key(cls, data):
-    if isinstance(data, Key):
-        return {
-            ...,
-            "expires": int(data.expires.timestamp()) if data.expires is not None else None,
-            "created": int(data.created.timestamp()),
-        }
-    return data
+# api/infrastructure/fastapi/schemas/__init__.py
+UnixTimestamp = Annotated[int, BeforeValidator(_to_unix_timestamp)]
+
+# api/infrastructure/fastapi/schemas/admin/keys.py
+expires: Annotated[UnixTimestamp | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]
+created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
 ```
 
-Endpoints keep calling `Response.model_validate(entity, from_attributes=True)`; the validator recognizes the entity and does the mapping. Schemas following this pattern: `admin/keys.py`, `admin/organizations.py`, `admin/roles.py`, `admin/routers.py`, `admin/providers.py`, `admin/users.py`, `me.py`, `models.py`, `usage.py`.
+Endpoints call `Response.model_validate(entity, from_attributes=True)`; Pydantic reads the entity's `datetime` attribute and the annotation converts it. The field stays typed `int`, so the OpenAPI schema is unchanged. Schemas following this pattern: `admin/keys.py`, `admin/organizations.py`, `admin/roles.py`, `admin/routers.py`, `admin/providers.py`, `admin/users.py`, `me.py`, `models.py`, `usage.py`.
+
+> **Amended 2026-09-04 (#1058)** — this originally read: a `@model_validator(mode="before")` per response schema, re-listing every field and calling `int(value.timestamp())` on each `datetime`. Applied to all nine schemas it came to 158 lines, 68 % of which were pure `data.x` → `"x"` copies, and it made the mapper a second, implicit declaration of the schema — a field forgotten in it silently fell back to its default instead of raising. The conversion moved onto the field itself; the mapping stayed at exactly one boundary. The generated OpenAPI schema is identical, type for type and description for description.
 
 ### Playground: local timezone, one helper
 
@@ -106,7 +104,7 @@ Endpoints keep calling `Response.model_validate(entity, from_attributes=True)`; 
 
 **Harder / to watch**
 
-* Every new response schema that carries a timestamp needs its `@model_validator(mode="before")`. Without it, `model_validate(entity, from_attributes=True)` would hand Pydantic a `datetime` for an `int` field and fail — loudly, which is the point.
+* Every new response timestamp field must be annotated `UnixTimestamp`, not `int`. Without it, `model_validate(entity, from_attributes=True)` hands Pydantic a `datetime` for an `int` field and fails — loudly, which is the point.
 * Sub-second precision is lost at the API boundary (`int(...timestamp())` truncates). That is the existing public contract and is unchanged by this ADR.
 
 **Unchanged**

--- a/adr/2026-08-27-datetime-handling.md
+++ b/adr/2026-08-27-datetime-handling.md
@@ -1,12 +1,12 @@
 # ADR - 2026-08-27 - Datetime handling across API, domain and playground
 
-* **Status:** Accepted
+* **Status:** Accepted — the *API boundary: `int`, converted in the schema* / **Response** paragraph is superseded by [ADR 2026-09-04](2026-09-04-response-schema-mapping.md). Everything else stands.
 * **Date:** 2026-08-27
 * **Authors:** Development Team
 * **Related:**
   * [#960 — [clean-architecture] Standardize datetime handling across API and playground](https://github.com/etalab-ia/OpenGateLLM/issues/960)
   * [ADR 2026-01-07 — Migration to Clean Architecture](2026-01-07-clean-architecture-migration.md)
-  * [#1058 — [clean-architecture] Reduce response schema mapper boilerplate](https://github.com/etalab-ia/OpenGateLLM/issues/1058) — amends the response side of this ADR
+  * [ADR 2026-09-04 — Response schema mapping](2026-09-04-response-schema-mapping.md) — supersedes the response half of the API boundary section
 * **Decision Outcome:** Unix timestamps (`int`) at the HTTP boundary only, timezone-aware UTC `datetime` in the domain and in Postgres, local-timezone rendering in the playground.
 
 ---
@@ -70,20 +70,23 @@ def must_be_future_and_convert_to_datetime(cls, expires) -> None | datetime:
 
 User `expires` uses the same conversion without the future check, so a past timestamp expires the account immediately (and a full-replacement PATCH can resubmit an already-expired user).
 
-**Response** — the field is annotated `UnixTimestamp`, the API-boundary counterpart of `UtcDatetime`:
+**Response** — a `@model_validator(mode="before")` maps the domain entity to the wire shape, converting each `datetime` with `int(value.timestamp())`:
 
 ```python
-# api/infrastructure/fastapi/schemas/__init__.py
-UnixTimestamp = Annotated[int, BeforeValidator(_to_unix_timestamp)]
-
-# api/infrastructure/fastapi/schemas/admin/keys.py
-expires: Annotated[UnixTimestamp | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]
-created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
+# api/infrastructure/fastapi/schemas/admin/keys.py — the reference implementation
+@model_validator(mode="before")
+@classmethod
+def from_key(cls, data):
+    if isinstance(data, Key):
+        return {
+            ...,
+            "expires": int(data.expires.timestamp()) if data.expires is not None else None,
+            "created": int(data.created.timestamp()),
+        }
+    return data
 ```
 
-Endpoints call `Response.model_validate(entity, from_attributes=True)`; Pydantic reads the entity's `datetime` attribute and the annotation converts it. The field stays typed `int`, so the OpenAPI schema is unchanged. Schemas following this pattern: `admin/keys.py`, `admin/organizations.py`, `admin/roles.py`, `admin/routers.py`, `admin/providers.py`, `admin/users.py`, `me.py`, `models.py`, `usage.py`.
-
-> **Amended 2026-09-04 (#1058)** — this originally read: a `@model_validator(mode="before")` per response schema, re-listing every field and calling `int(value.timestamp())` on each `datetime`. Applied to all nine schemas it came to 158 lines, 68 % of which were pure `data.x` → `"x"` copies, and it made the mapper a second, implicit declaration of the schema — a field forgotten in it silently fell back to its default instead of raising. The conversion moved onto the field itself; the mapping stayed at exactly one boundary. The generated OpenAPI schema is identical, type for type and description for description.
+Endpoints keep calling `Response.model_validate(entity, from_attributes=True)`; the validator recognizes the entity and does the mapping. Schemas following this pattern: `admin/keys.py`, `admin/organizations.py`, `admin/roles.py`, `admin/routers.py`, `admin/providers.py`, `admin/users.py`, `me.py`, `models.py`, `usage.py`.
 
 ### Playground: local timezone, one helper
 
@@ -104,7 +107,7 @@ Endpoints call `Response.model_validate(entity, from_attributes=True)`; Pydantic
 
 **Harder / to watch**
 
-* Every new response timestamp field must be annotated `UnixTimestamp`, not `int`. Without it, `model_validate(entity, from_attributes=True)` hands Pydantic a `datetime` for an `int` field and fails — loudly, which is the point.
+* Every new response schema that carries a timestamp needs its `@model_validator(mode="before")`. Without it, `model_validate(entity, from_attributes=True)` would hand Pydantic a `datetime` for an `int` field and fail — loudly, which is the point.
 * Sub-second precision is lost at the API boundary (`int(...timestamp())` truncates). That is the existing public contract and is unchanged by this ADR.
 
 **Unchanged**

--- a/adr/2026-09-04-response-schema-mapping.md
+++ b/adr/2026-09-04-response-schema-mapping.md
@@ -1,0 +1,101 @@
+# ADR - 2026-09-04 - Mapping domain entities to response schemas
+
+* **Status:** Accepted
+* **Date:** 2026-09-04
+* **Authors:** Development Team
+* **Related:**
+  * [#1058 — [clean-architecture] Reduce response schema mapper boilerplate](https://github.com/etalab-ia/OpenGateLLM/issues/1058)
+  * [ADR 2026-08-27 — Datetime handling across API, domain and playground](2026-08-27-datetime-handling.md) — supersedes its **Response** paragraph; the rest of that ADR stands
+  * [#960 — [clean-architecture] Standardize datetime handling across API and playground](https://github.com/etalab-ia/OpenGateLLM/issues/960)
+* **Decision Outcome:** `model_validate(entity, from_attributes=True)` does the field-by-field mapping; a response schema declares only what genuinely differs from its entity, on the field itself.
+
+---
+
+## Context
+
+[ADR 2026-08-27](2026-08-27-datetime-handling.md) settled where a `datetime` becomes an `int`, and prescribed a `@model_validator(mode="before")` per response schema to do it. [#960](https://github.com/etalab-ia/OpenGateLLM/issues/960) then generalized that mapper to every migrated resource. The pattern had a real origin — `KeyResponse` renamed `user_id` to `user`, which no automatic mapping could express — and `AGENTS.md` prescribed it.
+
+Applied to all ten response schemas, the cost became visible. Measured on `main` on 2026-09-04:
+
+| | count |
+|---|---|
+| `@model_validator(mode="before")` mappers | 10 |
+| lines of code they represent | 158 |
+| dict entries across all of them | 102 |
+| entries that are a pure `data.x` → `"x"` copy | **70 (68 %)** |
+
+The 32 entries that did something fell into four shapes only: `datetime` → Unix `int` (18), an `object` discriminator literal identical to the field's own `Literal` default (9), one field rename, and four nested structures.
+
+So four fifths of those lines restated what the field declarations directly above them already said. The costs:
+
+* **Drift.** The mapper is a second, implicit declaration of the schema. Adding a field and forgetting the dict does not raise — the field silently falls back to its default, or to `None`.
+* **Duplication.** `int(data.created.timestamp())` written 18 times, `"object": "<name>"` 9 times, across 10 files.
+* **Reviewability.** A 20-line dict where 16 lines are noise hides the two that matter.
+* **Onboarding.** It reads as if the explicit mapping were required, when `model_validate(entity, from_attributes=True)` alone covers most schemas.
+
+## Decision
+
+Endpoints keep calling `Response.model_validate(entity, from_attributes=True)` — that call is unchanged and remains the single mapping point. What changes is that Pydantic, not a hand-written dict, reads the entity's attributes. A response schema declares **only the differences**, and declares them on the field:
+
+| Difference | Declared as |
+|---|---|
+| `datetime` → Unix seconds | `Annotated[UnixTimestamp, Field(...)]` (or `UnixTimestamp \| None`) |
+| `object` discriminator | the field's own `Literal` default — `object: Annotated[Literal["key"], Field(default="key", ...)]` |
+| JSON key ≠ entity attribute | `Field(alias="type")` — `from_attributes` reads the attribute named by the alias |
+| Nested value object | declare the nested schema; `from_attributes` propagates into it (`RoleResponse.limits`, `MeResponse.limits`, `Model.costs`) |
+
+### `UnixTimestamp`
+
+The API-boundary counterpart of the domain's `UtcDatetime`, in `api/infrastructure/fastapi/schemas/__init__.py`:
+
+```python
+def _to_unix_timestamp(value: datetime | int) -> int:
+    return int(value.timestamp()) if isinstance(value, datetime) else value
+
+
+UnixTimestamp = Annotated[int, BeforeValidator(_to_unix_timestamp)]
+```
+
+The field stays typed `int`, so the generated OpenAPI schema still documents an integer — identical to what the mapper produced, type for type and description for description. It is idempotent on an `int`, which matters because FastAPI re-validates a response after dumping it.
+
+```python
+# api/infrastructure/fastapi/schemas/admin/keys.py
+expires: Annotated[UnixTimestamp | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]
+created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
+```
+
+### Responses carry the entity's field name
+
+The one rename that motivated the original pattern is removed rather than automated: `KeyResponse.user` became `user_id`, the name the `Key` entity uses. Response FK fields are always `*_id`; only request bodies shorten (`CreateKeyBody.user`), and the endpoint expands them when building the command. This is a breaking change on `/v1/keys`, `/v1/admin/keys` and — through `AuthLoginResponse` — `/v1/auth/login` and `/v1/auth/sso/login`.
+
+### The one exception: restructuring
+
+A `@model_validator(mode="before")` is still correct when a response **restructures** the entity rather than renaming it. One case exists today: `UsageResponse` nests `UsageRecord`'s flat counters under `usage`. It passes the record itself down under that name instead of re-listing the other fields, so `from_attributes` still does all the field work and no field list can drift:
+
+```python
+@model_validator(mode="before")
+@classmethod
+def nest_usage_counters(cls, data):
+    if isinstance(data, UsageRecord):
+        return data.model_copy(update={"usage": data})
+    return data
+```
+
+## Consequences
+
+**Easier**
+
+* 161 lines removed from `api/infrastructure/fastapi/schemas/`, and nine of the ten mappers with them. No mixed conventions left in the folder.
+* A field added to a response schema can no longer serialize silently to `None`: there is no second list to forget. A field with no matching attribute and no default raises.
+* The four recurring conversions are written once, not once per schema.
+* A diff on a response schema shows the fields, not the noise around them.
+
+**Harder / to watch**
+
+* Every new response timestamp field must be annotated `UnixTimestamp`, not `int`. Without it, `model_validate(entity, from_attributes=True)` hands Pydantic a `datetime` for an `int` field and fails — loudly, which is the point.
+* Pydantic now reads attributes off entities that carry more than the schema declares. It only fetches *declared* fields — it cannot enumerate extras off an arbitrary object — so nothing leaks, and this was checked per schema: `ProviderResponse` does not expose `key` / `basic_auth`, `UserResponse` (which keeps `extra="forbid"`) does not expose `claims` / `password`, `Model` does not expose `router_id`. A new response schema must still be read against its entity with that question in mind.
+* `from_attributes=True` is now load-bearing at every call site. Four `OrganizationResponse.model_validate(organization)` calls omitted it and worked only because the validator recognized the entity; they were fixed.
+
+**Unchanged**
+
+The public API, apart from the `user` → `user_id` rename stated above. The generated `openapi.json` was diffed before and after: identical, types and descriptions alike, except the six lines of that rename.

--- a/adr/README.md
+++ b/adr/README.md
@@ -26,6 +26,7 @@ Each ADR follows this structure:
 | [2026-05-28](2026-05-28-refactoring-model-forwarding.md) | Refactoring model forwarding                        | —           | 2026-05-28 |
 | [2026-07-01](2026-07-01-split-rag.md)                    | Extract RAG into OpenGateRAG (OGR)                  | Accepted    | 2026-07-01 |
 | [2026-08-27](2026-08-27-datetime-handling.md)            | Datetime handling across API, domain and playground | Accepted    | 2026-08-27 |
+| [2026-09-04](2026-09-04-response-schema-mapping.md)      | Mapping domain entities to response schemas         | Accepted    | 2026-09-04 |
 
 ## Creating a new ADR
 

--- a/api/infrastructure/fastapi/endpoints/admin/organizations.py
+++ b/api/infrastructure/fastapi/endpoints/admin/organizations.py
@@ -121,7 +121,7 @@ async def get_organizations(
                 total=organization_page.total,
                 offset=offset,
                 limit=limit,
-                data=[OrganizationResponse.model_validate(organization) for organization in organization_page.data],
+                data=[OrganizationResponse.model_validate(organization, from_attributes=True) for organization in organization_page.data],
             )
 
 
@@ -152,7 +152,7 @@ async def get_organization(
 
     match result:
         case GetOneOrganizationUseCaseSuccess(organization=organization):
-            return OrganizationResponse.model_validate(organization)
+            return OrganizationResponse.model_validate(organization, from_attributes=True)
         case OrganizationNotFoundError(id=not_found_organization_id):
             raise OrganizationNotFoundHTTPException(not_found_organization_id)
 
@@ -184,7 +184,7 @@ async def delete_organization(
 
     match result:
         case DeleteOrganizationUseCaseSuccess(organization=organization):
-            return OrganizationResponse.model_validate(organization)
+            return OrganizationResponse.model_validate(organization, from_attributes=True)
         case OrganizationNotFoundError(id=organization_id):
             raise OrganizationNotFoundHTTPException(organization_id)
         case OrganizationHasUsersError(id=organization_id):
@@ -220,7 +220,7 @@ async def update_organization(
 
     match result:
         case UpdateOrganizationUseCaseSuccess(organization=organization):
-            return OrganizationResponse.model_validate(organization)
+            return OrganizationResponse.model_validate(organization, from_attributes=True)
         case OrganizationNotFoundError(id=not_found_organization_id):
             raise OrganizationNotFoundHTTPException(not_found_organization_id)
         case OrganizationAlreadyExistsError(name=name):

--- a/api/infrastructure/fastapi/schemas/__init__.py
+++ b/api/infrastructure/fastapi/schemas/__init__.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+
+def _to_unix_timestamp(value: datetime | int) -> int:
+    return int(value.timestamp()) if isinstance(value, datetime) else value
+
+
+UnixTimestamp = Annotated[int, BeforeValidator(_to_unix_timestamp)]
+
+__all__ = ["UnixTimestamp"]

--- a/api/infrastructure/fastapi/schemas/admin/keys.py
+++ b/api/infrastructure/fastapi/schemas/admin/keys.py
@@ -1,10 +1,10 @@
 from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints, field_validator, model_validator
+from pydantic import Field, StringConstraints, field_validator
 
 from api.domain import BaseModel
-from api.domain.key.entities import Key
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 
 
 class CreateKeyBody(BaseModel):
@@ -30,24 +30,9 @@ class KeyResponse(BaseModel):
     id: Annotated[int, Field(description="ID of the key.")]
     name: Annotated[str, Field(description="Name of the key.")]
     value: Annotated[str, Field(description="Value of the key.")]
-    user: Annotated[int, Field(description="ID of the user that owns the key.")]
-    expires: Annotated[int | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]
-    created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_key(cls, data):
-        if isinstance(data, Key):
-            return {
-                "object": "key",
-                "id": data.id,
-                "name": data.name,
-                "value": data.value,
-                "user": data.user_id,
-                "expires": int(data.expires.timestamp()) if data.expires is not None else None,
-                "created": int(data.created.timestamp()),
-            }
-        return data
+    user_id: Annotated[int, Field(description="ID of the user that owns the key.")]
+    expires: Annotated[UnixTimestamp | None, Field(default=None, description="Time of expiration, as Unix timestamp. If None, the key never expires.")]  # fmt: off
+    created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
 
 
 class KeysResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/organizations.py
+++ b/api/infrastructure/fastapi/schemas/admin/organizations.py
@@ -1,9 +1,9 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StringConstraints
 
 from api.domain import BaseModel
-from api.domain.organization.entities import Organization
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 
 
 class CreateOrganizationBody(BaseModel):
@@ -19,22 +19,8 @@ class OrganizationResponse(BaseModel):
     id: Annotated[int, Field(description="ID of the organization.")]
     name: Annotated[str, Field(description="Name of the organization.")]
     users: Annotated[int, Field(description="Number of users in the organization.")]
-    created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
-    updated: Annotated[int, Field(description="Time of last update, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_organization(cls, data):
-        if isinstance(data, Organization):
-            return {
-                "object": "organization",
-                "id": data.id,
-                "name": data.name,
-                "users": data.users,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-            }
-        return data
+    created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
+    updated: Annotated[UnixTimestamp, Field(description="Time of last update, as Unix timestamp.")]
 
 
 class OrganizationsResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/providers.py
+++ b/api/infrastructure/fastapi/schemas/admin/providers.py
@@ -3,7 +3,8 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
-from api.domain.provider.entities import BasicAuth, HostingZone, Provider, ProviderType, QoSMetric
+from api.domain.provider.entities import BasicAuth, HostingZone, ProviderType, QoSMetric
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.schemas.core.configuration import ModelProvider
 
 
@@ -26,32 +27,8 @@ class CreateProviderResponse(BaseModel):
     model_active_params: Annotated[int, Field(default=0, ge=0, description="Active params of the model in billions of parameters for carbon footprint computation. If not provided, the total params will be used if provided, else carbon footprint will not be computed. For more information, see https://ecologits.ai")]  # fmt: off
     qos_metric: Annotated[QoSMetric | None, Field(default=None, description="The metric to use for the QoS policy. If not provided, no QoS policy is applied.")]  # fmt: off
     qos_limit: Annotated[float | None, Field(default=None, ge=0.0, description="The value to use for the quality of service. Depends of the metric, the value can be a percentile, a threshold, etc.")]  # fmt: off
-    created: Annotated[int | None, Field(default=None, description="Time of creation, as Unix timestamp.")]  # fmt: off
-    updated: Annotated[int | None, Field(default=None, description="Time of last update, as Unix timestamp.")]  # fmt: off
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_provider(cls, data):
-        if isinstance(data, Provider):
-            return {
-                "id": data.id,
-                "router_id": data.router_id,
-                "user_id": data.user_id,
-                "type": data.type,
-                "url": data.url,
-                "key": data.key,
-                "basic_auth": data.basic_auth,
-                "timeout": data.timeout,
-                "model_name": data.model_name,
-                "model_hosting_zone": data.model_hosting_zone,
-                "model_total_params": data.model_total_params,
-                "model_active_params": data.model_active_params,
-                "qos_metric": data.qos_metric,
-                "qos_limit": data.qos_limit,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-            }
-        return data
+    created: Annotated[UnixTimestamp | None, Field(default=None, description="Time of creation, as Unix timestamp.")]  # fmt: off
+    updated: Annotated[UnixTimestamp | None, Field(default=None, description="Time of last update, as Unix timestamp.")]  # fmt: off
 
 
 class UpdateProviderBody(BaseModel):
@@ -87,33 +64,8 @@ class ProviderResponse(BaseModel):
     qos_limit: Annotated[float | None, Field(default=None, ge=0.0, description="The value to use for the quality of service. Depends of the metric, the value can be a percentile, a threshold, etc.")]  # fmt: off
     max_context_length: Annotated[int | None, Field(default=None, description="Maximum amount of tokens a context could contains, probed on the provider API. It is the same for all the providers of a router.")]  # fmt: off
     vector_size: Annotated[int | None, Field(default=None, description="Dimension of the vectors, probed on the provider API for embeddings models only. It is the same for all the providers of a router.")]  # fmt: off
-    created: Annotated[int | None, Field(default=None, description="Time of creation, as Unix timestamp.")]
-    updated: Annotated[int | None, Field(default=None, description="Time of last update, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_provider(cls, data):
-        if isinstance(data, Provider):
-            return {
-                "object": "provider",
-                "id": data.id,
-                "router_id": data.router_id,
-                "user_id": data.user_id,
-                "type": data.type,
-                "url": data.url,
-                "timeout": data.timeout,
-                "model_name": data.model_name,
-                "model_hosting_zone": data.model_hosting_zone,
-                "model_total_params": data.model_total_params,
-                "model_active_params": data.model_active_params,
-                "qos_metric": data.qos_metric,
-                "qos_limit": data.qos_limit,
-                "max_context_length": data.max_context_length,
-                "vector_size": data.vector_size,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-            }
-        return data
+    created: Annotated[UnixTimestamp | None, Field(default=None, description="Time of creation, as Unix timestamp.")]
+    updated: Annotated[UnixTimestamp | None, Field(default=None, description="Time of last update, as Unix timestamp.")]
 
 
 class ProvidersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/roles.py
+++ b/api/infrastructure/fastapi/schemas/admin/roles.py
@@ -1,10 +1,10 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StringConstraints
 
 from api.domain import BaseModel
-from api.domain.role.entities import Role
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 
 
 class PermissionType(StrEnum):
@@ -45,24 +45,8 @@ class RoleResponse(BaseModel):
     permissions: Annotated[list[PermissionType], Field(..., description="List of permissions.")]
     limits: Annotated[list[Limit], Field(..., description="List of limits.")]
     users: Annotated[int, Field(..., description="Number of users assigned to the role.")]
-    created: Annotated[int, Field(..., description="Time of creation, as Unix timestamp.")]
-    updated: Annotated[int, Field(..., description="Time of last update, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_role(cls, data):
-        if isinstance(data, Role):
-            return {
-                "object": "role",
-                "id": data.id,
-                "name": data.name,
-                "permissions": data.permissions,
-                "limits": [{"router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in data.limits],
-                "users": data.users,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-            }
-        return data
+    created: Annotated[UnixTimestamp, Field(..., description="Time of creation, as Unix timestamp.")]
+    updated: Annotated[UnixTimestamp, Field(..., description="Time of last update, as Unix timestamp.")]
 
 
 class RolesResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/routers.py
+++ b/api/infrastructure/fastapi/schemas/admin/routers.py
@@ -1,9 +1,10 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StringConstraints
 
 from api.domain import BaseModel
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy
+from api.domain.router.entities import RouterLoadBalancingStrategy
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.schemas.models import ModelType
 
 
@@ -36,28 +37,8 @@ class RouterResponse(BaseModel):
     cost_prompt_tokens: Annotated[float, Field(description="Cost of a million prompt tokens (decrease user budget)")]
     cost_completion_tokens: Annotated[float, Field(description="Cost of a million completion tokens (decrease user budget)")]
     providers: Annotated[int, Field(default=0, description="Number of providers in the router.")]
-    created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
-    updated: Annotated[int, Field(description="Time of last update, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_router(cls, data):
-        if isinstance(data, Router):
-            return {
-                "object": "router",
-                "id": data.id,
-                "name": data.name,
-                "user_id": data.user_id,
-                "type": data.type,
-                "aliases": data.aliases,
-                "load_balancing_strategy": data.load_balancing_strategy,
-                "cost_prompt_tokens": data.cost_prompt_tokens,
-                "cost_completion_tokens": data.cost_completion_tokens,
-                "providers": data.providers,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-            }
-        return data
+    created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
+    updated: Annotated[UnixTimestamp, Field(description="Time of last update, as Unix timestamp.")]
 
 
 class RoutersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -1,10 +1,10 @@
 from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import ConfigDict, Field, StringConstraints, field_validator, model_validator
+from pydantic import ConfigDict, Field, StringConstraints, field_validator
 
 from api.domain import BaseModel
-from api.domain.user.entities import User
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
 
@@ -37,31 +37,10 @@ class UserResponse(BaseModel):
     role_id: Annotated[int, Field(..., description="ID of the role assigned to the user.")]
     organization_id: Annotated[int | None, Field(default=None, description="ID of the organization the user belongs to.")]
     budget: Annotated[float | None, Field(default=None, description="Budget allocated to the user.")]
-    expires: Annotated[int | None, Field(default=None, description="Expiration time of the user, as Unix timestamp.")]
-    created: Annotated[int, Field(..., description="Time of creation, as Unix timestamp.")]
-    updated: Annotated[int, Field(..., description="Time of last update, as Unix timestamp.")]
+    expires: Annotated[UnixTimestamp | None, Field(default=None, description="Expiration time of the user, as Unix timestamp.")]
+    created: Annotated[UnixTimestamp, Field(..., description="Time of creation, as Unix timestamp.")]
+    updated: Annotated[UnixTimestamp, Field(..., description="Time of last update, as Unix timestamp.")]
     priority: Annotated[int, Field(..., description="Priority of the user. Higher value means higher priority.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_user(cls, data):
-        if isinstance(data, User):
-            return {
-                "object": "user",
-                "id": data.id,
-                "email": data.email,
-                "name": data.name,
-                "sub": data.sub,
-                "iss": data.iss,
-                "role_id": data.role_id,
-                "organization_id": data.organization_id,
-                "budget": data.budget,
-                "expires": int(data.expires.timestamp()) if data.expires is not None else None,
-                "created": int(data.created.timestamp()),
-                "updated": int(data.updated.timestamp()),
-                "priority": data.priority,
-            }
-        return data
 
 
 class UsersResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/me.py
+++ b/api/infrastructure/fastapi/schemas/me.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints, model_validator
 
 from api.domain import BaseModel
-from api.domain.user.views import AuthenticatedUserView
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.infrastructure.fastapi.schemas.admin.roles import Limit, PermissionType
 from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
@@ -17,24 +17,7 @@ class MeResponse(BaseModel):
     budget: Annotated[float | None, Field(default=None, description="The user budget. If None, the user has unlimited budget.")]
     permissions: Annotated[list[PermissionType], Field(description="The user permissions.")]
     limits: Annotated[list[Limit], Field(description="The user rate limits.")]
-    expires: Annotated[int | None, Field(default=None, description="The user expiration timestamp. If None, the user will never expire.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_authenticated_user(cls, data):
-        if isinstance(data, AuthenticatedUserView):
-            return {
-                "object": "userInfo",
-                "id": data.id,
-                "email": data.email,
-                "name": data.name,
-                "organization_id": data.organization_id,
-                "budget": data.budget,
-                "permissions": data.permissions,
-                "limits": [{"router_id": limit.router_id, "type": limit.type, "value": limit.value} for limit in data.limits],
-                "expires": int(data.expires.timestamp()) if data.expires is not None else None,
-            }
-        return data
+    expires: Annotated[UnixTimestamp | None, Field(default=None, description="The user expiration timestamp. If None, the user will never expire.")]
 
 
 class UpdateMeBody(BaseModel):

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -1,10 +1,10 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from api.domain import BaseModel
 from api.domain.model.entities import ModelType
-from api.domain.model.views import ModelView
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 
 
 class ModelCosts(BaseModel):
@@ -17,26 +17,10 @@ class Model(BaseModel):
     id: Annotated[str, Field(..., description="The model identifier, which can be referenced in the API endpoints.")]
     type: Annotated[ModelType | None, Field(default=None, description="The type of the model, which can be used to identify the model type.", examples=["text-generation"])]  # fmt: off
     aliases: Annotated[list[str], Field(default_factory=list, description="Aliases of the model. It will be used to identify the model by users.", examples=[["model-alias", "model-alias-2"]])]  # fmt: off
-    created: Annotated[int, Field(..., description="Time of creation, as Unix timestamp.")]
+    created: Annotated[UnixTimestamp, Field(..., description="Time of creation, as Unix timestamp.")]
     owned_by: Annotated[str, Field(..., description="The organization that owns the model.")]
     max_context_length: Annotated[int | None, Field(default=None, description="Maximum amount of tokens a context could contains. Makes sure it is the same for all models.")]  # fmt: off
     costs: Annotated[ModelCosts, Field(default_factory=ModelCosts, description="Costs of the model.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def from_model(cls, data):
-        if isinstance(data, ModelView):
-            return {
-                "object": "model",
-                "id": data.id,
-                "type": data.type,
-                "aliases": data.aliases,
-                "created": int(data.created.timestamp()),
-                "owned_by": data.owned_by,
-                "max_context_length": data.max_context_length,
-                "costs": {"prompt_tokens": data.costs.prompt_tokens, "completion_tokens": data.costs.completion_tokens},
-            }
-        return data
 
 
 class ModelsResponse(BaseModel):

--- a/api/infrastructure/fastapi/schemas/usage.py
+++ b/api/infrastructure/fastapi/schemas/usage.py
@@ -42,8 +42,6 @@ class UsageResponse(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def nest_usage_counters(cls, data):
-        # `UsageRecord` carries the counters flat, the API nests them under `usage`: expose the record itself under that name and let
-        # `from_attributes` read the counters off it. Every other field is still read straight from the record.
         if isinstance(data, UsageRecord):
             return data.model_copy(update={"usage": data})
         return data

--- a/api/infrastructure/fastapi/schemas/usage.py
+++ b/api/infrastructure/fastapi/schemas/usage.py
@@ -5,6 +5,7 @@ from pydantic import Field, model_validator
 
 from api.domain import BaseModel
 from api.domain.usage.entities import UsageRecord
+from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.utils.variables import EndpointRoute
 
 
@@ -36,26 +37,15 @@ class UsageResponse(BaseModel):
     key: Annotated[str | None, Field(default=None, description="Key used for the request.")]
     endpoint: Annotated[str | None, Field(default=None, description="Endpoint used for the request.")]
     usage: Annotated[UsageDetail, Field(default_factory=UsageDetail)]
-    created: Annotated[int, Field(description="Time of creation, as Unix timestamp.")]
+    created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
 
     @model_validator(mode="before")
     @classmethod
-    def from_usage_record(cls, data):
+    def nest_usage_counters(cls, data):
+        # `UsageRecord` carries the counters flat, the API nests them under `usage`: expose the record itself under that name and let
+        # `from_attributes` read the counters off it. Every other field is still read straight from the record.
         if isinstance(data, UsageRecord):
-            return {
-                "object": "usage",
-                "model": data.model,
-                "key": data.key,
-                "endpoint": data.endpoint,
-                "usage": {
-                    "prompt_tokens": data.prompt_tokens,
-                    "completion_tokens": data.completion_tokens,
-                    "total_tokens": data.total_tokens,
-                    "cost": data.cost,
-                    "impacts": data.impacts,
-                },
-                "created": int(data.created.timestamp()),
-            }
+            return data.model_copy(update={"usage": data})
         return data
 
 

--- a/api/tests/integration/endpoints/admin/keys/test_create_key.py
+++ b/api/tests/integration/endpoints/admin/keys/test_create_key.py
@@ -42,7 +42,7 @@ class TestCreateKey:
         data = response.json()
         assert data["object"] == "key"
         assert data["name"] == "new-key"
-        assert data["user"] == self.target_user.id
+        assert data["user_id"] == self.target_user.id
         assert isinstance(data["id"], int)
         assert data["value"].startswith("sk-")
         assert data["expires"] is None

--- a/api/tests/integration/endpoints/admin/keys/test_delete_key.py
+++ b/api/tests/integration/endpoints/admin/keys/test_delete_key.py
@@ -35,7 +35,7 @@ class TestDeleteKey:
         assert data["object"] == "key"
         assert data["id"] == key.id
         assert data["name"] == "to-delete"
-        assert data["user"] == user.id
+        assert data["user_id"] == user.id
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/keys/test_get_key.py
+++ b/api/tests/integration/endpoints/admin/keys/test_get_key.py
@@ -35,7 +35,7 @@ class TestGetKey:
         assert data["id"] == key.id
         assert data["object"] == "key"
         assert data["name"] == "my-key"
-        assert data["user"] == user.id
+        assert data["user_id"] == user.id
 
     @pytest.mark.parametrize(
         "use_case_result,expected_status,expected_detail",

--- a/api/tests/integration/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/admin/keys/test_get_keys.py
@@ -53,7 +53,7 @@ class TestGetKeys:
         data = response.json()
         assert data["total"] == 1
         assert data["data"][0]["id"] == key.id
-        assert data["data"][0]["user"] == user.id
+        assert data["data"][0]["user_id"] == user.id
 
     async def test_rejects_non_admin_user(self, client: AsyncClient, db_session):
         regular_user = UserSQLFactory(regular_user=True)

--- a/api/tests/integration/endpoints/keys/test_create_key.py
+++ b/api/tests/integration/endpoints/keys/test_create_key.py
@@ -38,7 +38,7 @@ class TestCreateMeKey:
         data = response.json()
         assert data["object"] == "key"
         assert data["name"] == "new-key"
-        assert data["user"] == self.user.id
+        assert data["user_id"] == self.user.id
         assert isinstance(data["id"], int)
         assert data["value"].startswith("sk-")
         assert data["expires"] is None

--- a/api/tests/integration/endpoints/keys/test_delete_key.py
+++ b/api/tests/integration/endpoints/keys/test_delete_key.py
@@ -34,7 +34,7 @@ class TestDeleteMeKey:
         assert data["object"] == "key"
         assert data["id"] == own_key.id
         assert data["name"] == "to-delete"
-        assert data["user"] == self.user.id
+        assert data["user_id"] == self.user.id
 
     async def test_cannot_delete_another_users_key(self, client: AsyncClient, db_session):
         other_user = UserSQLFactory()

--- a/api/tests/integration/endpoints/keys/test_get_key.py
+++ b/api/tests/integration/endpoints/keys/test_get_key.py
@@ -31,7 +31,7 @@ class TestGetMeKey:
         assert data["object"] == "key"
         assert data["id"] == self.key.id
         assert data["name"] == "user_key"
-        assert data["user"] == self.user.id
+        assert data["user_id"] == self.user.id
         assert data["value"] == self.key.token
         assert data["expires"] is None
         assert isinstance(data["created"], int)

--- a/api/tests/integration/endpoints/keys/test_get_keys.py
+++ b/api/tests/integration/endpoints/keys/test_get_keys.py
@@ -35,7 +35,7 @@ class TestGetMeKeys:
         assert data["limit"] == 10
         assert len(data["data"]) == 2
         assert all(item["object"] == "key" for item in data["data"])
-        assert all(item["user"] == self.user.id for item in data["data"])
+        assert all(item["user_id"] == self.user.id for item in data["data"])
         returned_ids = {item["id"] for item in data["data"]}
         assert own_key.id in returned_ids
         assert self.key.id in returned_ids

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_key.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_key.py
@@ -35,7 +35,7 @@ class TestGetKeyEndpoint:
         assert isinstance(result, KeyResponse)
         assert result.id == 1
         assert result.name == "my-key"
-        assert result.user == 42
+        assert result.user_id == 42
         mock_use_case.execute.assert_awaited_once_with(GetOneKeyCommand(key_id=1))
 
     @pytest.mark.asyncio

--- a/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
+++ b/api/tests/unit/infrastructure/fastapi/endpoints/admin/keys/test_get_keys.py
@@ -45,7 +45,7 @@ class TestGetKeysEndpoint:
         assert result.limit == 10
         assert len(result.data) == 1
         assert result.data[0].name == "my-key"
-        assert result.data[0].user == 42
+        assert result.data[0].user_id == 42
         mock_use_case.execute.assert_awaited_once_with(
             GetKeysCommand(user_id=None, offset=0, limit=10, sort_by=SortField.ID, sort_order=SortOrder.ASC)
         )


### PR DESCRIPTION
## Overview

Resolves #1058.

Every response schema in `api/infrastructure/fastapi/schemas/` mapped its domain entity through a hand-written `@model_validator(mode="before")` that re-listed **every** field: 10 mappers, 158 lines, 68 % of them a pure `data.x` → `"x"` copy. That made each mapper a second, implicit declaration of the schema — a field added above but forgotten in the dict did not raise, it silently fell back to its default.

Following the arbitration in the issue (option 2), the mappers are gone. `model_validate(entity, from_attributes=True)` — which every endpoint already called — now does the field-by-field work, and each genuine difference is declared **on the field**:

| Difference | Occurrences | Now expressed as |
|---|---|---|
| `datetime` → Unix seconds | 18 | `UnixTimestamp`, a new `Annotated[int, BeforeValidator(...)]` alias in `api/infrastructure/fastapi/schemas/__init__.py` — the API-boundary counterpart of the domain's `UtcDatetime` |
| `object` discriminator | 9 | the field's own `Literal` default, which already said the same thing |
| field renaming | 1 | removed: `KeyResponse.user` is now `user_id`, the entity's own name |
| nested structures | 4 | 3 need nothing — pydantic propagates `from_attributes` into `RoleResponse.limits`, `MeResponse.limits`, `Model.costs` |

One `@model_validator(mode="before")` survives, on `UsageResponse`: it *restructures* rather than renames, nesting `UsageRecord`'s flat counters under `usage`. It passes the record itself down under that name instead of re-listing the other fields, so no field list can drift there either.

Net: **−161 lines** in `api/infrastructure/fastapi/schemas/`.

**DoD**

- [x] The decision is recorded — new ADR `adr/2026-09-04-response-schema-mapping.md`
- [x] The four real cases are handled: timestamp conversion (`UnixTimestamp`), `object` discriminator (`Literal` default), field renaming (dropped in favour of the entity's name), nested structures (`from_attributes` propagation, plus one documented exception for `UsageResponse`)
- [x] `AGENTS.md` § *Mapping domain → API* rewritten. The issue asked to *amend* `adr/2026-08-27-datetime-handling.md`, but an ADR is a dated record and its body is not rewritten once accepted — so the new ADR **supersedes** its **Response** paragraph instead, and only that file's header was touched, to point forward. Everything else in the 2026-08-27 ADR (domain, Postgres, request side, playground) still stands
- [x] The 10 mappers are migrated in one pass — no mixed conventions left in `api/infrastructure/fastapi/schemas/`
- [x] API contract unchanged: the generated `openapi.json` was diffed before/after and is identical, types **and** descriptions, **except** the intended `user` → `user_id` rename below
- [ ] *Existing endpoint integration tests pass untouched* — **9 assertions were changed**, all of them reading `data["user"]` on a key response. The rename makes this criterion unachievable; see Breaking changes
- [x] A schema field added without touching the mapper can no longer silently serialize to `None` — there is no mapper to forget; a field with no matching attribute and no default now raises

**Breaking changes:**

- [ ] No breaking changes
- [x] This PR contains breaking changes (explain below)

`KeyResponse.user` is renamed to `user_id`, per the arbitration in the issue ("Le retour du endpoint devrait être `user_id`, c'est un oubli qu'il soit encore présent"). Responses carry the entity's FK name; only request bodies shorten it.

| | Affected |
|---|---|
| Endpoints | `POST/GET/DELETE /v1/keys`, `/v1/admin/keys`, and `POST /v1/auth/login`, `/v1/auth/sso/login` (`AuthLoginResponse` subclasses `KeyResponse`) |
| Migration | consumers read `user_id` instead of `user` in the response body |
| **Not** affected | `CreateKeyBody.user` (request body) and the `?user=` list filter are request-side and unchanged |

The playground does not read that field — it consumes only `id`, `value` and `expires` from the login response — so no playground change was needed.

## Check lists

### Review checklist

- [x] Updated or added documentation — `AGENTS.md` (§ *Mapping domain → API*, § *Timestamps*, `_id` suffix table), a new ADR, and the `adr/README.md` index
- [x] Updated or added unit tests — *N/A as new tests: the 668 existing unit tests cover the mapping and 2 assertions were updated for the rename. The behaviour is unchanged by design, so the existing suite is the regression net*
- [x] Updated or added integration tests — *same: 650 existing integration tests exercise the real HTTP payloads; 7 assertions updated for the rename*
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**`api/sql/models.py` has not been modified** — no Alembic migration involved.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A: no schema change*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No special deployment step. API consumers reading the key `user` field must be updated (see Breaking changes).

## Additional Notes

**How the contract was verified.** `app.openapi()` was dumped before and after the change and diffed. The only difference is the 6 lines of the intended rename (property name, `title`, and the `required` entry, in both `KeyResponse` and `AuthLoginResponse`). Every timestamp field still renders as `"type": "integer"` with its original description — `UnixTimestamp` is `Annotated[int, BeforeValidator]`, so the JSON schema sees a plain `int`.

**What a reviewer should look at.**

1. **`UsageResponse.nest_usage_counters`** (`api/infrastructure/fastapi/schemas/usage.py`) — `data.model_copy(update={"usage": data})` puts the record under its own `usage` attribute so `from_attributes` can read the counters off it. It is the one clever line in the diff; the alternative was to re-list the other five fields and reintroduce the drift this PR removes.
2. **Field leakage.** Dropping the explicit dicts means pydantic reads attributes off entities that carry more than the schema declares. Checked directly, per schema: `ProviderResponse` does not expose `key` / `basic_auth`, `UserResponse` does not expose `claims` / `password`, `Model` does not expose `router_id`. `from_attributes` only fetches declared fields — it cannot enumerate extras — and `UserResponse` keeps its `extra="forbid"`.
3. **The ADR handling.** `adr/2026-08-27-datetime-handling.md` was first edited in place, then restored to its original text — see `5e0b6f43`. Reviewing the diff on that file should show a header change and nothing else.
4. **`admin/organizations.py`** — four call sites were `OrganizationResponse.model_validate(organization)` without `from_attributes=True`; they worked only because the validator recognised the entity. They now pass it, like every other call site.
