### PR TITLE
feat(usage): return daily usage buckets from GET /v1/usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ compose.yaml
 compose.**.yml
 playground/.web
 playground/.states
+playground/reflex.lock
 playground/.gitignore
 playground/requirements.txt
 run.sh

--- a/api/domain/usage/_usagerepository.py
+++ b/api/domain/usage/_usagerepository.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from api.domain.usage.entities import UsagePage
+from api.domain.usage.entities import UsageBucketPage
 
 
 class UsageRepository(ABC):
     @abstractmethod
-    async def get_usages_page(
+    async def get_usage_buckets_page(
         self,
         user_id: int,
         start_time: datetime,
@@ -14,5 +14,7 @@ class UsageRepository(ABC):
         offset: int,
         limit: int,
         endpoint: str | None = None,
-    ) -> UsagePage:
+        models: list[str] | None = None,
+        key_id: int | None = None,
+    ) -> UsageBucketPage:
         pass

--- a/api/domain/usage/entities.py
+++ b/api/domain/usage/entities.py
@@ -28,6 +28,7 @@ class UsageBucket(BaseModel):
     completion_tokens: int = 0
     total_tokens: int = 0
     cost: float = 0.0
+    requests: int = 0
     impacts: EnvironmentalImpacts = EnvironmentalImpacts()
 
 

--- a/api/domain/usage/entities.py
+++ b/api/domain/usage/entities.py
@@ -21,16 +21,14 @@ class Usage(BaseModel):
         return round(number=prompt_tokens_cost + completion_tokens_cost, ndigits=6)
 
 
-class UsageRecord(BaseModel):
-    model: str | None
-    key: str | None
-    endpoint: str | None
-    prompt_tokens: int | None
-    completion_tokens: int | None
-    total_tokens: int | None
-    cost: float | None
-    impacts: EnvironmentalImpacts
-    created: UtcDatetime
+class UsageBucket(BaseModel):
+    start_time: UtcDatetime
+    end_time: UtcDatetime
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost: float = 0.0
+    impacts: EnvironmentalImpacts = EnvironmentalImpacts()
 
 
-UsagePage = EntitiesPage["UsageRecord"]
+UsageBucketPage = EntitiesPage["UsageBucket"]

--- a/api/infrastructure/fastapi/endpoints/usage.py
+++ b/api/infrastructure/fastapi/endpoints/usage.py
@@ -8,7 +8,7 @@ from api.infrastructure.fastapi.accesscontroller import AccessController
 from api.infrastructure.fastapi.dependencies import get_authenticated_user
 from api.infrastructure.fastapi.documentation import get_documentation_responses
 from api.infrastructure.fastapi.endpoints.exceptions import InternalServerHTTPException
-from api.infrastructure.fastapi.schemas.usage import EndpointUsage, UsageResponse, UsagesResponse
+from api.infrastructure.fastapi.schemas.usage import EndpointUsage, UsageBucketResponse, UsagesResponse
 from api.use_cases.usage import GetUsagesCommand, GetUsagesUseCase, GetUsagesUseCaseSuccess
 from api.utils.variables import EndpointRoute, RouterName
 
@@ -31,16 +31,18 @@ router = APIRouter(prefix="/v1", tags=[RouterName.USAGE.title()])
     responses=get_documentation_responses([]),
 )
 async def get_usages(
-    offset: int = Query(default=0, ge=0, description="Number of usages to skip."),
-    limit: int = Query(default=10, ge=1, le=100, description="Maximum number of usages to return."),
-    start_time: int | None = Query(default=None, description="Start time as Unix timestamp (if not provided, will be set to 30 days ago)."),
-    end_time: int | None = Query(default=None, description="End time as Unix timestamp (if not provided, will be set to now)."),
+    offset: int = Query(default=0, ge=0, description="Number of usage buckets to skip."),
+    limit: int = Query(default=10, ge=1, le=100, description="Maximum number of usage buckets to return."),
+    start_time: int = Query(description="Start time as Unix timestamp."),
+    end_time: int = Query(description="End time as Unix timestamp."),
     endpoint: EndpointUsage | None = Query(default=None, description="The endpoint to get usage for."),
+    models: list[str] | None = Query(default=None, description="Router names to filter usage by."),
+    key_id: int | None = Query(default=None, description="Key ID to filter usage by."),
     get_usages_use_case: GetUsagesUseCase = Depends(get_usages_use_case_factory),
     authenticated_user: AuthenticatedUserView = Depends(get_authenticated_user),
 ) -> UsagesResponse:
     """
-    Get usage for the current user.
+    Get daily usage buckets for the current user.
     """
 
     command = GetUsagesCommand(
@@ -50,6 +52,8 @@ async def get_usages(
         start_time=start_time,
         end_time=end_time,
         endpoint=endpoint.value if endpoint is not None else None,
+        models=models,
+        key_id=key_id,
     )
     try:
         result = await get_usages_use_case.execute(command)
@@ -63,6 +67,8 @@ async def get_usages(
                 "start_time": command.start_time,
                 "end_time": command.end_time,
                 "endpoint": command.endpoint,
+                "models": command.models,
+                "key_id": command.key_id,
                 "error_type": type(e).__name__,
             },
         )
@@ -74,5 +80,5 @@ async def get_usages(
                 total=usage_page.total,
                 offset=offset,
                 limit=limit,
-                data=[UsageResponse.model_validate(usage, from_attributes=True) for usage in usage_page.data],
+                data=[UsageBucketResponse.model_validate(bucket, from_attributes=True) for bucket in usage_page.data],
             )

--- a/api/infrastructure/fastapi/schemas/usage.py
+++ b/api/infrastructure/fastapi/schemas/usage.py
@@ -1,10 +1,9 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from api.domain import BaseModel
-from api.domain.usage.entities import UsageRecord
 from api.infrastructure.fastapi.schemas import UnixTimestamp
 from api.utils.variables import EndpointRoute
 
@@ -23,33 +22,20 @@ class EnvironmentalImpacts(BaseModel):
     kgCO2eq: Annotated[float, Field(default=0.0, description="Carbon footprint in kgCO2eq (global warming potential).")]
 
 
-class UsageDetail(BaseModel):
-    prompt_tokens: Annotated[int | None, Field(default=None, description="Number of prompt tokens (e.g. input tokens).")]
-    completion_tokens: Annotated[int | None, Field(default=None, description="Number of completion tokens (e.g. output tokens).")]
-    total_tokens: Annotated[int | None, Field(default=None, description="Total number of tokens (e.g. input and output tokens).")]
-    cost: Annotated[float | None, Field(default=None, description="Total cost of the request.")]
+class UsageBucketResponse(BaseModel):
+    object: Annotated[Literal["usage.bucket"], Field(default="usage.bucket", description="Type of the object.")]
+    start_time: Annotated[UnixTimestamp, Field(description="UTC start of the day bucket, as Unix timestamp.")]
+    end_time: Annotated[UnixTimestamp, Field(description="UTC exclusive end of the day bucket, as Unix timestamp.")]
+    prompt_tokens: Annotated[int, Field(description="Sum of prompt tokens in the bucket.")]
+    completion_tokens: Annotated[int, Field(description="Sum of completion tokens in the bucket.")]
+    total_tokens: Annotated[int, Field(description="Sum of total tokens in the bucket.")]
+    cost: Annotated[float, Field(description="Sum of request costs in the bucket.")]
     impacts: Annotated[EnvironmentalImpacts, Field(default_factory=EnvironmentalImpacts)]
-
-
-class UsageResponse(BaseModel):
-    object: Annotated[Literal["usage"], Field(default="usage", description="Type of the object.")]
-    model: Annotated[str | None, Field(default=None, description="Model used for the request.")]
-    key: Annotated[str | None, Field(default=None, description="Key used for the request.")]
-    endpoint: Annotated[str | None, Field(default=None, description="Endpoint used for the request.")]
-    usage: Annotated[UsageDetail, Field(default_factory=UsageDetail)]
-    created: Annotated[UnixTimestamp, Field(description="Time of creation, as Unix timestamp.")]
-
-    @model_validator(mode="before")
-    @classmethod
-    def nest_usage_counters(cls, data):
-        if isinstance(data, UsageRecord):
-            return data.model_copy(update={"usage": data})
-        return data
 
 
 class UsagesResponse(BaseModel):
     object: Annotated[Literal["list"], Field(default="list", description="Type of the object.")]
-    total: Annotated[int, Field(description="Total number of usages.")]
-    offset: Annotated[int, Field(description="Offset of the usages list.")]
-    limit: Annotated[int, Field(description="Limit of the usages list.")]
-    data: Annotated[list[UsageResponse], Field(description="List of usages.")]
+    total: Annotated[int, Field(description="Total number of usage buckets.")]
+    offset: Annotated[int, Field(description="Offset of the usage buckets list.")]
+    limit: Annotated[int, Field(description="Limit of the usage buckets list.")]
+    data: Annotated[list[UsageBucketResponse], Field(description="List of daily usage buckets.")]

--- a/api/infrastructure/fastapi/schemas/usage.py
+++ b/api/infrastructure/fastapi/schemas/usage.py
@@ -30,6 +30,7 @@ class UsageBucketResponse(BaseModel):
     completion_tokens: Annotated[int, Field(description="Sum of completion tokens in the bucket.")]
     total_tokens: Annotated[int, Field(description="Sum of total tokens in the bucket.")]
     cost: Annotated[float, Field(description="Sum of request costs in the bucket.")]
+    requests: Annotated[int, Field(description="Number of successful requests in the bucket.")]
     impacts: Annotated[EnvironmentalImpacts, Field(default_factory=EnvironmentalImpacts)]
 
 

--- a/api/infrastructure/postgres/_postgresusagerepository.py
+++ b/api/infrastructure/postgres/_postgresusagerepository.py
@@ -1,10 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.usage import UsageRepository
-from api.domain.usage.entities import EnvironmentalImpacts, UsagePage, UsageRecord
+from api.domain.usage.entities import EnvironmentalImpacts, UsageBucket, UsageBucketPage
 from api.infrastructure.postgres._pagination import fetch_page_with_total
 from api.sql.models import Usage as UsageTable
 
@@ -13,7 +13,11 @@ class PostgresUsageRepository(UsageRepository):
     def __init__(self, postgres_session: AsyncSession):
         self.postgres_session = postgres_session
 
-    async def get_usages_page(
+    @staticmethod
+    def _utc_day_start():
+        return func.timezone("UTC", func.date_trunc("day", func.timezone("UTC", UsageTable.created)))
+
+    async def get_usage_buckets_page(
         self,
         user_id: int,
         start_time: datetime,
@@ -21,7 +25,10 @@ class PostgresUsageRepository(UsageRepository):
         offset: int,
         limit: int,
         endpoint: str | None = None,
-    ) -> UsagePage:
+        models: list[str] | None = None,
+        key_id: int | None = None,
+    ) -> UsageBucketPage:
+        utc_day_start = self._utc_day_start()
         filters = [
             UsageTable.user_id == user_id,
             UsageTable.status >= 200,
@@ -31,27 +38,42 @@ class PostgresUsageRepository(UsageRepository):
         ]
         if endpoint is not None:
             filters.append(UsageTable.endpoint == endpoint)
+        if models:
+            filters.append(UsageTable.router_name.in_(models))
+        if key_id is not None:
+            filters.append(UsageTable.token_id == key_id)
 
-        usages_query = (
-            select(UsageTable, func.count().over().label("total")).where(*filters).order_by(UsageTable.created.desc()).offset(offset).limit(limit)
+        buckets_query = (
+            select(
+                utc_day_start.label("start_time"),
+                func.coalesce(func.sum(UsageTable.prompt_tokens), 0).label("prompt_tokens"),
+                func.coalesce(func.sum(UsageTable.completion_tokens), 0).label("completion_tokens"),
+                func.coalesce(func.sum(UsageTable.total_tokens), 0).label("total_tokens"),
+                func.coalesce(func.sum(UsageTable.cost), 0.0).label("cost"),
+                func.coalesce(func.sum(UsageTable.kwh), 0.0).label("kwh"),
+                func.coalesce(func.sum(UsageTable.kgco2eq), 0.0).label("kgco2eq"),
+                func.count().over().label("total"),
+            )
+            .where(*filters)
+            .group_by(utc_day_start)
+            .order_by(utc_day_start.desc())
+            .offset(offset)
+            .limit(limit)
         )
-        count_query = select(func.count()).select_from(UsageTable).where(*filters)
-        rows, total = await fetch_page_with_total(self.postgres_session, usages_query, count_query)
+        count_query = select(func.count()).select_from(select(utc_day_start).where(*filters).group_by(utc_day_start).subquery())
+        rows, total = await fetch_page_with_total(self.postgres_session, buckets_query, count_query)
 
-        usages = [self._row_to_usage_record(row[0]) for row in rows]
-
-        return UsagePage(total=total, data=usages)
+        return UsageBucketPage(total=total, data=[self._row_to_usage_bucket(row) for row in rows])
 
     @staticmethod
-    def _row_to_usage_record(row: UsageTable) -> UsageRecord:
-        return UsageRecord(
-            model=row.router_name,
-            key=row.token_name,
-            endpoint=row.endpoint,
-            prompt_tokens=row.prompt_tokens,
-            completion_tokens=int(row.completion_tokens) if row.completion_tokens is not None else None,
-            total_tokens=row.total_tokens,
-            cost=row.cost,
-            impacts=EnvironmentalImpacts(kWh=(row.kwh or 0.0), kgCO2eq=(row.kgco2eq or 0.0)),
-            created=row.created,
+    def _row_to_usage_bucket(row) -> UsageBucket:
+        start_time = row.start_time
+        return UsageBucket(
+            start_time=start_time,
+            end_time=start_time + timedelta(days=1),
+            prompt_tokens=int(row.prompt_tokens or 0),
+            completion_tokens=int(row.completion_tokens or 0),
+            total_tokens=int(row.total_tokens or 0),
+            cost=float(row.cost or 0.0),
+            impacts=EnvironmentalImpacts(kWh=float(row.kwh or 0.0), kgCO2eq=float(row.kgco2eq or 0.0)),
         )

--- a/api/infrastructure/postgres/_postgresusagerepository.py
+++ b/api/infrastructure/postgres/_postgresusagerepository.py
@@ -52,6 +52,7 @@ class PostgresUsageRepository(UsageRepository):
                 func.coalesce(func.sum(UsageTable.cost), 0.0).label("cost"),
                 func.coalesce(func.sum(UsageTable.kwh), 0.0).label("kwh"),
                 func.coalesce(func.sum(UsageTable.kgco2eq), 0.0).label("kgco2eq"),
+                func.count().label("requests"),
                 func.count().over().label("total"),
             )
             .where(*filters)
@@ -75,5 +76,6 @@ class PostgresUsageRepository(UsageRepository):
             completion_tokens=int(row.completion_tokens or 0),
             total_tokens=int(row.total_tokens or 0),
             cost=float(row.cost or 0.0),
+            requests=int(row.requests or 0),
             impacts=EnvironmentalImpacts(kWh=float(row.kwh or 0.0), kgCO2eq=float(row.kgco2eq or 0.0)),
         )

--- a/api/tests/integ/test_me.py
+++ b/api/tests/integ/test_me.py
@@ -48,6 +48,28 @@ def setup_model_and_user(client: TestClient):
         kill_openmockllm(process=process)
 
 
+def _get_usage(client: TestClient, key: str, start_time: int) -> UsagesResponse:
+    response = client.get(
+        url=f"/v1{EndpointRoute.USAGE}",
+        headers={"Authorization": f"Bearer {key}"},
+        params={"start_time": start_time, "end_time": int(time.time()) + 1},
+    )
+    assert response.status_code == 200, response.text
+    return UsagesResponse(**response.json())
+
+
+def _assert_single_chat_bucket(usages: UsagesResponse) -> None:
+    assert usages.object == "list"
+    assert usages.total == 1
+    assert len(usages.data) == 1
+    bucket = usages.data[0]
+    assert bucket.object == "usage.bucket"
+    assert bucket.requests == 1
+    assert bucket.prompt_tokens > 0
+    assert bucket.completion_tokens > 0
+    assert bucket.total_tokens == bucket.prompt_tokens + bucket.completion_tokens
+
+
 @pytest.mark.usefixtures("client")
 class TestUsage:
     @pytest.mark.asyncio
@@ -69,18 +91,7 @@ class TestUsage:
             chunks.append(chunk)
         await sleep(2)
 
-        # get usage
-        response = client.get(url=f"/v1{EndpointRoute.USAGE}", headers={"Authorization": f"Bearer {key}"}, params={"start_time": start_time})
-        assert response.status_code == 200, response.text
-        data = response.json()
-        usages = UsagesResponse(**data)
-
-        assert len(usages.data) == 1
-        assert usages.data[0].endpoint == f"/v1{EndpointRoute.CHAT_COMPLETIONS}"
-        assert usages.data[0].model == model_name
-        assert usages.data[0].usage.prompt_tokens is not None
-        assert usages.data[0].usage.completion_tokens is not None
-        assert usages.data[0].usage.total_tokens is not None
+        _assert_single_chat_bucket(_get_usage(client, key, start_time))
 
     @pytest.mark.asyncio
     async def test_get_me_usage_unstream_response(self, client: TestClient, setup_model_and_user):
@@ -99,14 +110,4 @@ class TestUsage:
         response.json()
         await sleep(2)
 
-        response = client.get(url=f"/v1{EndpointRoute.USAGE}", headers={"Authorization": f"Bearer {key}"}, params={"start_time": start_time})
-        assert response.status_code == 200, response.text
-        data = response.json()
-        usages = UsagesResponse(**data)
-
-        assert len(usages.data) == 1
-        assert usages.data[0].endpoint == f"/v1{EndpointRoute.CHAT_COMPLETIONS}"
-        assert usages.data[0].model == model_name
-        assert usages.data[0].usage.prompt_tokens is not None
-        assert usages.data[0].usage.completion_tokens is not None
-        assert usages.data[0].usage.total_tokens is not None
+        _assert_single_chat_bucket(_get_usage(client, key, start_time))

--- a/api/tests/integration/endpoints/usage/test_get_usages.py
+++ b/api/tests/integration/endpoints/usage/test_get_usages.py
@@ -91,6 +91,7 @@ class TestGetUsages:
         assert newest["completion_tokens"] == 1
         assert newest["total_tokens"] == 2
         assert newest["cost"] == pytest.approx(0.01)
+        assert newest["requests"] == 1
         assert newest["impacts"]["kWh"] == pytest.approx(0.001)
         assert newest["impacts"]["kgCO2eq"] == pytest.approx(0.002)
 
@@ -101,6 +102,7 @@ class TestGetUsages:
         assert oldest["completion_tokens"] == 25
         assert oldest["total_tokens"] == 40
         assert oldest["cost"] == pytest.approx(0.15)
+        assert oldest["requests"] == 2
         assert oldest["impacts"]["kWh"] == pytest.approx(0.015)
         assert oldest["impacts"]["kgCO2eq"] == pytest.approx(0.03)
 

--- a/api/tests/integration/endpoints/usage/test_get_usages.py
+++ b/api/tests/integration/endpoints/usage/test_get_usages.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from httpx import AsyncClient
 import pytest
 import pytest_asyncio
@@ -7,6 +9,13 @@ from api.tests.integration.factories.sql import UsageSQLFactory, UserSQLFactory
 from api.utils.variables import EndpointRoute
 
 URL = f"/v1{EndpointRoute.USAGE}"
+DEPRECATED_URL = f"/v1{EndpointRoute.ME_USAGE}"
+DAY = datetime(2026, 8, 1, tzinfo=UTC)
+NEXT_DAY = datetime(2026, 8, 2, tzinfo=UTC)
+
+
+def _unix(moment: datetime) -> int:
+    return int(moment.timestamp())
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -16,33 +25,84 @@ class TestGetUsages:
         self.user = UserSQLFactory(regular_user=True)
         self.key = await create_key(db_session, name="user_key", user=self.user, never_expires=True)
 
-    async def test_happy_path(self, client: AsyncClient, db_session):
-        own_usage = UsageSQLFactory(user=self.user, router_name="model-a", token_name="own-key", endpoint="/v1/chat/completions")
+    @pytest.mark.parametrize("url", [URL, DEPRECATED_URL])
+    async def test_happy_path(self, client: AsyncClient, db_session, url: str):
+        UsageSQLFactory(
+            user=self.user,
+            router_name="model-a",
+            token_id=self.key.id,
+            endpoint="/v1/chat/completions",
+            created=DAY.replace(hour=10),
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            cost=0.1,
+            kwh=0.01,
+            kgco2eq=0.02,
+        )
+        UsageSQLFactory(
+            user=self.user,
+            router_name="model-a",
+            token_id=self.key.id,
+            endpoint="/v1/chat/completions",
+            created=DAY.replace(hour=18),
+            prompt_tokens=5,
+            completion_tokens=5,
+            total_tokens=10,
+            cost=0.05,
+            kwh=0.005,
+            kgco2eq=0.01,
+        )
+        UsageSQLFactory(
+            user=self.user,
+            router_name="model-b",
+            created=NEXT_DAY.replace(hour=8),
+            prompt_tokens=1,
+            completion_tokens=1,
+            total_tokens=2,
+            cost=0.01,
+            kwh=0.001,
+            kgco2eq=0.002,
+        )
         other_user = UserSQLFactory()
-        UsageSQLFactory(user=other_user, router_name="other-model")
+        UsageSQLFactory(user=other_user, router_name="other-model", created=DAY.replace(hour=12))
+        UsageSQLFactory(user=self.user, router_name="failed-model", created=DAY.replace(hour=11), failed=True)
         await db_session.flush()
 
         response = await client.get(
-            url=URL,
+            url=url,
             headers={"Authorization": f"Bearer {self.key.token}"},
+            params={"start_time": _unix(DAY), "end_time": _unix(NEXT_DAY + timedelta(days=1)), "limit": 10},
         )
 
         assert response.status_code == 200, response.text
         data = response.json()
         assert data["object"] == "list"
-        assert data["total"] == 1
+        assert data["total"] == 2
         assert data["offset"] == 0
         assert data["limit"] == 10
-        assert len(data["data"]) == 1
-        item = data["data"][0]
-        assert item["object"] == "usage"
-        assert item["model"] == "model-a"
-        assert item["key"] == "own-key"
-        assert item["endpoint"] == "/v1/chat/completions"
-        assert item["usage"]["prompt_tokens"] == own_usage.prompt_tokens
-        assert item["usage"]["completion_tokens"] == own_usage.completion_tokens
-        assert item["usage"]["total_tokens"] == own_usage.total_tokens
-        assert item["created"] == int(own_usage.created.timestamp())
+        assert len(data["data"]) == 2
+
+        newest, oldest = data["data"]
+        assert newest["object"] == "usage.bucket"
+        assert newest["start_time"] == _unix(NEXT_DAY)
+        assert newest["end_time"] == _unix(NEXT_DAY + timedelta(days=1))
+        assert newest["prompt_tokens"] == 1
+        assert newest["completion_tokens"] == 1
+        assert newest["total_tokens"] == 2
+        assert newest["cost"] == pytest.approx(0.01)
+        assert newest["impacts"]["kWh"] == pytest.approx(0.001)
+        assert newest["impacts"]["kgCO2eq"] == pytest.approx(0.002)
+
+        assert oldest["object"] == "usage.bucket"
+        assert oldest["start_time"] == _unix(DAY)
+        assert oldest["end_time"] == _unix(NEXT_DAY)
+        assert oldest["prompt_tokens"] == 15
+        assert oldest["completion_tokens"] == 25
+        assert oldest["total_tokens"] == 40
+        assert oldest["cost"] == pytest.approx(0.15)
+        assert oldest["impacts"]["kWh"] == pytest.approx(0.015)
+        assert oldest["impacts"]["kgCO2eq"] == pytest.approx(0.03)
 
     @pytest.mark.parametrize(
         "headers,expected_status,expected_detail",
@@ -53,7 +113,11 @@ class TestGetUsages:
         ],
     )
     async def test_auth(self, client: AsyncClient, headers, expected_status, expected_detail):
-        response = await client.get(url=URL, headers=headers)
+        response = await client.get(
+            url=URL,
+            headers=headers,
+            params={"start_time": _unix(DAY), "end_time": _unix(NEXT_DAY)},
+        )
 
         assert response.status_code == expected_status
         assert response.json().get("detail") == expected_detail

--- a/api/tests/integration/postgres/test_postgresusagerepository.py
+++ b/api/tests/integration/postgres/test_postgresusagerepository.py
@@ -3,12 +3,15 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from api.domain import EntitiesPage
-from api.domain.usage.entities import EnvironmentalImpacts, UsageRecord
+from api.domain.usage.entities import EnvironmentalImpacts, UsageBucket
 from api.infrastructure.postgres import PostgresUsageRepository
-from api.tests.integration.factories.sql import UsageSQLFactory, UserSQLFactory
+from api.tests.integration.factories.sql import KeySQLFactory, UsageSQLFactory, UserSQLFactory
 
 CHAT_COMPLETIONS = "/v1/chat/completions"
 EMBEDDINGS = "/v1/embeddings"
+DAY = datetime(2026, 8, 1, tzinfo=UTC)
+NEXT_DAY = datetime(2026, 8, 2, tzinfo=UTC)
+THIRD_DAY = datetime(2026, 8, 3, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -16,53 +19,107 @@ def repository(db_session):
     return PostgresUsageRepository(postgres_session=db_session)
 
 
-def _window(*, days_ago: int = 30):
-    end_time = datetime.now(tz=UTC)
-    start_time = end_time - timedelta(days=days_ago)
-    return start_time, end_time
+def _window():
+    return DAY, THIRD_DAY + timedelta(days=1)
 
 
 @pytest.mark.asyncio(loop_scope="session")
-class TestGetUsagesPage:
-    async def test_returns_usages_for_user(self, repository, db_session):
+class TestGetUsageBucketsPage:
+    async def test_returns_buckets_grouped_by_utc_day(self, repository, db_session):
         user = UserSQLFactory()
         other_user = UserSQLFactory()
-        UsageSQLFactory(user=user, router_name="own-model", token_name="own-key")
-        UsageSQLFactory(user=other_user, router_name="other-model")
+        UsageSQLFactory(
+            user=user,
+            router_name="own-model",
+            created=DAY.replace(hour=10),
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            cost=0.1,
+            kwh=0.01,
+            kgco2eq=0.02,
+        )
+        UsageSQLFactory(
+            user=user,
+            router_name="own-model",
+            created=DAY.replace(hour=22),
+            prompt_tokens=5,
+            completion_tokens=5,
+            total_tokens=10,
+            cost=0.05,
+            kwh=0.005,
+            kgco2eq=0.01,
+        )
+        UsageSQLFactory(
+            user=user,
+            router_name="own-model",
+            created=NEXT_DAY.replace(hour=1),
+            prompt_tokens=1,
+            completion_tokens=1,
+            total_tokens=2,
+            cost=0.01,
+            kwh=0.001,
+            kgco2eq=0.002,
+        )
+        UsageSQLFactory(user=other_user, router_name="other-model", created=DAY.replace(hour=12))
         await db_session.flush()
 
         start_time, end_time = _window()
-        result = await repository.get_usages_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
+        result = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
 
         assert isinstance(result, EntitiesPage)
-        assert result.total == 1
-        assert len(result.data) == 1
-        usage = result.data[0]
-        assert isinstance(usage, UsageRecord)
-        assert usage.model == "own-model"
-        assert usage.key == "own-key"
-        assert usage.endpoint == CHAT_COMPLETIONS
+        assert result.total == 2
+        assert len(result.data) == 2
+        newest, oldest = result.data
+        assert isinstance(newest, UsageBucket)
+        assert newest.start_time == NEXT_DAY
+        assert newest.end_time == THIRD_DAY
+        assert newest.prompt_tokens == 1
+        assert newest.completion_tokens == 1
+        assert newest.total_tokens == 2
+        assert newest.cost == pytest.approx(0.01)
+        assert newest.impacts == EnvironmentalImpacts(kWh=0.001, kgCO2eq=0.002)
+
+        assert oldest.start_time == DAY
+        assert oldest.end_time == NEXT_DAY
+        assert oldest.prompt_tokens == 15
+        assert oldest.completion_tokens == 25
+        assert oldest.total_tokens == 40
+        assert oldest.cost == pytest.approx(0.15)
+        assert oldest.impacts == EnvironmentalImpacts(kWh=0.015, kgCO2eq=0.03)
+
+    async def test_omits_days_with_no_usage(self, repository, db_session):
+        user = UserSQLFactory()
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12))
+        UsageSQLFactory(user=user, created=THIRD_DAY.replace(hour=12))
+        await db_session.flush()
+
+        start_time, end_time = _window()
+        result = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
+
+        assert result.total == 2
+        assert [bucket.start_time for bucket in result.data] == [THIRD_DAY, DAY]
 
     async def test_excludes_non_success_status(self, repository, db_session):
         user = UserSQLFactory()
-        UsageSQLFactory(user=user, router_name="ok-model", status=200)
-        UsageSQLFactory(user=user, router_name="failed-model", failed=True)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), status=200, prompt_tokens=10, total_tokens=10)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=13), failed=True, prompt_tokens=99, total_tokens=99)
         await db_session.flush()
 
         start_time, end_time = _window()
-        result = await repository.get_usages_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
+        result = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
 
         assert result.total == 1
-        assert result.data[0].model == "ok-model"
+        assert result.data[0].prompt_tokens == 10
 
     async def test_filters_by_endpoint(self, repository, db_session):
         user = UserSQLFactory()
-        UsageSQLFactory(user=user, router_name="chat-model", endpoint=CHAT_COMPLETIONS)
-        UsageSQLFactory(user=user, router_name="embed-model", embeddings=True)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), endpoint=CHAT_COMPLETIONS, prompt_tokens=10, total_tokens=10)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=13), embeddings=True, prompt_tokens=3, total_tokens=3)
         await db_session.flush()
 
         start_time, end_time = _window()
-        result = await repository.get_usages_page(
+        result = await repository.get_usage_buckets_page(
             user_id=user.id,
             start_time=start_time,
             end_time=end_time,
@@ -72,56 +129,89 @@ class TestGetUsagesPage:
         )
 
         assert result.total == 1
-        assert result.data[0].model == "embed-model"
-        assert result.data[0].endpoint == EMBEDDINGS
+        assert result.data[0].prompt_tokens == 3
+
+    async def test_filters_by_models(self, repository, db_session):
+        user = UserSQLFactory()
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), router_name="model-a", prompt_tokens=10, total_tokens=10)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=13), router_name="model-b", prompt_tokens=4, total_tokens=4)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=14), router_name="model-c", prompt_tokens=7, total_tokens=7)
+        await db_session.flush()
+
+        start_time, end_time = _window()
+        result = await repository.get_usage_buckets_page(
+            user_id=user.id,
+            start_time=start_time,
+            end_time=end_time,
+            offset=0,
+            limit=10,
+            models=["model-a", "model-c"],
+        )
+
+        assert result.total == 1
+        assert result.data[0].prompt_tokens == 17
+
+    async def test_filters_by_key_id(self, repository, db_session):
+        user = UserSQLFactory()
+        matching_key = KeySQLFactory(user=user, name="matching-key")
+        other_key = KeySQLFactory(user=user, name="other-key")
+        await db_session.flush()
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), token_id=matching_key.id, prompt_tokens=10, total_tokens=10)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=13), token_id=other_key.id, prompt_tokens=4, total_tokens=4)
+        await db_session.flush()
+
+        start_time, end_time = _window()
+        result = await repository.get_usage_buckets_page(
+            user_id=user.id,
+            start_time=start_time,
+            end_time=end_time,
+            offset=0,
+            limit=10,
+            key_id=matching_key.id,
+        )
+
+        assert result.total == 1
+        assert result.data[0].prompt_tokens == 10
 
     async def test_filters_by_time_window(self, repository, db_session):
         user = UserSQLFactory()
-        now = datetime.now(tz=UTC)
-        UsageSQLFactory(user=user, router_name="recent-model", created=now - timedelta(days=1))
-        UsageSQLFactory(user=user, router_name="old-model", created=now - timedelta(days=60))
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), prompt_tokens=10, total_tokens=10)
+        UsageSQLFactory(user=user, created=THIRD_DAY.replace(hour=12), prompt_tokens=4, total_tokens=4)
         await db_session.flush()
 
-        result = await repository.get_usages_page(
+        result = await repository.get_usage_buckets_page(
             user_id=user.id,
-            start_time=now - timedelta(days=30),
-            end_time=now,
+            start_time=DAY,
+            end_time=NEXT_DAY,
             offset=0,
             limit=10,
         )
 
         assert result.total == 1
-        assert result.data[0].model == "recent-model"
+        assert result.data[0].start_time == DAY
 
     async def test_maps_null_environmental_impacts_to_zero(self, repository, db_session):
         user = UserSQLFactory()
-        UsageSQLFactory(user=user, kwh=None, kgco2eq=None)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12), kwh=None, kgco2eq=None)
         await db_session.flush()
 
         start_time, end_time = _window()
-        result = await repository.get_usages_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
+        result = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
 
         assert result.data[0].impacts == EnvironmentalImpacts(kWh=0.0, kgCO2eq=0.0)
 
-    async def test_returns_empty_page_when_offset_exceeds_total(self, repository, db_session):
+    async def test_paginates_over_days(self, repository, db_session):
         user = UserSQLFactory()
-        UsageSQLFactory(user=user)
+        UsageSQLFactory(user=user, created=DAY.replace(hour=12))
+        UsageSQLFactory(user=user, created=NEXT_DAY.replace(hour=12))
+        UsageSQLFactory(user=user, created=THIRD_DAY.replace(hour=12))
         await db_session.flush()
 
         start_time, end_time = _window()
-        result = await repository.get_usages_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=100, limit=10)
+        first_page = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=2)
+        second_page = await repository.get_usage_buckets_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=2, limit=2)
 
-        assert result.data == []
-        assert result.total == 1
-
-    async def test_orders_by_created_desc(self, repository, db_session):
-        user = UserSQLFactory()
-        now = datetime.now(tz=UTC)
-        UsageSQLFactory(user=user, router_name="older", created=now - timedelta(hours=2))
-        UsageSQLFactory(user=user, router_name="newer", created=now - timedelta(hours=1))
-        await db_session.flush()
-
-        start_time, end_time = _window()
-        result = await repository.get_usages_page(user_id=user.id, start_time=start_time, end_time=end_time, offset=0, limit=10)
-
-        assert [usage.model for usage in result.data] == ["newer", "older"]
+        assert first_page.total == 3
+        assert [bucket.start_time for bucket in first_page.data] == [THIRD_DAY, NEXT_DAY]
+        assert second_page.total == 3
+        assert [bucket.start_time for bucket in second_page.data] == [DAY]

--- a/api/tests/integration/postgres/test_postgresusagerepository.py
+++ b/api/tests/integration/postgres/test_postgresusagerepository.py
@@ -78,6 +78,7 @@ class TestGetUsageBucketsPage:
         assert newest.completion_tokens == 1
         assert newest.total_tokens == 2
         assert newest.cost == pytest.approx(0.01)
+        assert newest.requests == 1
         assert newest.impacts == EnvironmentalImpacts(kWh=0.001, kgCO2eq=0.002)
 
         assert oldest.start_time == DAY
@@ -86,6 +87,7 @@ class TestGetUsageBucketsPage:
         assert oldest.completion_tokens == 25
         assert oldest.total_tokens == 40
         assert oldest.cost == pytest.approx(0.15)
+        assert oldest.requests == 2
         assert oldest.impacts == EnvironmentalImpacts(kWh=0.015, kgCO2eq=0.03)
 
     async def test_omits_days_with_no_usage(self, repository, db_session):

--- a/api/tests/unit/use_case/usage/test_getusagesusecase.py
+++ b/api/tests/unit/use_case/usage/test_getusagesusecase.py
@@ -1,39 +1,42 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import create_autospec
 
 import pytest
 
 from api.domain import EntitiesPage
-from api.domain.usage.entities import EnvironmentalImpacts, UsageRecord
+from api.domain.usage import UsageRepository
+from api.domain.usage.entities import EnvironmentalImpacts, UsageBucket
 from api.use_cases.usage import GetUsagesCommand, GetUsagesUseCase, GetUsagesUseCaseSuccess
 
 
 @pytest.fixture
-def usage_repository():
-    return AsyncMock()
+def mock_usage_repository():
+    return create_autospec(UsageRepository, instance=True, spec_set=True)
 
 
 @pytest.fixture
-def use_case(usage_repository):
-    return GetUsagesUseCase(usage_repository=usage_repository)
+def use_case(mock_usage_repository):
+    return GetUsagesUseCase(usage_repository=mock_usage_repository)
+
+
+def _bucket(*, start: datetime) -> UsageBucket:
+    return UsageBucket(
+        start_time=start,
+        end_time=start + timedelta(days=1),
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        cost=0.1,
+        impacts=EnvironmentalImpacts(kWh=0.01, kgCO2eq=0.02),
+    )
 
 
 class TestGetUsagesUseCase:
     @pytest.mark.asyncio
-    async def test_should_return_usages_page(self, use_case, usage_repository):
+    async def test_should_return_usage_buckets_page(self, use_case, mock_usage_repository):
         # Arrange
-        usage = UsageRecord(
-            model="model-a",
-            key="key-a",
-            endpoint="/v1/chat/completions",
-            prompt_tokens=10,
-            completion_tokens=20,
-            total_tokens=30,
-            cost=0.1,
-            impacts=EnvironmentalImpacts(kWh=0.01, kgCO2eq=0.02),
-            created=datetime(2026, 8, 1, tzinfo=UTC),
-        )
-        usage_repository.get_usages_page.return_value = EntitiesPage(total=1, data=[usage])
+        bucket = _bucket(start=datetime(2026, 8, 1, tzinfo=UTC))
+        mock_usage_repository.get_usage_buckets_page.return_value = EntitiesPage(total=1, data=[bucket])
         command = GetUsagesCommand(
             user_id=42,
             offset=0,
@@ -41,6 +44,8 @@ class TestGetUsagesUseCase:
             start_time=1_700_000_000,
             end_time=1_800_000_000,
             endpoint="/v1/chat/completions",
+            models=["model-a", "model-b"],
+            key_id=7,
         )
 
         # Act
@@ -49,36 +54,14 @@ class TestGetUsagesUseCase:
         # Assert
         assert isinstance(result, GetUsagesUseCaseSuccess)
         assert result.usage_page.total == 1
-        assert result.usage_page.data == [usage]
-        usage_repository.get_usages_page.assert_awaited_once_with(
+        assert result.usage_page.data == [bucket]
+        mock_usage_repository.get_usage_buckets_page.assert_awaited_once_with(
             user_id=42,
             start_time=datetime.fromtimestamp(1_700_000_000, tz=UTC),
             end_time=datetime.fromtimestamp(1_800_000_000, tz=UTC),
             offset=0,
             limit=10,
             endpoint="/v1/chat/completions",
-        )
-
-    @pytest.mark.asyncio
-    async def test_should_default_time_window_to_last_30_days(self, use_case, usage_repository):
-        # Arrange
-        frozen_now = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
-        usage_repository.get_usages_page.return_value = EntitiesPage(total=0, data=[])
-        command = GetUsagesCommand(user_id=42, offset=0, limit=10, start_time=None, end_time=None, endpoint=None)
-
-        # Act
-        with patch("api.use_cases.usage._getusagesusecase.dt.datetime") as mock_datetime:
-            mock_datetime.now.return_value = frozen_now
-            mock_datetime.fromtimestamp = datetime.fromtimestamp
-            result = await use_case.execute(command)
-
-        # Assert
-        assert isinstance(result, GetUsagesUseCaseSuccess)
-        usage_repository.get_usages_page.assert_awaited_once_with(
-            user_id=42,
-            start_time=frozen_now - timedelta(days=30),
-            end_time=frozen_now,
-            offset=0,
-            limit=10,
-            endpoint=None,
+            models=["model-a", "model-b"],
+            key_id=7,
         )

--- a/api/use_cases/usage/_getusagesusecase.py
+++ b/api/use_cases/usage/_getusagesusecase.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import datetime as dt
 
 from api.domain.usage import UsageRepository
-from api.domain.usage.entities import UsagePage
+from api.domain.usage.entities import UsageBucketPage
 
 
 @dataclass
@@ -10,41 +10,38 @@ class GetUsagesCommand:
     user_id: int
     offset: int
     limit: int
-    start_time: int | None
-    end_time: int | None
+    start_time: int
+    end_time: int
     endpoint: str | None
+    models: list[str] | None
+    key_id: int | None
 
 
 @dataclass
 class GetUsagesUseCaseSuccess:
-    usage_page: UsagePage
+    usage_page: UsageBucketPage
 
 
 type GetUsagesUseCaseResult = GetUsagesUseCaseSuccess
 
 
 class GetUsagesUseCase:
-    DEFAULT_LOOKBACK_DAYS = 30
-
     def __init__(self, usage_repository: UsageRepository):
         self.usage_repository = usage_repository
 
     async def execute(self, command: GetUsagesCommand) -> GetUsagesUseCaseResult:
-        now = dt.datetime.now(tz=dt.UTC)
-        start_time = (
-            dt.datetime.fromtimestamp(command.start_time, tz=dt.UTC)
-            if command.start_time is not None
-            else now - dt.timedelta(days=self.DEFAULT_LOOKBACK_DAYS)
-        )
-        end_time = dt.datetime.fromtimestamp(command.end_time, tz=dt.UTC) if command.end_time is not None else now
+        start_time = dt.datetime.fromtimestamp(command.start_time, tz=dt.UTC)
+        end_time = dt.datetime.fromtimestamp(command.end_time, tz=dt.UTC)
 
-        usage_page = await self.usage_repository.get_usages_page(
+        usage_page = await self.usage_repository.get_usage_buckets_page(
             user_id=command.user_id,
             start_time=start_time,
             end_time=end_time,
             offset=command.offset,
             limit=command.limit,
             endpoint=command.endpoint,
+            models=command.models,
+            key_id=command.key_id,
         )
 
         return GetUsagesUseCaseSuccess(usage_page=usage_page)

--- a/playground/app/app.py
+++ b/playground/app/app.py
@@ -103,10 +103,7 @@ def providers() -> rx.Component:
 
 
 app = rx.App(
-    style={
-        "font-family": "DM Sans, sans-serif",
-        rx.heading: {"font_weight": "500"},
-    },
+    style={rx.heading: {"font_weight": "500"}},
     theme=rx.theme(
         has_background=configuration.settings.playground_theme_has_background,
         accent_color=configuration.settings.playground_theme_accent_color,

--- a/playground/app/features/account/components/account_header.py
+++ b/playground/app/features/account/components/account_header.py
@@ -2,14 +2,9 @@
 
 import reflex as rx
 
-from app.core.variables import HEADING_SIZE_PAGE, HEADING_WEIGHT, MARGIN_MEDIUM
+from app.shared.components.headers import header
 
 
 def account_header() -> rx.Component:
     """Header with title."""
-    return rx.heading(
-        "Account settings",
-        size=HEADING_SIZE_PAGE,
-        weight=HEADING_WEIGHT,
-        margin_bottom=MARGIN_MEDIUM,
-    )
+    return header("Account settings")

--- a/playground/app/features/account/components/account_info_card.py
+++ b/playground/app/features/account/components/account_info_card.py
@@ -50,7 +50,7 @@ def account_info_card() -> rx.Component:
                     width="100%",
                 ),
                 rx.vstack(
-                    rx.text("Expires", size=TEXT_SIZE_LABEL, weight="bold"),
+                    rx.text("Account expires", size=TEXT_SIZE_LABEL, weight="bold"),
                     rx.input(
                         value=AccountState.user_expires_formatted,
                         read_only=True,

--- a/playground/app/features/chat/components/headers.py
+++ b/playground/app/features/chat/components/headers.py
@@ -2,25 +2,27 @@
 
 import reflex as rx
 
-from app.core.variables import ICON_SIZE_MEDIUM, MARGIN_MEDIUM, PADDING_PAGE
+from app.core.variables import ICON_SIZE_MEDIUM, PADDING_PAGE
 from app.features.chat.state import ChatState
-from app.shared.components.headers import header_heading
+from app.shared.components.headers import header_heading, page_header
 
 
 def chat_header() -> rx.Component:
     """Page title and new-chat action, matching other feature headers."""
-    return rx.hstack(
-        header_heading("Playground"),
-        rx.button(
-            rx.icon("message-square-plus", size=ICON_SIZE_MEDIUM),
-            "New chat",
-            on_click=ChatState.clear_chat,
-            variant="soft",
+    return page_header(
+        rx.hstack(
+            header_heading("Playground"),
+            rx.button(
+                rx.icon("message-square-plus", size=ICON_SIZE_MEDIUM),
+                "New chat",
+                on_click=ChatState.clear_chat,
+                variant="soft",
+            ),
+            width="100%",
+            justify="between",
+            align="center",
+            padding_x=PADDING_PAGE,
+            padding_top=PADDING_PAGE,
         ),
-        width="100%",
-        justify="between",
-        align="center",
-        margin_bottom=MARGIN_MEDIUM,
-        padding_x=PADDING_PAGE,
-        padding_top=PADDING_PAGE,
+        bleed=False,
     )

--- a/playground/app/features/chat/components/headers.py
+++ b/playground/app/features/chat/components/headers.py
@@ -2,28 +2,44 @@
 
 import reflex as rx
 
-from app.core.variables import ICON_SIZE_MEDIUM, PADDING_PAGE
+from app.core.variables import ICON_SIZE_XL, PADDING_MEDIUM, PADDING_PAGE
 from app.features.chat.state import ChatState
 from app.shared.components.headers import header_heading, page_header
 
 
 def chat_header() -> rx.Component:
-    """Page title and new-chat action, matching other feature headers."""
+    """Full-width Playground title."""
     return page_header(
-        rx.hstack(
+        rx.box(
             header_heading("Playground"),
-            rx.button(
-                rx.icon("message-square-plus", size=ICON_SIZE_MEDIUM),
-                "New chat",
-                on_click=ChatState.clear_chat,
-                variant="soft",
-            ),
-            width="100%",
-            justify="between",
-            align="center",
             padding_x=PADDING_PAGE,
             padding_top=PADDING_PAGE,
+            width="100%",
         ),
         bleed=False,
         margin_bottom="0",
+    )
+
+
+def new_chat_button() -> rx.Component:
+    """Start a new conversation, shown under the page header."""
+    return rx.hstack(
+        rx.spacer(),
+        rx.tooltip(
+            rx.button(
+                rx.icon(
+                    "message-square-plus",
+                    size=ICON_SIZE_XL,
+                    color="black",
+                ),
+                on_click=ChatState.clear_chat,
+                variant="ghost",
+            ),
+            content="New chat",
+            side="bottom",
+        ),
+        padding_x=PADDING_PAGE,
+        padding_y=PADDING_MEDIUM,
+        width="100%",
+        align="center",
     )

--- a/playground/app/features/chat/components/headers.py
+++ b/playground/app/features/chat/components/headers.py
@@ -25,4 +25,5 @@ def chat_header() -> rx.Component:
             padding_top=PADDING_PAGE,
         ),
         bleed=False,
+        margin_bottom="0",
     )

--- a/playground/app/features/chat/page.py
+++ b/playground/app/features/chat/page.py
@@ -2,7 +2,7 @@
 
 import reflex as rx
 
-from app.features.chat.components.headers import chat_header
+from app.features.chat.components.headers import chat_header, new_chat_button
 from app.features.chat.components.input_bars import chat_input_bar
 from app.features.chat.components.sidebars import chat_params_sidebar
 from app.features.chat.components.windows import chat_window
@@ -20,6 +20,7 @@ def chat_page_content() -> rx.Component:
         rx.hstack(
             rx.box(
                 rx.vstack(
+                    new_chat_button(),
                     rx.box(
                         chat_window(),
                         flex="1",

--- a/playground/app/features/chat/page.py
+++ b/playground/app/features/chat/page.py
@@ -9,62 +9,57 @@ from app.features.chat.components.windows import chat_window
 
 
 def chat_page_content() -> rx.Component:
-    # Overflow hidden so only chat_window scrolls
-    main_area_height = "100vh"
-
-    return rx.hstack(
-        # Left column: column with sticky header, scrollable chat window, sticky input
+    """Playground layout: full-width header, then chat and params side by side."""
+    return rx.vstack(
         rx.box(
-            rx.vstack(
-                # Sticky chat header
-                rx.box(
-                    chat_header(),
-                    position="sticky",
-                    top="0",
-                    z_index="docked",
-                    width="100%",
-                ),
-                # Chat window: the ONLY scrollable area
-                rx.box(
-                    chat_window(),
-                    flex="1",
-                    overflow="auto",
-                    width="100%",
-                    min_height="0",
-                    padding_bottom="80px",  # ensure content isn't hidden by sticky input
-                ),
-                # Sticky input bar at the bottom of the left column
-                rx.box(
-                    chat_input_bar(),
-                    position="sticky",
-                    bottom="0",
-                    z_index="banner",
-                    width="100%",
-                    background_color=rx.color("mauve", 1),
-                ),
-                spacing="0",
-                align_items="stretch",
-                height="100%",
-            ),
-            background_color=rx.color("mauve", 1),
-            color=rx.color("mauve", 12),
-            flex="1",
-            min_width="0",
-            height="100%",
-            padding="0",
-            position="relative",
-            overflow="hidden",
-        ),
-        # Right column: fixed width params sidebar (non-scrollable)
-        rx.box(
-            chat_params_sidebar(),
-            width="320px",
+            chat_header(),
+            width="100%",
             flex="none",
-            height="100%",
-            overflow="hidden",
+            background_color=rx.color("mauve", 1),
         ),
-        align_items="stretch",
+        rx.hstack(
+            rx.box(
+                rx.vstack(
+                    rx.box(
+                        chat_window(),
+                        flex="1",
+                        overflow="auto",
+                        width="100%",
+                        min_height="0",
+                        padding_bottom="80px",
+                    ),
+                    rx.box(
+                        chat_input_bar(),
+                        width="100%",
+                        background_color=rx.color("mauve", 1),
+                    ),
+                    spacing="0",
+                    align_items="stretch",
+                    height="100%",
+                ),
+                background_color=rx.color("mauve", 1),
+                color=rx.color("mauve", 12),
+                flex="1",
+                min_width="0",
+                height="100%",
+                overflow="hidden",
+            ),
+            rx.box(
+                chat_params_sidebar(),
+                width="320px",
+                flex="none",
+                height="100%",
+                overflow="auto",
+            ),
+            spacing="0",
+            align_items="stretch",
+            width="100%",
+            flex="1",
+            min_height="0",
+        ),
         spacing="0",
         width="100%",
-        height=main_area_height,
+        height="100vh",
+        overflow="hidden",
+        background_color=rx.color("mauve", 1),
     )

--- a/playground/app/features/navigation/components/sidebars.py
+++ b/playground/app/features/navigation/components/sidebars.py
@@ -94,12 +94,12 @@ def navigation_sidebar() -> rx.Component:
                         ),
                         align="center",
                         spacing="2",
-                        padding_bottom="1.5em",
                     ),
                     href="/",
                     style={"textDecoration": "none"},
                     width="100%",
                 ),
+                rx.divider(margin_y="0.75em"),
                 nav_item("Playground", "message-square", "/"),
                 *user_items,
                 *(
@@ -140,7 +140,7 @@ def navigation_sidebar() -> rx.Component:
                     if model_items or admin_items
                     else []
                 ),
-                *([rx.divider(), *docs_items] if docs_items else []),
+                *docs_items,
                 spacing="0",
                 width="100%",
                 padding="1em",

--- a/playground/app/features/navigation/components/sidebars.py
+++ b/playground/app/features/navigation/components/sidebars.py
@@ -1,7 +1,7 @@
 import reflex as rx
 
 from app.core.configuration import PlaygroundPages, configuration
-from app.core.variables import PADDING_NAV
+from app.core.variables import HEADING_SIZE_PAGE, HEADING_WEIGHT, PADDING_MEDIUM, PADDING_NAV, PADDING_PAGE
 from app.features.auth.state import AuthState
 from app.shared.components.dark_mode_toggle import dark_mode_toggle
 
@@ -33,7 +33,7 @@ def nav_item(label: str, icon: str | None, page: str, is_external: bool = False,
             border_radius="8px",
             color=rx.color("mauve", 11),
             _hover={
-                "background_color": rx.color("mauve", 3),
+                "background_color": rx.color("mauve", 4),
             },
             width="100%",
             spacing="3",
@@ -89,7 +89,8 @@ def navigation_sidebar() -> rx.Component:
                         ),
                         rx.heading(
                             configuration.settings.app_title,
-                            size="6",
+                            size=HEADING_SIZE_PAGE,
+                            weight=HEADING_WEIGHT,
                             color=rx.color("accent", 11),
                         ),
                         align="center",
@@ -98,8 +99,8 @@ def navigation_sidebar() -> rx.Component:
                     href="/",
                     style={"textDecoration": "none"},
                     width="100%",
+                    padding_bottom="2.5em",
                 ),
-                rx.divider(margin_y="0.75em"),
                 nav_item("Playground", "message-square", "/"),
                 *user_items,
                 *(
@@ -143,7 +144,9 @@ def navigation_sidebar() -> rx.Component:
                 *docs_items,
                 spacing="0",
                 width="100%",
-                padding="1em",
+                padding_x=PADDING_MEDIUM,
+                padding_bottom=PADDING_MEDIUM,
+                padding_top=PADDING_PAGE,
             ),
             # User info and logout at the bottom
             rx.spacer(),
@@ -204,8 +207,8 @@ def navigation_sidebar() -> rx.Component:
         ),
         width="250px",
         height="100vh",
-        background_color=rx.color("mauve", 2),
-        border_right=f"1px solid {rx.color('mauve', 3)}",
+        background_color=rx.color("mauve", 3),
+        border_right=f"1px solid {rx.color('mauve', 6)}",
         position="fixed",
         left="0",
         top="0",

--- a/playground/app/features/usage/components/lists.py
+++ b/playground/app/features/usage/components/lists.py
@@ -3,13 +3,12 @@
 import reflex as rx
 
 from app.core.variables import (
+    HEADING_SIZE_FORM,
     HEADING_SIZE_SECTION,
     SELECT_MEDIUM_WIDTH,
     SPACING_LARGE,
-    SPACING_MEDIUM,
     SPACING_SMALL,
     TEXT_SIZE_LABEL,
-    TEXT_SIZE_MEDIUM,
 )
 from app.features.usage.state import UsageState
 
@@ -63,15 +62,18 @@ def usage_filters() -> rx.Component:
 def usage_summary_stat(label: str, value: rx.Var) -> rx.Component:
     return rx.vstack(
         rx.text(label, size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-        rx.text(value, size=TEXT_SIZE_MEDIUM, weight="bold", color=rx.color("mauve", 12)),
+        rx.heading(value, size=HEADING_SIZE_SECTION, color=rx.color("mauve", 12)),
         spacing="0",
-        align="start",
+        align="center",
+        flex="1",
+        min_width="120px",
     )
 
 
 def usage_summary() -> rx.Component:
     """Totals over the selected date range."""
     return rx.hstack(
+        usage_summary_stat("Requests", UsageState.summary_requests),
         usage_summary_stat("Prompt tokens", UsageState.summary_prompt_tokens),
         usage_summary_stat("Completion tokens", UsageState.summary_completion_tokens),
         usage_summary_stat("Total tokens", UsageState.summary_total_tokens),
@@ -81,61 +83,94 @@ def usage_summary() -> rx.Component:
         spacing=SPACING_LARGE,
         wrap="wrap",
         width="100%",
-    )
-
-
-def usage_series_toggle(label: str, checked: rx.Var, on_change) -> rx.Component:
-    return rx.hstack(
-        rx.checkbox(checked=checked, on_change=on_change),
-        rx.text(label, size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-        spacing=SPACING_SMALL,
+        justify="center",
         align="center",
     )
 
 
-def usage_chart() -> rx.Component:
-    """Bar chart of daily usage buckets with toggleable metric series."""
+def usage_metric_chart(title: str, *bars: rx.Component, bar_gap: int = 4) -> rx.Component:
     return rx.vstack(
-        rx.hstack(
-            usage_series_toggle("Prompt tokens", UsageState.show_prompt_tokens, UsageState.set_show_prompt_tokens),
-            usage_series_toggle("Completion tokens", UsageState.show_completion_tokens, UsageState.set_show_completion_tokens),
-            usage_series_toggle("Total tokens", UsageState.show_total_tokens, UsageState.set_show_total_tokens),
-            usage_series_toggle("Cost", UsageState.show_cost, UsageState.set_show_cost),
-            usage_series_toggle("kWh", UsageState.show_kwh, UsageState.set_show_kwh),
-            usage_series_toggle("kgCO2eq", UsageState.show_kgco2eq, UsageState.set_show_kgco2eq),
-            spacing=SPACING_MEDIUM,
-            wrap="wrap",
-            align="center",
+        rx.heading(title, size=HEADING_SIZE_FORM, color=rx.color("mauve", 12)),
+        rx.recharts.bar_chart(
+            *bars,
+            rx.recharts.x_axis(data_key="date"),
+            rx.recharts.graphing_tooltip(),
+            data=UsageState.chart_data,
+            width="100%",
+            height=260,
+            bar_gap=bar_gap,
         ),
-        rx.cond(
-            UsageState.chart_data.length() > 0,
-            rx.recharts.bar_chart(
-                rx.foreach(
-                    UsageState.visible_chart_series,
-                    lambda series: rx.recharts.bar(
-                        data_key=series["data_key"],
-                        name=series["name"],
-                        fill=series["fill"],
-                    ),
-                ),
-                rx.recharts.x_axis(data_key="date"),
-                rx.recharts.y_axis(),
-                rx.recharts.cartesian_grid(stroke_dasharray="3 3"),
-                rx.recharts.graphing_tooltip(),
-                rx.recharts.legend(),
-                data=UsageState.chart_data,
-                width="100%",
-                height=360,
-            ),
-            rx.text("No usage in this period.", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-        ),
-        spacing=SPACING_MEDIUM,
+        spacing=SPACING_SMALL,
         width="100%",
     )
 
 
+def usage_charts() -> rx.Component:
+    """One bar chart per metric; tokens stack, impacts group kWh and kgCO2eq."""
+    return rx.cond(
+        UsageState.chart_data.length() > 0,
+        rx.grid(
+            usage_metric_chart(
+                "Requests",
+                rx.recharts.bar(
+                    data_key="requests",
+                    name="Requests",
+                    stroke=rx.color("accent", 9),
+                    fill=rx.color("accent", 8),
+                ),
+            ),
+            usage_metric_chart(
+                "Tokens",
+                rx.recharts.bar(
+                    data_key="prompt_tokens",
+                    name="Prompt tokens",
+                    stroke=rx.color("green", 9),
+                    fill=rx.color("green", 8),
+                    stack_id="tokens",
+                ),
+                rx.recharts.bar(
+                    data_key="completion_tokens",
+                    name="Completion tokens",
+                    stroke=rx.color("accent", 9),
+                    fill=rx.color("accent", 8),
+                    stack_id="tokens",
+                ),
+            ),
+            usage_metric_chart(
+                "Cost",
+                rx.recharts.bar(
+                    data_key="cost",
+                    name="Cost",
+                    stroke=rx.color("accent", 9),
+                    fill=rx.color("accent", 8),
+                ),
+            ),
+            usage_metric_chart(
+                "Impacts",
+                rx.recharts.bar(
+                    data_key="kWh",
+                    name="kWh",
+                    stroke=rx.color("accent", 9),
+                    fill=rx.color("accent", 8),
+                ),
+                rx.recharts.bar(
+                    data_key="kgCO2eq",
+                    name="kgCO2eq",
+                    stroke=rx.color("green", 9),
+                    fill=rx.color("green", 8),
+                ),
+                bar_gap=0,
+            ),
+            columns="2",
+            spacing=SPACING_LARGE,
+            width="100%",
+        ),
+        rx.text("No usage in this period.", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+    )
+
+
 def usage_list() -> rx.Component:
-    """Usage tracking page with filters, summary totals, and chart."""
+    """Usage tracking page with filters, summary totals, and charts."""
     return rx.card(
         rx.vstack(
             rx.hstack(
@@ -150,7 +185,7 @@ def usage_list() -> rx.Component:
             rx.divider(),
             usage_summary(),
             rx.divider(),
-            usage_chart(),
+            usage_charts(),
             spacing=SPACING_LARGE,
             width="100%",
         ),

--- a/playground/app/features/usage/components/lists.py
+++ b/playground/app/features/usage/components/lists.py
@@ -4,117 +4,155 @@ import reflex as rx
 
 from app.core.variables import (
     HEADING_SIZE_SECTION,
-    ICON_SIZE_TINY,
     SELECT_MEDIUM_WIDTH,
     SPACING_LARGE,
+    SPACING_MEDIUM,
     SPACING_SMALL,
-    SPACING_TINY,
     TEXT_SIZE_LABEL,
+    TEXT_SIZE_MEDIUM,
 )
 from app.features.usage.state import UsageState
-from app.shared.components.pagination import pagination
 
 
 def usage_filters() -> rx.Component:
-    """Filters for usage list."""
-    return (
-        rx.hstack(
-            rx.text("Filters", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-            rx.select(
-                UsageState.endpoints_name_list,
-                on_change=UsageState.set_filter_endpoint,
-                value=UsageState.filter_endpoint_value,
-                width=SELECT_MEDIUM_WIDTH,
-            ),
-            rx.text("From", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-            rx.input(
-                type="date",
-                value=UsageState.get_filter_date_from_value,
-                on_change=UsageState.set_filter_date_from,
-                max=UsageState.filter_date_to_value_max,
-            ),
-            rx.text("To", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
-            rx.input(
-                type="date",
-                value=UsageState.get_filter_date_to_value,
-                on_change=UsageState.set_filter_date_to,
-            ),
-            rx.button(
-                "Apply",
-                on_click=UsageState.apply_filters,
-                align_self="end",
-            ),
-            spacing=SPACING_SMALL,
-            align="center",
+    """Filters for usage buckets."""
+    return rx.hstack(
+        rx.text("Filters", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.select(
+            UsageState.endpoints_name_list,
+            on_change=UsageState.set_filter_endpoint,
+            value=UsageState.filter_endpoint_value,
+            width=SELECT_MEDIUM_WIDTH,
         ),
+        rx.select(
+            UsageState.available_models,
+            on_change=UsageState.set_filter_model,
+            value=UsageState.filter_model_value,
+            width=SELECT_MEDIUM_WIDTH,
+        ),
+        rx.select(
+            UsageState.available_keys,
+            on_change=UsageState.set_filter_key,
+            value=UsageState.filter_key_value,
+            width=SELECT_MEDIUM_WIDTH,
+        ),
+        rx.text("From", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.input(
+            type="date",
+            value=UsageState.get_filter_date_from_value,
+            on_change=UsageState.set_filter_date_from,
+            max=UsageState.filter_date_to_value_max,
+        ),
+        rx.text("To", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.input(
+            type="date",
+            value=UsageState.get_filter_date_to_value,
+            on_change=UsageState.set_filter_date_to,
+        ),
+        rx.button(
+            "Apply",
+            on_click=UsageState.apply_filters,
+            align_self="end",
+        ),
+        spacing=SPACING_SMALL,
+        align="center",
+        wrap="wrap",
     )
 
 
-def usage_table() -> rx.Component:
-    """Table displaying usage data."""
-    return rx.table.root(
-        rx.table.header(
-            rx.table.row(
-                rx.table.column_header_cell("Date", width="140px"),
-                rx.table.column_header_cell("Key", width="120px"),
-                rx.table.column_header_cell("Endpoint", width="200px"),
-                rx.table.column_header_cell("Model", width="150px"),
-                rx.table.column_header_cell("Tokens", width="120px"),
-                rx.table.column_header_cell("Cost", width="100px"),
-                rx.table.column_header_cell(
-                    rx.tooltip(
-                        rx.hstack(
-                            rx.text("Impacts"),
-                            rx.icon("info", size=ICON_SIZE_TINY),
-                            spacing=SPACING_TINY,
-                            align="center",
-                        ),
-                        content="Footprint impacts in kgCO2eq (Global warming potential)",
-                    ),
-                    width="150px",
-                ),
-            ),
-        ),
-        rx.table.body(
-            rx.foreach(
-                UsageState.usage_rows,
-                lambda row: rx.table.row(
-                    rx.table.cell(row["date"], width="140px"),
-                    rx.table.cell(row["key"], width="120px"),
-                    rx.table.cell(row["endpoint"], width="200px"),
-                    rx.table.cell(row["model"], width="150px"),
-                    rx.table.cell(row["tokens"], width="120px"),
-                    rx.table.cell(row["cost"], width="100px"),
-                    rx.table.cell(row["kgCO2eq"], width="150px"),
-                ),
-            ),
-        ),
-        variant="surface",
+def usage_summary_stat(label: str, value: rx.Var) -> rx.Component:
+    return rx.vstack(
+        rx.text(label, size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        rx.text(value, size=TEXT_SIZE_MEDIUM, weight="bold", color=rx.color("mauve", 12)),
+        spacing="0",
+        align="start",
+    )
+
+
+def usage_summary() -> rx.Component:
+    """Totals over the selected date range."""
+    return rx.hstack(
+        usage_summary_stat("Prompt tokens", UsageState.summary_prompt_tokens),
+        usage_summary_stat("Completion tokens", UsageState.summary_completion_tokens),
+        usage_summary_stat("Total tokens", UsageState.summary_total_tokens),
+        usage_summary_stat("Cost", UsageState.summary_cost),
+        usage_summary_stat("kWh", UsageState.summary_kwh),
+        usage_summary_stat("kgCO2eq", UsageState.summary_kgco2eq),
+        spacing=SPACING_LARGE,
+        wrap="wrap",
         width="100%",
-        style={"table-layout": "fixed"},
+    )
+
+
+def usage_series_toggle(label: str, checked: rx.Var, on_change) -> rx.Component:
+    return rx.hstack(
+        rx.checkbox(checked=checked, on_change=on_change),
+        rx.text(label, size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        spacing=SPACING_SMALL,
+        align="center",
+    )
+
+
+def usage_chart() -> rx.Component:
+    """Bar chart of daily usage buckets with toggleable metric series."""
+    return rx.vstack(
+        rx.hstack(
+            usage_series_toggle("Prompt tokens", UsageState.show_prompt_tokens, UsageState.set_show_prompt_tokens),
+            usage_series_toggle("Completion tokens", UsageState.show_completion_tokens, UsageState.set_show_completion_tokens),
+            usage_series_toggle("Total tokens", UsageState.show_total_tokens, UsageState.set_show_total_tokens),
+            usage_series_toggle("Cost", UsageState.show_cost, UsageState.set_show_cost),
+            usage_series_toggle("kWh", UsageState.show_kwh, UsageState.set_show_kwh),
+            usage_series_toggle("kgCO2eq", UsageState.show_kgco2eq, UsageState.set_show_kgco2eq),
+            spacing=SPACING_MEDIUM,
+            wrap="wrap",
+            align="center",
+        ),
+        rx.cond(
+            UsageState.chart_data.length() > 0,
+            rx.recharts.bar_chart(
+                rx.foreach(
+                    UsageState.visible_chart_series,
+                    lambda series: rx.recharts.bar(
+                        data_key=series["data_key"],
+                        name=series["name"],
+                        fill=series["fill"],
+                    ),
+                ),
+                rx.recharts.x_axis(data_key="date"),
+                rx.recharts.y_axis(),
+                rx.recharts.cartesian_grid(stroke_dasharray="3 3"),
+                rx.recharts.graphing_tooltip(),
+                rx.recharts.legend(),
+                data=UsageState.chart_data,
+                width="100%",
+                height=360,
+            ),
+            rx.text("No usage in this period.", size=TEXT_SIZE_LABEL, color=rx.color("mauve", 11)),
+        ),
+        spacing=SPACING_MEDIUM,
+        width="100%",
     )
 
 
 def usage_list() -> rx.Component:
-    """Usage tracking page with filters, table, and chart."""
+    """Usage tracking page with filters, summary totals, and chart."""
     return rx.card(
         rx.vstack(
             rx.hstack(
-                rx.heading("Requests details", size=HEADING_SIZE_SECTION),
+                rx.heading("Daily usage", size=HEADING_SIZE_SECTION),
                 rx.spacer(),
                 usage_filters(),
                 align="center",
                 spacing=SPACING_SMALL,
                 width="100%",
+                wrap="wrap",
             ),
             rx.divider(),
-            rx.spacer(size="10"),
-            rx.vstack(
-                usage_table(),
-                rx.hstack(pagination(state=UsageState), width="100%", justify="end"),
-                spacing=SPACING_LARGE,
-                width="100%",
-            ),
+            usage_summary(),
+            rx.divider(),
+            usage_chart(),
+            spacing=SPACING_LARGE,
+            width="100%",
         ),
         width="100%",
         spacing=SPACING_LARGE,

--- a/playground/app/features/usage/components/lists.py
+++ b/playground/app/features/usage/components/lists.py
@@ -5,6 +5,7 @@ import reflex as rx
 from app.core.variables import (
     HEADING_SIZE_FORM,
     HEADING_SIZE_SECTION,
+    PADDING_MEDIUM,
     SELECT_MEDIUM_WIDTH,
     SPACING_LARGE,
     SPACING_SMALL,
@@ -85,20 +86,34 @@ def usage_summary() -> rx.Component:
         width="100%",
         justify="center",
         align="center",
+        padding_bottom=PADDING_MEDIUM,
     )
 
 
-def usage_metric_chart(title: str, *bars: rx.Component, bar_gap: int = 4) -> rx.Component:
+def usage_max_line(y: rx.Var, label: rx.Var) -> rx.Component:
+    return rx.recharts.reference_line(
+        rx.recharts.label(value=label, position="insideTopRight"),
+        stroke=rx.color("mauve", 9),
+        stroke_width=1,
+        if_overflow="visible",
+        custom_attrs={"y": y, "strokeDasharray": "4 4"},
+    )
+
+
+def usage_metric_chart(title: str, *bars: rx.Component, max_y: rx.Var, max_label: rx.Var, bar_gap: int = 4) -> rx.Component:
     return rx.vstack(
         rx.heading(title, size=HEADING_SIZE_FORM, color=rx.color("mauve", 12)),
         rx.recharts.bar_chart(
             *bars,
+            usage_max_line(max_y, max_label),
             rx.recharts.x_axis(data_key="date"),
+            rx.recharts.y_axis(hide=True, width=0, domain=[0, max_y]),
             rx.recharts.graphing_tooltip(),
             data=UsageState.chart_data,
             width="100%",
             height=260,
             bar_gap=bar_gap,
+            margin={"top": 20, "right": 8, "left": 0, "bottom": 0},
         ),
         spacing=SPACING_SMALL,
         width="100%",
@@ -118,6 +133,8 @@ def usage_charts() -> rx.Component:
                     stroke=rx.color("accent", 9),
                     fill=rx.color("accent", 8),
                 ),
+                max_y=UsageState.chart_max_requests,
+                max_label=UsageState.chart_max_requests_label,
             ),
             usage_metric_chart(
                 "Tokens",
@@ -135,6 +152,8 @@ def usage_charts() -> rx.Component:
                     fill=rx.color("accent", 8),
                     stack_id="tokens",
                 ),
+                max_y=UsageState.chart_max_tokens,
+                max_label=UsageState.chart_max_tokens_label,
             ),
             usage_metric_chart(
                 "Cost",
@@ -144,6 +163,8 @@ def usage_charts() -> rx.Component:
                     stroke=rx.color("accent", 9),
                     fill=rx.color("accent", 8),
                 ),
+                max_y=UsageState.chart_max_cost,
+                max_label=UsageState.chart_max_cost_label,
             ),
             usage_metric_chart(
                 "Impacts",
@@ -159,6 +180,8 @@ def usage_charts() -> rx.Component:
                     stroke=rx.color("green", 9),
                     fill=rx.color("green", 8),
                 ),
+                max_y=UsageState.chart_max_impacts,
+                max_label=UsageState.chart_max_impacts_label,
                 bar_gap=0,
             ),
             columns="2",

--- a/playground/app/features/usage/components/lists.py
+++ b/playground/app/features/usage/components/lists.py
@@ -123,7 +123,7 @@ def usage_metric_chart(title: str, *bars: rx.Component, max_y: rx.Var, max_label
 def usage_charts() -> rx.Component:
     """One bar chart per metric; tokens stack, impacts group kWh and kgCO2eq."""
     return rx.cond(
-        UsageState.chart_data.length() > 0,
+        UsageState.entities.length() > 0,
         rx.grid(
             usage_metric_chart(
                 "Requests",

--- a/playground/app/features/usage/models.py
+++ b/playground/app/features/usage/models.py
@@ -8,6 +8,7 @@ class Usage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    requests: int = 0
     cost: float = 0.0
     kwh: float = 0.0
     kgco2eq: float | None = None

--- a/playground/app/features/usage/models.py
+++ b/playground/app/features/usage/models.py
@@ -1,13 +1,21 @@
-from app.shared.models.entities import Entity
+from pydantic import BaseModel
 
 
-class Usage(Entity):
+class Usage(BaseModel):
+    start_time: int = 0
+    end_time: int = 0
+    date: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost: float = 0.0
+    kwh: float = 0.0
+    kgco2eq: float | None = None
     endpoint: str | None = None
     model: str | None = None
     key: str | None = None
-    prompt_tokens: int | None = None
-    completion_tokens: int | None = None
-    total_tokens: int | None = None
-    cost: float | None = None
-    kgco2eq: float | None = None
     created: str | None = None
+    id: int | None = None
+
+
+UsageBucket = Usage

--- a/playground/app/features/usage/models.py
+++ b/playground/app/features/usage/models.py
@@ -12,11 +12,3 @@ class Usage(BaseModel):
     cost: float = 0.0
     kwh: float = 0.0
     kgco2eq: float | None = None
-    endpoint: str | None = None
-    model: str | None = None
-    key: str | None = None
-    created: str | None = None
-    id: int | None = None
-
-
-UsageBucket = Usage

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -9,7 +9,7 @@ import reflex as rx
 from app.features.usage.models import Usage
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import date_to_timestamp, format_date, format_local_date, local_now
+from app.shared.utils.timestamps import DATE_FORMAT, date_to_timestamp, format_date, format_local_date, local_now
 
 ALL_ENDPOINTS = "All endpoints"
 ALL_MODELS = "All models"
@@ -19,19 +19,12 @@ USAGE_PAGE_LIMIT = 100
 
 
 class UsageState(EntityState):
-    """State for account usage buckets, filters, and chart series."""
+    """State for account usage buckets, filters, and charts."""
 
     entities: list[Usage] = []
     available_models: list[str] = [ALL_MODELS]
     available_keys: list[str] = [ALL_KEYS]
     key_ids_by_name: dict[str, int] = {}
-
-    show_prompt_tokens: bool = False
-    show_completion_tokens: bool = False
-    show_total_tokens: bool = True
-    show_cost: bool = True
-    show_kwh: bool = False
-    show_kgco2eq: bool = True
 
     filter_date_from_value: str | None = None
     filter_date_to_value: str | None = None
@@ -59,6 +52,7 @@ class UsageState(EntityState):
             prompt_tokens=bucket["prompt_tokens"],
             completion_tokens=bucket["completion_tokens"],
             total_tokens=bucket["total_tokens"],
+            requests=bucket.get("requests", 0),
             cost=bucket["cost"],
             kwh=bucket["impacts"]["kWh"],
             kgco2eq=bucket["impacts"]["kgCO2eq"],
@@ -149,37 +143,48 @@ class UsageState(EntityState):
             self.entities_loading = False
             yield
 
-    @rx.var
-    def chart_data(self) -> list[dict[str, Any]]:
-        return [
-            {
-                "date": bucket.date,
-                "prompt_tokens": bucket.prompt_tokens,
-                "completion_tokens": bucket.completion_tokens,
-                "total_tokens": bucket.total_tokens,
-                "cost": bucket.cost,
-                "kWh": bucket.kwh,
-                "kgCO2eq": bucket.kgco2eq,
-            }
-            for bucket in self.entities
-        ]
+    @staticmethod
+    def _chart_point(bucket: Usage) -> dict[str, Any]:
+        return {
+            "date": bucket.date,
+            "prompt_tokens": bucket.prompt_tokens,
+            "completion_tokens": bucket.completion_tokens,
+            "total_tokens": bucket.total_tokens,
+            "requests": getattr(bucket, "requests", 0),
+            "cost": round(bucket.cost, 2),
+            "kWh": round(bucket.kwh, 2),
+            "kgCO2eq": round(bucket.kgco2eq or 0, 2),
+        }
+
+    @staticmethod
+    def _empty_chart_point(date: str) -> dict[str, Any]:
+        return {
+            "date": date,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "requests": 0,
+            "cost": 0.0,
+            "kWh": 0.0,
+            "kgCO2eq": 0.0,
+        }
 
     @rx.var
-    def visible_chart_series(self) -> list[dict[str, str]]:
-        series: list[dict[str, str]] = []
-        if self.show_prompt_tokens:
-            series.append({"data_key": "prompt_tokens", "name": "Prompt tokens", "fill": "var(--blue-9)"})
-        if self.show_completion_tokens:
-            series.append({"data_key": "completion_tokens", "name": "Completion tokens", "fill": "var(--cyan-9)"})
-        if self.show_total_tokens:
-            series.append({"data_key": "total_tokens", "name": "Total tokens", "fill": "var(--iris-9)"})
-        if self.show_cost:
-            series.append({"data_key": "cost", "name": "Cost", "fill": "var(--amber-9)"})
-        if self.show_kwh:
-            series.append({"data_key": "kWh", "name": "kWh", "fill": "var(--green-9)"})
-        if self.show_kgco2eq:
-            series.append({"data_key": "kgCO2eq", "name": "kgCO2eq", "fill": "var(--tomato-9)"})
-        return series
+    def chart_data(self) -> list[dict[str, Any]]:
+        by_date = {bucket.date: self._chart_point(bucket) for bucket in self.entities}
+        start = dt.datetime.strptime(self.get_filter_date_from_value, DATE_FORMAT).date()
+        end = dt.datetime.strptime(self.get_filter_date_to_value, DATE_FORMAT).date()
+        points: list[dict[str, Any]] = []
+        day = start
+        while day < end:
+            key = day.strftime(DATE_FORMAT)
+            points.append(by_date.get(key) or self._empty_chart_point(key))
+            day += dt.timedelta(days=1)
+        return points
+
+    @rx.var
+    def summary_requests(self) -> str:
+        return f"{sum(getattr(bucket, 'requests', 0) for bucket in self.entities):,}"
 
     @rx.var
     def summary_prompt_tokens(self) -> str:
@@ -195,20 +200,20 @@ class UsageState(EntityState):
 
     @rx.var
     def summary_cost(self) -> str:
-        return f"{sum(bucket.cost for bucket in self.entities):.4f}"
+        return f"{sum(bucket.cost for bucket in self.entities):.2f}"
 
     @rx.var
     def summary_kwh(self) -> str:
-        return f"{sum(bucket.kwh for bucket in self.entities):.5f}"
+        return f"{sum(bucket.kwh for bucket in self.entities):.2f}"
 
     @rx.var
     def summary_kgco2eq(self) -> str:
-        return f"{sum(bucket.kgco2eq for bucket in self.entities):.5f}"
+        return f"{sum(bucket.kgco2eq or 0 for bucket in self.entities):.2f}"
 
     @rx.var
     def get_filter_date_from_value(self) -> str:
         if self.filter_date_from_value is None:
-            return format_local_date(local_now() - dt.timedelta(days=30))
+            return format_local_date(local_now() - dt.timedelta(days=7))
         return self.filter_date_from_value
 
     @rx.var
@@ -240,30 +245,6 @@ class UsageState(EntityState):
     @rx.event
     def set_filter_key(self, value: str):
         self.filter_key_value = value
-
-    @rx.event
-    def set_show_prompt_tokens(self, value: bool):
-        self.show_prompt_tokens = value
-
-    @rx.event
-    def set_show_completion_tokens(self, value: bool):
-        self.show_completion_tokens = value
-
-    @rx.event
-    def set_show_total_tokens(self, value: bool):
-        self.show_total_tokens = value
-
-    @rx.event
-    def set_show_cost(self, value: bool):
-        self.show_cost = value
-
-    @rx.event
-    def set_show_kwh(self, value: bool):
-        self.show_kwh = value
-
-    @rx.event
-    def set_show_kgco2eq(self, value: bool):
-        self.show_kgco2eq = value
 
     @rx.event
     async def apply_filters(self):

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -1,7 +1,6 @@
-"""Usage state for fetching account usage with pagination and filters."""
+"""Usage state for fetching daily usage buckets with filters."""
 
 import datetime as dt
-import math
 from typing import Any
 
 import httpx
@@ -10,32 +9,59 @@ import reflex as rx
 from app.features.usage.models import Usage
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import date_to_timestamp, format_datetime, format_local_date, local_now
+from app.shared.utils.timestamps import date_to_timestamp, format_date, format_local_date, local_now
+
+ALL_ENDPOINTS = "All endpoints"
+ALL_MODELS = "All models"
+ALL_KEYS = "All keys"
+SYSTEM_KEY_NAMES = {"_system_playground_key", "_system_search_tool"}
+USAGE_PAGE_LIMIT = 100
 
 
 class UsageState(EntityState):
-    """State for account usage listing and filters."""
+    """State for account usage buckets, filters, and chart series."""
+
+    entities: list[Usage] = []
+    available_models: list[str] = [ALL_MODELS]
+    available_keys: list[str] = [ALL_KEYS]
+    key_ids_by_name: dict[str, int] = {}
+
+    show_prompt_tokens: bool = False
+    show_completion_tokens: bool = False
+    show_total_tokens: bool = True
+    show_cost: bool = True
+    show_kwh: bool = False
+    show_kgco2eq: bool = True
+
+    filter_date_from_value: str | None = None
+    filter_date_to_value: str | None = None
+    filter_endpoint_value: str = ALL_ENDPOINTS
+    filter_model_value: str = ALL_MODELS
+    filter_key_value: str = ALL_KEYS
 
     @rx.var
     def endpoints_name_list(self) -> list[str]:
-        return ["All endpoints", "/v1/chat/completions", "/v1/embeddings", "/v1/ocr", "/v1/rerank", "/v1/search"]
+        return [
+            ALL_ENDPOINTS,
+            "/v1/audio/transcriptions",
+            "/v1/chat/completions",
+            "/v1/embeddings",
+            "/v1/ocr",
+            "/v1/rerank",
+            "/v1/search",
+        ]
 
-    ############################################################
-    # Load entities
-    ############################################################
-    entities: list[Usage] = []
-
-    def _format_usage(self, usage: dict) -> Usage:
+    def _format_bucket(self, bucket: dict) -> Usage:
         return Usage(
-            created=format_datetime(usage["created"]),
-            endpoint=usage["endpoint"],
-            model=usage["model"],
-            key=usage["key"],
-            prompt_tokens=usage["usage"]["prompt_tokens"],
-            completion_tokens=usage["usage"]["completion_tokens"],
-            total_tokens=usage["usage"]["total_tokens"],
-            cost=usage["usage"]["cost"],
-            kgco2eq=usage["usage"]["impacts"]["kgCO2eq"],
+            start_time=bucket["start_time"],
+            end_time=bucket["end_time"],
+            date=format_date(bucket["start_time"]),
+            prompt_tokens=bucket["prompt_tokens"],
+            completion_tokens=bucket["completion_tokens"],
+            total_tokens=bucket["total_tokens"],
+            cost=bucket["cost"],
+            kwh=bucket["impacts"]["kWh"],
+            kgco2eq=bucket["impacts"]["kgCO2eq"],
         )
 
     @rx.event
@@ -48,30 +74,74 @@ class UsageState(EntityState):
 
         start_time = date_to_timestamp(self.get_filter_date_from_value)
         end_time = date_to_timestamp(self.get_filter_date_to_value)
-
-        params = {
-            "offset": (self.page - 1) * self.per_page,
-            "limit": self.per_page,
-            "start_time": start_time,
-            "end_time": end_time,
-        }
-        if self.filter_endpoint_value != "All endpoints":
-            params["endpoint"] = self.filter_endpoint_value
+        headers = {"Authorization": f"Bearer {self.api_key}"}
 
         response = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(
-                    url=f"{self.opengatellm_url}/v1/usage",
-                    params=params,
-                    headers={"Authorization": f"Bearer {self.api_key}"},
+                models_response = await client.get(
+                    url=f"{self.opengatellm_url}/v1/models",
+                    headers=headers,
                     timeout=self.opengatellm_timeout,
                 )
-                response.raise_for_status()
-                data = response.json()
-                self.entities = [self._format_usage(usage) for usage in data.get("data", [])]
+                models_response.raise_for_status()
+                model_names = sorted(model.get("id") for model in models_response.json().get("data", []) if model.get("id"))
+                self.available_models = [ALL_MODELS, *model_names]
+                if self.filter_model_value not in self.available_models:
+                    self.filter_model_value = ALL_MODELS
 
-            self.total = data.get("total", 0)
+                keys_response = await client.get(
+                    url=f"{self.opengatellm_url}/v1/keys",
+                    params={"offset": 0, "limit": USAGE_PAGE_LIMIT},
+                    headers=headers,
+                    timeout=self.opengatellm_timeout,
+                )
+                keys_response.raise_for_status()
+                key_ids_by_name: dict[str, int] = {}
+                key_names: list[str] = []
+                for key in keys_response.json().get("data", []):
+                    if key["name"] in SYSTEM_KEY_NAMES:
+                        continue
+                    key_names.append(key["name"])
+                    key_ids_by_name[key["name"]] = key["id"]
+                self.available_keys = [ALL_KEYS, *key_names]
+                self.key_ids_by_name = key_ids_by_name
+                if self.filter_key_value not in self.available_keys:
+                    self.filter_key_value = ALL_KEYS
+
+                buckets: list[Usage] = []
+                offset = 0
+                total = None
+                while total is None or len(buckets) < total:
+                    params: dict[str, Any] = {
+                        "offset": offset,
+                        "limit": USAGE_PAGE_LIMIT,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                    }
+                    if self.filter_endpoint_value != ALL_ENDPOINTS:
+                        params["endpoint"] = self.filter_endpoint_value
+                    if self.filter_model_value != ALL_MODELS:
+                        params["models"] = self.filter_model_value
+                    if self.filter_key_value != ALL_KEYS:
+                        params["key_id"] = self.key_ids_by_name[self.filter_key_value]
+
+                    response = await client.get(
+                        url=f"{self.opengatellm_url}/v1/usage",
+                        params=params,
+                        headers=headers,
+                        timeout=self.opengatellm_timeout,
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+                    total = payload.get("total", 0)
+                    page = [self._format_bucket(bucket) for bucket in payload.get("data", [])]
+                    buckets.extend(page)
+                    if not page:
+                        break
+                    offset += USAGE_PAGE_LIMIT
+
+                self.entities = sorted(buckets, key=lambda bucket: bucket.start_time)
 
         except Exception as e:
             yield httpx_error_toast(exception=e, response=response)
@@ -80,56 +150,60 @@ class UsageState(EntityState):
             yield
 
     @rx.var
-    def usage_rows(self) -> list[dict[str, Any]]:
-        rows: list[dict[str, Any]] = []
-        for row in self.entities:
-            rows.append(
-                {
-                    "date": row.created,
-                    "endpoint": row.endpoint,
-                    "key": row.key,
-                    "model": row.model,
-                    "tokens": "" if row.total_tokens == 0 else f"{row.prompt_tokens} → {row.completion_tokens}",
-                    "cost": "" if row.cost == 0.0 or row.cost is None else f"{row.cost:.4f}",
-                    "kgCO2eq": "" if row.kgco2eq is None else f"{round(row.kgco2eq, 5)}",
-                }
-            )
-        return rows
-
-    ############################################################
-    # Pagination & filters
-    ############################################################
-    page: int = 1
-    per_page: int = 20
-    total: int = 0
-    order_by_value: str = "id"
-    order_direction: str = "asc"
-    order_direction_options: list[str] = ["asc", "desc"]
-    order_direction_value: str = "asc"
+    def chart_data(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "date": bucket.date,
+                "prompt_tokens": bucket.prompt_tokens,
+                "completion_tokens": bucket.completion_tokens,
+                "total_tokens": bucket.total_tokens,
+                "cost": bucket.cost,
+                "kWh": bucket.kwh,
+                "kgCO2eq": bucket.kgco2eq,
+            }
+            for bucket in self.entities
+        ]
 
     @rx.var
-    def total_pages(self) -> int:
-        return max(1, math.ceil(self.total / self.per_page))
+    def visible_chart_series(self) -> list[dict[str, str]]:
+        series: list[dict[str, str]] = []
+        if self.show_prompt_tokens:
+            series.append({"data_key": "prompt_tokens", "name": "Prompt tokens", "fill": "var(--blue-9)"})
+        if self.show_completion_tokens:
+            series.append({"data_key": "completion_tokens", "name": "Completion tokens", "fill": "var(--cyan-9)"})
+        if self.show_total_tokens:
+            series.append({"data_key": "total_tokens", "name": "Total tokens", "fill": "var(--iris-9)"})
+        if self.show_cost:
+            series.append({"data_key": "cost", "name": "Cost", "fill": "var(--amber-9)"})
+        if self.show_kwh:
+            series.append({"data_key": "kWh", "name": "kWh", "fill": "var(--green-9)"})
+        if self.show_kgco2eq:
+            series.append({"data_key": "kgCO2eq", "name": "kgCO2eq", "fill": "var(--tomato-9)"})
+        return series
 
-    @rx.event
-    async def prev_page(self):
-        if self.page > 1:
-            self.page -= 1
-            yield
-            async for _ in self.load_entities():
-                yield
+    @rx.var
+    def summary_prompt_tokens(self) -> str:
+        return f"{sum(bucket.prompt_tokens for bucket in self.entities):,}"
 
-    @rx.event
-    async def next_page(self):
-        if self.page < self.total_pages:
-            self.page += 1
-            yield
-            async for _ in self.load_entities():
-                yield
+    @rx.var
+    def summary_completion_tokens(self) -> str:
+        return f"{sum(bucket.completion_tokens for bucket in self.entities):,}"
 
-    filter_date_from_value: str | None = None
-    filter_date_to_value: str | None = None
-    filter_endpoint_value: str = "All endpoints"
+    @rx.var
+    def summary_total_tokens(self) -> str:
+        return f"{sum(bucket.total_tokens for bucket in self.entities):,}"
+
+    @rx.var
+    def summary_cost(self) -> str:
+        return f"{sum(bucket.cost for bucket in self.entities):.4f}"
+
+    @rx.var
+    def summary_kwh(self) -> str:
+        return f"{sum(bucket.kwh for bucket in self.entities):.5f}"
+
+    @rx.var
+    def summary_kgco2eq(self) -> str:
+        return f"{sum(bucket.kgco2eq for bucket in self.entities):.5f}"
 
     @rx.var
     def get_filter_date_from_value(self) -> str:
@@ -160,8 +234,39 @@ class UsageState(EntityState):
         self.filter_endpoint_value = value
 
     @rx.event
+    def set_filter_model(self, value: str):
+        self.filter_model_value = value
+
+    @rx.event
+    def set_filter_key(self, value: str):
+        self.filter_key_value = value
+
+    @rx.event
+    def set_show_prompt_tokens(self, value: bool):
+        self.show_prompt_tokens = value
+
+    @rx.event
+    def set_show_completion_tokens(self, value: bool):
+        self.show_completion_tokens = value
+
+    @rx.event
+    def set_show_total_tokens(self, value: bool):
+        self.show_total_tokens = value
+
+    @rx.event
+    def set_show_cost(self, value: bool):
+        self.show_cost = value
+
+    @rx.event
+    def set_show_kwh(self, value: bool):
+        self.show_kwh = value
+
+    @rx.event
+    def set_show_kgco2eq(self, value: bool):
+        self.show_kgco2eq = value
+
+    @rx.event
     async def apply_filters(self):
-        self.page = 1
         yield
         async for _ in self.load_entities():
             yield

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -9,7 +9,7 @@ import reflex as rx
 from app.features.usage.models import Usage
 from app.shared.components.toasts import httpx_error_toast
 from app.shared.states.entity_state import EntityState
-from app.shared.utils.timestamps import DATE_FORMAT, date_to_timestamp, format_date, format_local_date, local_now
+from app.shared.utils.timestamps import date_to_timestamp, format_local_date, format_utc_date, local_now, utc_dates_in_range
 
 ALL_ENDPOINTS = "All endpoints"
 ALL_MODELS = "All models"
@@ -48,7 +48,7 @@ class UsageState(EntityState):
         return Usage(
             start_time=bucket["start_time"],
             end_time=bucket["end_time"],
-            date=format_date(bucket["start_time"]),
+            date=format_utc_date(bucket["start_time"]),
             prompt_tokens=bucket["prompt_tokens"],
             completion_tokens=bucket["completion_tokens"],
             total_tokens=bucket["total_tokens"],
@@ -150,7 +150,7 @@ class UsageState(EntityState):
             "prompt_tokens": bucket.prompt_tokens,
             "completion_tokens": bucket.completion_tokens,
             "total_tokens": bucket.total_tokens,
-            "requests": getattr(bucket, "requests", 0),
+            "requests": bucket.requests,
             "cost": round(bucket.cost, 2),
             "kWh": round(bucket.kwh, 2),
             "kgCO2eq": round(bucket.kgco2eq or 0, 2),
@@ -180,15 +180,13 @@ class UsageState(EntityState):
     @rx.var
     def chart_data(self) -> list[dict[str, Any]]:
         by_date = {bucket.date: self._chart_point(bucket) for bucket in self.entities}
-        start = dt.datetime.strptime(self.get_filter_date_from_value, DATE_FORMAT).date()
-        end = dt.datetime.strptime(self.get_filter_date_to_value, DATE_FORMAT).date()
-        points: list[dict[str, Any]] = []
-        day = start
-        while day < end:
-            key = day.strftime(DATE_FORMAT)
-            points.append(by_date.get(key) or self._empty_chart_point(key))
-            day += dt.timedelta(days=1)
-        return points
+        return [
+            by_date.get(date) or self._empty_chart_point(date)
+            for date in utc_dates_in_range(
+                date_to_timestamp(self.get_filter_date_from_value),
+                date_to_timestamp(self.get_filter_date_to_value),
+            )
+        ]
 
     @rx.var
     def chart_max_requests(self) -> int:
@@ -224,7 +222,7 @@ class UsageState(EntityState):
 
     @rx.var
     def summary_requests(self) -> str:
-        return f"{sum(getattr(bucket, 'requests', 0) for bucket in self.entities):,}"
+        return f"{sum(bucket.requests for bucket in self.entities):,}"
 
     @rx.var
     def summary_prompt_tokens(self) -> str:

--- a/playground/app/features/usage/state.py
+++ b/playground/app/features/usage/state.py
@@ -169,6 +169,14 @@ class UsageState(EntityState):
             "kgCO2eq": 0.0,
         }
 
+    @staticmethod
+    def _chart_max(points: list[dict[str, Any]], *keys: str, stacked: bool = False) -> float:
+        if not points:
+            return 0.0
+        if stacked:
+            return max(sum(float(point.get(key, 0) or 0) for key in keys) for point in points)
+        return max(float(point.get(key, 0) or 0) for point in points for key in keys)
+
     @rx.var
     def chart_data(self) -> list[dict[str, Any]]:
         by_date = {bucket.date: self._chart_point(bucket) for bucket in self.entities}
@@ -181,6 +189,38 @@ class UsageState(EntityState):
             points.append(by_date.get(key) or self._empty_chart_point(key))
             day += dt.timedelta(days=1)
         return points
+
+    @rx.var
+    def chart_max_requests(self) -> int:
+        return int(self._chart_max(self.chart_data, "requests"))
+
+    @rx.var
+    def chart_max_requests_label(self) -> str:
+        return f"{self.chart_max_requests:,}"
+
+    @rx.var
+    def chart_max_tokens(self) -> int:
+        return int(self._chart_max(self.chart_data, "prompt_tokens", "completion_tokens", stacked=True))
+
+    @rx.var
+    def chart_max_tokens_label(self) -> str:
+        return f"{self.chart_max_tokens:,}"
+
+    @rx.var
+    def chart_max_cost(self) -> float:
+        return self._chart_max(self.chart_data, "cost")
+
+    @rx.var
+    def chart_max_cost_label(self) -> str:
+        return f"{self.chart_max_cost:.2f}"
+
+    @rx.var
+    def chart_max_impacts(self) -> float:
+        return self._chart_max(self.chart_data, "kWh", "kgCO2eq")
+
+    @rx.var
+    def chart_max_impacts_label(self) -> str:
+        return f"{self.chart_max_impacts:.2f}"
 
     @rx.var
     def summary_requests(self) -> str:

--- a/playground/app/shared/components/headers.py
+++ b/playground/app/shared/components/headers.py
@@ -5,12 +5,40 @@ from app.core.variables import (
     HEADING_WEIGHT,
     ICON_SIZE_MEDIUM,
     MARGIN_MEDIUM,
+    PADDING_PAGE,
+    SPACING_MEDIUM,
 )
 
 
 def header_heading(title: str) -> rx.Component:
     """Heading with title."""
     return rx.heading(title, size=HEADING_SIZE_PAGE, weight=HEADING_WEIGHT)
+
+
+def header_divider(*, bleed: bool = True) -> rx.Component:
+    """Solid horizontal rule under a page header.
+
+    When `bleed` is True, the rule breaks out of page padding so it spans the
+    full content pane (full-bleed).
+    """
+    style = {
+        "width": f"calc(100% + 2 * {PADDING_PAGE})" if bleed else "100%",
+        "margin_left": f"-{PADDING_PAGE}" if bleed else "0",
+        "margin_right": f"-{PADDING_PAGE}" if bleed else "0",
+        "border_bottom": f"1px solid {rx.color('mauve', 6)}",
+    }
+    return rx.box(**style)
+
+
+def page_header(title_row: rx.Component, *, bleed: bool = True) -> rx.Component:
+    """Page title row with a full-width solid divider underneath."""
+    return rx.vstack(
+        title_row,
+        header_divider(bleed=bleed),
+        spacing=SPACING_MEDIUM,
+        width="100%",
+        margin_bottom=MARGIN_MEDIUM,
+    )
 
 
 def entity_refresh_button(state: rx.State) -> rx.Component:
@@ -26,16 +54,17 @@ def entity_refresh_button(state: rx.State) -> rx.Component:
 
 def entity_header(title: str, state: rx.State) -> rx.Component:
     """Header with title and refresh button."""
-    return rx.hstack(
-        header_heading(title),
-        entity_refresh_button(state),
-        width="100%",
-        justify="between",
-        align="center",
-        margin_bottom=MARGIN_MEDIUM,
+    return page_header(
+        rx.hstack(
+            header_heading(title),
+            entity_refresh_button(state),
+            width="100%",
+            justify="between",
+            align="center",
+        )
     )
 
 
 def header(title: str) -> rx.Component:
     """Header with title."""
-    return header_heading(title)
+    return page_header(header_heading(title))

--- a/playground/app/shared/components/headers.py
+++ b/playground/app/shared/components/headers.py
@@ -30,14 +30,14 @@ def header_divider(*, bleed: bool = True) -> rx.Component:
     return rx.box(**style)
 
 
-def page_header(title_row: rx.Component, *, bleed: bool = True) -> rx.Component:
+def page_header(title_row: rx.Component, *, bleed: bool = True, margin_bottom: str = MARGIN_MEDIUM) -> rx.Component:
     """Page title row with a full-width solid divider underneath."""
     return rx.vstack(
         title_row,
         header_divider(bleed=bleed),
         spacing=SPACING_MEDIUM,
         width="100%",
-        margin_bottom=MARGIN_MEDIUM,
+        margin_bottom=margin_bottom,
     )
 
 

--- a/playground/app/shared/components/headers.py
+++ b/playground/app/shared/components/headers.py
@@ -42,13 +42,15 @@ def page_header(title_row: rx.Component, *, bleed: bool = True, margin_bottom: s
 
 
 def entity_refresh_button(state: rx.State) -> rx.Component:
-    """Refresh button."""
-    return rx.button(
-        rx.icon("refresh-cw", size=ICON_SIZE_MEDIUM),
-        "Refresh",
-        on_click=state.load_entities,
-        variant="soft",
-        loading=state.entities_loading,
+    """Icon-only refresh control for page headers."""
+    return rx.tooltip(
+        rx.button(
+            rx.icon("refresh-cw", size=ICON_SIZE_MEDIUM, color="black"),
+            on_click=state.load_entities,
+            variant="ghost",
+            loading=state.entities_loading,
+        ),
+        content="Refresh",
     )
 
 

--- a/playground/app/shared/utils/timestamps.py
+++ b/playground/app/shared/utils/timestamps.py
@@ -42,6 +42,27 @@ def format_date(timestamp: int | float | None, default: str = "") -> str:
     return default if local is None else local.strftime(DATE_FORMAT)
 
 
+def format_utc_date(timestamp: int | float | None, default: str = "") -> str:
+    """Render a Unix timestamp as a UTC `YYYY-MM-DD` string, or `default` if it is None."""
+    if timestamp is None:
+        return default
+    return dt.datetime.fromtimestamp(timestamp=timestamp, tz=dt.UTC).strftime(DATE_FORMAT)
+
+
+def utc_dates_in_range(start_timestamp: int, end_timestamp: int) -> list[str]:
+    """UTC `YYYY-MM-DD` dates overlapping `[start_timestamp, end_timestamp)`."""
+    if end_timestamp <= start_timestamp:
+        return []
+    start = dt.datetime.fromtimestamp(start_timestamp, tz=dt.UTC).date()
+    last = dt.datetime.fromtimestamp(end_timestamp - 1, tz=dt.UTC).date()
+    dates: list[str] = []
+    day = start
+    while day <= last:
+        dates.append(day.strftime(DATE_FORMAT))
+        day += dt.timedelta(days=1)
+    return dates
+
+
 def format_local_date(moment: dt.datetime) -> str:
     """Render a datetime as a local `YYYY-MM-DD` string, for date pickers."""
     return moment.astimezone().strftime(DATE_FORMAT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 playground = [
     "python-jose==3.5.0",
-    "reflex==0.8.27",
+    "reflex==0.8.28.post1",
 ]
 api = [
     "alembic==1.18.4",
@@ -32,10 +32,10 @@ api = [
     "limits==5.8.0",
     "mistralai==2.0.0",
     "openai==2.15.0",
-    "prometheus-fastapi-instrumentator==7.1.0",
+    "prometheus-fastapi-instrumentator==8.1.0",
     "psycopg2-binary==2.9.11",
     "python-jose==3.5.0",
-    "python-multipart==0.0.27",
+    "python-multipart==0.0.32",
     "redis==7.2.1",
     "sentry-sdk[fastapi]==2.53.0",
     "sqlalchemy-utils==0.42.1",


### PR DESCRIPTION
## Overview

`GET /v1/usage` (and the deprecated `GET /v1/me/usage`) now returns **daily UTC buckets** for the authenticated user instead of per-request rows. `start_time` and `end_time` are required. The playground Usage page charts those buckets (requests, stacked tokens, cost, impacts), with summary totals and a dashed line at each chart’s peak (stacked total for tokens).

Playground chrome on the same branch: full-width page headers, sidebar divider under the app title, parameters panel below the chat header, and icon-only New chat / Refresh actions.

- [x] Daily UTC usage buckets from `GET /v1/usage`, with required `start_time` / `end_time`
- [x] Filters (endpoint, model, key) still apply to the aggregated buckets
- [x] Unit, endpoint, and repository tests updated for the new contract
- [x] Playground Usage page: date-range charts, summary metrics, peak reference lines
- [x] Playground header / sidebar / chat layout tightened without changing auth or routing

**Breaking changes:**

- [ ] No breaking changes
- [x] This PR contains breaking changes (explain below)

`GET /v1/usage` no longer returns individual usage records. Clients receive `usage.bucket` objects (`start_time`, `end_time`, token sums, `requests`, `cost`, `impacts`). `start_time` and `end_time` are now required query parameters.

## Check lists

### Review checklist

- [ ] Updated or added documentation (OpenAPI schema is updated; docs site not touched)
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**

Not modified. Aggregation is a query change only (no Alembic revision).

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

API clients of `GET /v1/usage` must send `start_time` / `end_time` and consume daily buckets.

## Additional Notes

Worth checking in review:

- UTC day boundaries in `_postgresusagerepository.py` (`date_trunc` after converting `created` to UTC)
- Playground Tokens chart: peak line is `prompt_tokens + completion_tokens` (stacked), not the max of a single series
- Reflex bump to `0.8.28.post1` (plus unrelated patch bumps of `prometheus-fastapi-instrumentator` and `python-multipart` in `pyproject.toml`)