### PR TITLE
refacto(router): make Router.aliases non-nullable and align the test factory

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "80.75%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "80.94%", "color": "green"}

--- a/api/domain/audio/entities.py
+++ b/api/domain/audio/entities.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 from pydantic import Field
 
 from api.domain import BaseModel, ForwardablePayload
-from api.domain.model.entities import ModelJsonResponse
+from api.domain.model.entities import ProviderJsonResponse
 from api.domain.usage.entities import Usage
 from api.utils.variables import SUPPORTED_LANGUAGES
 
@@ -37,7 +37,7 @@ class Segment(BaseModel):
     speaker: Annotated[str | None, Field(default=None, description="Speaker label assigned by diarization, if available.")]
 
 
-class AudioTranscriptions(ModelJsonResponse):
+class AudioTranscriptions(ProviderJsonResponse):
     id: str
     model: str
     text: str

--- a/api/domain/embeddings/entities.py
+++ b/api/domain/embeddings/entities.py
@@ -8,7 +8,7 @@ from openai.types.chat import ChatCompletionContentPartParam
 from pydantic import Field
 
 from api.domain import BaseModel, ForwardablePayload
-from api.domain.model.entities import ModelJsonResponse
+from api.domain.model.entities import ProviderJsonResponse
 from api.domain.usage.entities import Usage
 
 
@@ -51,7 +51,7 @@ class CreateEmbeddingsBody(ForwardablePayload):
             return []
 
 
-class Embeddings(CreateEmbeddingResponse, ModelJsonResponse):
+class Embeddings(CreateEmbeddingResponse, ProviderJsonResponse):
     object: Literal["list"] = "list"
     id: str
     model: str

--- a/api/domain/model/_modelenvironmentalimpactscomputer.py
+++ b/api/domain/model/_modelenvironmentalimpactscomputer.py
@@ -1,13 +1,7 @@
 from abc import ABC, abstractmethod
-from enum import StrEnum
 
-import pycountry
-
+from api.domain.provider.entities import HostingZone
 from api.domain.usage.entities import EnvironmentalImpacts
-
-# Add world as a country code, default value of the carbon footprint computation framework
-_country_codes = [country.alpha_3 for country in pycountry.countries] + ["WOR"]
-HostingZone = StrEnum("HostingZone", {str(code).upper(): str(code) for code in sorted(set(_country_codes))})
 
 
 class ModelEnvironmentalImpactsComputer(ABC):

--- a/api/domain/model/entities.py
+++ b/api/domain/model/entities.py
@@ -1,6 +1,8 @@
 from enum import StrEnum
 
 from api.domain import BaseModel
+from api.domain.provider.entities import ProviderJsonResponse
+from api.domain.router.entities import RouterType
 
 
 class ModelCosts(BaseModel):
@@ -8,30 +10,21 @@ class ModelCosts(BaseModel):
     completion_tokens: float = 0.0
 
 
-class ModelType(StrEnum):
-    AUTOMATIC_SPEECH_RECOGNITION = "automatic-speech-recognition"
-    IMAGE_TEXT_TO_TEXT = "image-text-to-text"
-    IMAGE_TO_TEXT = "image-to-text"
-    TEXT_CLASSIFICATION = "text-classification"
-    TEXT_EMBEDDINGS_INFERENCE = "text-embeddings-inference"
-    TEXT_GENERATION = "text-generation"
-
-
-class ModelJsonResponse(BaseModel):
-    def get_completions(self) -> list[str]:
-        return []
+# class ModelJsonResponse(BaseModel):
+#     def get_completions(self) -> list[str]:
+#         return []
 
 
 class Model(BaseModel):
     id: str
-    type: ModelType
+    type: RouterType
     aliases: list[str] = []
     created: int
     owned_by: str
     max_context_length: int | None = None
 
 
-class Models(ModelJsonResponse):
+class Models(ProviderJsonResponse):
     data: list[Model]
 
 

--- a/api/domain/model/views.py
+++ b/api/domain/model/views.py
@@ -3,7 +3,8 @@ from typing import Annotated
 from pydantic import ConfigDict, Field
 
 from api.domain import BaseModel, UtcDatetime
-from api.domain.model.entities import ModelCosts, ModelType
+from api.domain.model.entities import ModelCosts
+from api.domain.router.entities import RouterType
 
 
 class ModelView(BaseModel):
@@ -13,7 +14,7 @@ class ModelView(BaseModel):
 
     router_id: int
     id: str
-    type: ModelType
+    type: RouterType
     aliases: list[str] = []
     created: UtcDatetime
     owned_by: str

--- a/api/domain/ocr/entities.py
+++ b/api/domain/ocr/entities.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Literal
 from pydantic import Field
 
 from api.domain import BaseModel, ForwardablePayload
-from api.domain.model.entities import ModelJsonResponse
+from api.domain.model.entities import ProviderJsonResponse
 from api.domain.usage.entities import Usage
 
 
@@ -81,7 +81,7 @@ class OCRPageObject(BaseModel):
     markdown: str | None = None
 
 
-class OCR(ModelJsonResponse):
+class OCR(ProviderJsonResponse):
     id: str
     model: str
     document_annotation: str | None = None

--- a/api/domain/provider/entities.py
+++ b/api/domain/provider/entities.py
@@ -2,13 +2,16 @@ from enum import StrEnum
 from http import HTTPMethod
 from typing import Annotated, Literal
 
+import pycountry
 from pydantic import Field, model_validator
 
 from api.domain import BaseModel, EntitiesPage, ForwardablePayload, UtcDatetime
-from api.domain.model._modelenvironmentalimpactscomputer import HostingZone
-from api.domain.model.entities import ModelJsonResponse, ModelType
-from api.domain.router.entities import Router
+from api.domain.router.entities import Router, RouterType
 from api.utils.variables import EndpointRoute
+
+# Add world as a country code, default value of the carbon footprint computation framework
+_country_codes = [country.alpha_3 for country in pycountry.countries] + ["WOR"]
+HostingZone = StrEnum("HostingZone", {str(code).upper(): str(code) for code in sorted(set(_country_codes))})
 
 
 class Metric(StrEnum):
@@ -28,6 +31,11 @@ class BasicAuth(BaseModel):
     password: str
 
 
+class ProviderJsonResponse(BaseModel):
+    def get_completions(self) -> list[str]:
+        return []
+
+
 class ProviderType(StrEnum):
     ALBERT = "albert"
     OPENAI = "openai"
@@ -35,42 +43,42 @@ class ProviderType(StrEnum):
     TEI = "tei"
     VLLM = "vllm"
 
-    def is_compatible_with(self, router_type: ModelType) -> bool:
+    def is_compatible_with(self, router_type: RouterType) -> bool:
         return self.value in COMPATIBLE_PROVIDER_TYPES[router_type]
 
 
-COMPATIBLE_PROVIDER_TYPES: dict[ModelType, list[str]] = {
-    ModelType.AUTOMATIC_SPEECH_RECOGNITION: [  # audio transcriptions
+COMPATIBLE_PROVIDER_TYPES: dict[RouterType, list[str]] = {
+    RouterType.AUTOMATIC_SPEECH_RECOGNITION: [  # audio transcriptions
         ProviderType.ALBERT.value,
         ProviderType.MISTRAL.value,
         ProviderType.OPENAI.value,
         ProviderType.VLLM.value,
     ],
-    ModelType.IMAGE_TEXT_TO_TEXT: [  # chat completions
+    RouterType.IMAGE_TEXT_TO_TEXT: [  # chat completions
         ProviderType.ALBERT.value,
         ProviderType.MISTRAL.value,
         ProviderType.OPENAI.value,
         ProviderType.VLLM.value,
     ],
-    ModelType.TEXT_EMBEDDINGS_INFERENCE: [  # embeddings
+    RouterType.TEXT_EMBEDDINGS_INFERENCE: [  # embeddings
         ProviderType.ALBERT.value,
         ProviderType.OPENAI.value,
         ProviderType.MISTRAL.value,
         ProviderType.TEI.value,
         ProviderType.VLLM.value,
     ],
-    ModelType.TEXT_GENERATION: [  # chat completions
+    RouterType.TEXT_GENERATION: [  # chat completions
         ProviderType.ALBERT.value,
         ProviderType.MISTRAL.value,
         ProviderType.OPENAI.value,
         ProviderType.VLLM.value,
     ],
-    ModelType.TEXT_CLASSIFICATION: [  # rerank
+    RouterType.TEXT_CLASSIFICATION: [  # rerank
         ProviderType.ALBERT.value,
         ProviderType.TEI.value,
         ProviderType.VLLM.value,
     ],
-    ModelType.IMAGE_TO_TEXT: [  # ocr
+    RouterType.IMAGE_TO_TEXT: [  # ocr
         ProviderType.MISTRAL.value,
     ],
 }
@@ -165,7 +173,7 @@ class ProviderOriginalResponse(BaseModel):
     text: Annotated[str | None, Field(default=None, description="The text data to use for the response.")]
 
 
-class ProviderMetrics(ModelJsonResponse):
+class ProviderMetrics(ProviderJsonResponse):
     object: Literal["providerMetrics"] = "providerMetrics"
     waiting_requests: float
     running_requests: float
@@ -173,7 +181,7 @@ class ProviderMetrics(ModelJsonResponse):
 
 class ProviderFormattedResponse(BaseModel):
     id: Annotated[str, Field(description="The request identifier.")]
-    data: Annotated[ModelJsonResponse | None, Field(default=None, description="The JSON data to use for the response.")]
+    data: Annotated[ProviderJsonResponse | None, Field(default=None, description="The JSON data to use for the response.")]
     text: Annotated[str | None, Field(default=None, description="The text data to use for the response.")]
 
     @model_validator(mode="after")

--- a/api/domain/rerank/entities.py
+++ b/api/domain/rerank/entities.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from pydantic import Field
 
 from api.domain import BaseModel, ForwardablePayload
-from api.domain.model.entities import ModelJsonResponse
+from api.domain.model.entities import ProviderJsonResponse
 from api.domain.usage.entities import Usage
 
 
@@ -22,7 +22,7 @@ class RerankResult(BaseModel):
     index: int
 
 
-class Rerank(ModelJsonResponse):
+class Rerank(ProviderJsonResponse):
     id: str
     model: str
     results: list[RerankResult]

--- a/api/domain/router/_routerrepository.py
+++ b/api/domain/router/_routerrepository.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
 
 from api.domain import SortField, SortOrder
-from api.domain.model.entities import ModelType as RouterType
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterPage
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterPage, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 
 

--- a/api/domain/router/entities.py
+++ b/api/domain/router/entities.py
@@ -22,7 +22,7 @@ class Router(BaseModel):
     name: str
     user_id: int
     type: RouterType
-    aliases: list[str] | None
+    aliases: list[str]
     load_balancing_strategy: RouterLoadBalancingStrategy
     cost_prompt_tokens: float
     cost_completion_tokens: float

--- a/api/domain/router/entities.py
+++ b/api/domain/router/entities.py
@@ -5,7 +5,6 @@ from typing import Annotated
 from pydantic import BaseModel, Field
 
 from api.domain import EntitiesPage, UtcDatetime
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.role.entities import LimitType
 
 
@@ -15,6 +14,15 @@ class RouterLoadBalancingStrategy(StrEnum):
 
 
 RouterPage = EntitiesPage["Router"]
+
+
+class RouterType(StrEnum):
+    AUTOMATIC_SPEECH_RECOGNITION = "automatic-speech-recognition"
+    IMAGE_TEXT_TO_TEXT = "image-text-to-text"
+    IMAGE_TO_TEXT = "image-to-text"
+    TEXT_CLASSIFICATION = "text-classification"
+    TEXT_EMBEDDINGS_INFERENCE = "text-embeddings-inference"
+    TEXT_GENERATION = "text-generation"
 
 
 class Router(BaseModel):

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field
 
 from api.domain import BaseModel
-from api.domain.model.entities import ModelType
+from api.domain.router.entities import RouterType as ModelType
 from api.infrastructure.fastapi.schemas import UnixTimestamp
 
 

--- a/api/infrastructure/http/adapters/models/_modelsadapter.py
+++ b/api/infrastructure/http/adapters/models/_modelsadapter.py
@@ -1,7 +1,8 @@
 from http import HTTPMethod
 
-from api.domain.model.entities import Model, Models, ModelType
+from api.domain.model.entities import Model, Models
 from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.router.entities import RouterType
 from api.infrastructure.http.adapters import HttpProviderAdapter
 from api.utils.variables import EndpointRoute
 
@@ -34,7 +35,7 @@ class ModelsAdapter(HttpProviderAdapter):
                         created=model.get("created", 0),
                         owned_by=model.get("owned_by", "unknown"),
                         max_context_length=model.get("max_context_length", None),
-                        type=ModelType.TEXT_GENERATION,  # dummy value, not used
+                        type=RouterType.TEXT_GENERATION,  # dummy value, not used
                     )
                     for model in original_response.data["data"]
                 ]

--- a/api/infrastructure/http/adapters/models/mistral/_mistralmodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/mistral/_mistralmodelsadapter.py
@@ -1,5 +1,6 @@
-from api.domain.model.entities import Model, Models, ModelType
+from api.domain.model.entities import Model, Models
 from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.router.entities import RouterType
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
@@ -21,7 +22,7 @@ class MistralModelsAdapter(ModelsAdapter):
                         created=model["created"],
                         owned_by=model["owned_by"],
                         max_context_length=model["max_context_length"],
-                        type=ModelType.TEXT_GENERATION,  # dummy value, not used
+                        type=RouterType.TEXT_GENERATION,  # dummy value, not used
                     )
                     for model in original_response.data.get("data", [])
                 ]

--- a/api/infrastructure/http/adapters/models/tei/_teimodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/tei/_teimodelsadapter.py
@@ -1,5 +1,6 @@
-from api.domain.model.entities import Model, Models, ModelType
+from api.domain.model.entities import Model, Models
 from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.router.entities import RouterType
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
@@ -23,7 +24,7 @@ class TeiModelsAdapter(ModelsAdapter):
                         created=0,
                         owned_by="tei",
                         max_context_length=original_response.data["max_input_length"],
-                        type=ModelType.TEXT_GENERATION,  # dummy value, not used
+                        type=RouterType.TEXT_GENERATION,  # dummy value, not used
                     )
                 ]
             ),

--- a/api/infrastructure/http/adapters/models/vllm/_vllmmodelsadapter.py
+++ b/api/infrastructure/http/adapters/models/vllm/_vllmmodelsadapter.py
@@ -1,5 +1,6 @@
-from api.domain.model.entities import Model, Models, ModelType
+from api.domain.model.entities import Model, Models
 from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
+from api.domain.router.entities import RouterType
 from api.infrastructure.http.adapters.models import ModelsAdapter
 
 
@@ -21,7 +22,7 @@ class VllmModelsAdapter(ModelsAdapter):
                         created=model["created"],
                         owned_by=model["owned_by"],
                         max_context_length=model["max_model_len"],
-                        type=ModelType.TEXT_GENERATION,  # dummy value, not used
+                        type=RouterType.TEXT_GENERATION,  # dummy value, not used
                     )
                     for model in original_response.data.get("data", [])
                 ]

--- a/api/infrastructure/postgres/_postgresmodelquery.py
+++ b/api/infrastructure/postgres/_postgresmodelquery.py
@@ -2,9 +2,10 @@ from sqlalchemy import Select, func, literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain.model import ModelQuery
-from api.domain.model.entities import ModelCosts, ModelType
+from api.domain.model.entities import ModelCosts
 from api.domain.model.errors import ModelNotFoundError
 from api.domain.model.views import ModelView
+from api.domain.router.entities import RouterType
 from api.sql.models import Organization as OrganizationTable
 from api.sql.models import Provider as ProviderTable
 from api.sql.models import Router as RouterTable
@@ -82,7 +83,7 @@ class PostgresModelQuery(ModelQuery):
         return ModelView(
             router_id=row.router_id,
             id=row.id,
-            type=ModelType(row.type),
+            type=RouterType(row.type),
             aliases=row.aliases,
             created=row.created,
             owned_by=row.owned_by,

--- a/api/infrastructure/postgres/_postgresrouterrepository.py
+++ b/api/infrastructure/postgres/_postgresrouterrepository.py
@@ -229,13 +229,12 @@ class PostgresRouterRepository(RouterRepository):
             result = await self.postgres_session.execute(update_query)
             row = result.one()
 
-            if router.aliases is not None:
-                await self.postgres_session.execute(delete(RouterAliasTable).where(RouterAliasTable.router_id == router.id))
-                if router.aliases:
-                    await self.postgres_session.execute(
-                        insert(RouterAliasTable),
-                        [{"value": alias, "router_id": router.id} for alias in router.aliases],
-                    )
+            await self.postgres_session.execute(delete(RouterAliasTable).where(RouterAliasTable.router_id == router.id))
+            if router.aliases:
+                await self.postgres_session.execute(
+                    insert(RouterAliasTable),
+                    [{"value": alias, "router_id": router.id} for alias in router.aliases],
+                )
         except IntegrityError as e:
             if "router_name_key" in str(e.orig):
                 return RouterNameAlreadyExistsError(name=router.name)

--- a/api/infrastructure/postgres/_postgresrouterrepository.py
+++ b/api/infrastructure/postgres/_postgresrouterrepository.py
@@ -3,9 +3,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.domain import SortField, SortOrder
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.router import RouterRepository
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterPage
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterPage, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.infrastructure.postgres._pagination import fetch_page_with_total
 from api.infrastructure.postgres.decorators import with_lock

--- a/api/tests/integration/endpoints/admin/provider/test_create_provider.py
+++ b/api/tests/integration/endpoints/admin/provider/test_create_provider.py
@@ -6,7 +6,6 @@ import pytest_asyncio
 import respx
 
 from api.dependencies import create_provider_use_case_factory
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError, ModelNotFoundError
 from api.domain.provider.entities import ProviderType
 from api.domain.provider.errors import (
@@ -15,6 +14,7 @@ from api.domain.provider.errors import (
     ProviderInvalidResponseError,
     ProviderNotReachableError,
 )
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
 from api.tests.integration.endpoints.utils import DEFAULT_PROVIDER_URL, mock_models_responses

--- a/api/tests/integration/endpoints/admin/router/test_update_router.py
+++ b/api/tests/integration/endpoints/admin/router/test_update_router.py
@@ -5,8 +5,7 @@ import pytest
 import pytest_asyncio
 
 from api.dependencies import update_router_use_case_factory
-from api.domain.model.entities import ModelType
-from api.domain.router.entities import RouterLoadBalancingStrategy
+from api.domain.router.entities import RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.tests.helpers import INVALID_API_KEY, create_key
 from api.tests.integration.factories.sql import RouterSQLFactory, UserSQLFactory
@@ -18,7 +17,7 @@ URL = f"/v1{EndpointRoute.ADMIN_ROUTERS}"
 def _valid_body(**overrides) -> dict:
     body = {
         "name": "updated-name",
-        "type": ModelType.TEXT_GENERATION,
+        "type": RouterType.TEXT_GENERATION,
         "aliases": [],
         "load_balancing_strategy": RouterLoadBalancingStrategy.SHUFFLE,
         "cost_prompt_tokens": 0.0,
@@ -55,7 +54,7 @@ class TestUpdateRouter:
         assert data["id"] == router.id
         assert data["name"] == "updated-name"
         assert data["aliases"] == ["alias-1"]
-        assert data["type"] == ModelType.TEXT_GENERATION
+        assert data["type"] == RouterType.TEXT_GENERATION
         assert data["load_balancing_strategy"] == RouterLoadBalancingStrategy.SHUFFLE
         assert data["cost_prompt_tokens"] == 0.5
         assert data["cost_completion_tokens"] == 1.5

--- a/api/tests/integration/endpoints/test_audiotranscriptions.py
+++ b/api/tests/integration/endpoints/test_audiotranscriptions.py
@@ -7,11 +7,11 @@ import respx
 
 from api.dependencies import create_audio_transcriptions_use_case_factory
 from api.domain.audio.errors import AudioFileSizeLimitExceededError
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider.entities import HostingZone, ProviderType
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import LimitType
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
 from api.schemas.models import ModelType

--- a/api/tests/integration/endpoints/test_embeddings.py
+++ b/api/tests/integration/endpoints/test_embeddings.py
@@ -7,11 +7,11 @@ import pytest_asyncio
 import respx
 
 from api.dependencies import create_embeddings_use_case_factory
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider.entities import ProviderType
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import LimitType
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
 from api.schemas.models import ModelType

--- a/api/tests/integration/endpoints/test_ocr.py
+++ b/api/tests/integration/endpoints/test_ocr.py
@@ -6,11 +6,11 @@ import pytest_asyncio
 import respx
 
 from api.dependencies import create_ocr_use_case_factory
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider.entities import HostingZone, ProviderType
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import LimitType
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
 from api.schemas.models import ModelType

--- a/api/tests/integration/endpoints/test_post_response_hooks.py
+++ b/api/tests/integration/endpoints/test_post_response_hooks.py
@@ -6,8 +6,7 @@ import pytest
 import pytest_asyncio
 import respx
 
-from api.domain.model._modelenvironmentalimpactscomputer import HostingZone
-from api.domain.provider.entities import ProviderType
+from api.domain.provider.entities import HostingZone, ProviderType
 from api.domain.role.entities import Limit, LimitType
 from api.infrastructure.redis import RedisRouterRateLimiter
 from api.schemas.core.configuration import LimitingStrategy

--- a/api/tests/integration/endpoints/test_post_response_hooks.py
+++ b/api/tests/integration/endpoints/test_post_response_hooks.py
@@ -6,10 +6,10 @@ import pytest
 import pytest_asyncio
 import respx
 
+from api.domain.model._modelenvironmentalimpactscomputer import HostingZone
 from api.domain.provider.entities import ProviderType
 from api.domain.role.entities import Limit, LimitType
 from api.infrastructure.redis import RedisRouterRateLimiter
-from api.schemas.admin.providers import ProviderCarbonFootprintZone
 from api.schemas.core.configuration import LimitingStrategy
 from api.schemas.models import ModelType
 from api.tests.helpers import create_key
@@ -49,7 +49,7 @@ class TestPostResponseHooks:
             providers=1,
             providers__type=ProviderType.MISTRAL,
             providers__url=DEFAULT_PROVIDER_URL,
-            providers__model_hosting_zone=ProviderCarbonFootprintZone.FRA,
+            providers__model_hosting_zone=HostingZone.FRA,
         )
         for limit_type, value in LIMITS:
             LimitSQLFactory(role=self.user.role, router=self.router, type=limit_type, value=value)

--- a/api/tests/integration/endpoints/test_rerank.py
+++ b/api/tests/integration/endpoints/test_rerank.py
@@ -7,11 +7,11 @@ import pytest_asyncio
 import respx
 
 from api.dependencies import create_rerank_use_case_factory
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider.entities import ProviderType
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import LimitType
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.user.errors import UserHasInsufficientBudgetError, UserHasNoAccessToRouterError
 from api.schemas.models import ModelType

--- a/api/tests/integration/factories/albert.py
+++ b/api/tests/integration/factories/albert.py
@@ -1,7 +1,7 @@
 import factory
 from faker import Faker
 
-from api.domain.model.entities import ModelCosts, ModelType
+from api.domain.model.entities import ModelCosts, RouterType
 
 fake = Faker()
 
@@ -22,7 +22,7 @@ class AlbertModelResponseFactory(factory.DictFactory):
     aliases = factory.LazyFunction(lambda: [fake.bothify(text="????/???-?#")])
     object = "model"
     owned_by = "albert"
-    type = factory.Faker("random_element", elements=list(ModelType))
+    type = factory.Faker("random_element", elements=list(RouterType))
     max_context_length = factory.Faker("random_int", min=1024, max=8192)
     costs = factory.LazyFunction(
         lambda: ModelCosts(

--- a/api/tests/integration/postgres/test_postgresmodelquery.py
+++ b/api/tests/integration/postgres/test_postgresmodelquery.py
@@ -2,9 +2,9 @@ from datetime import datetime
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import ModelNotFoundError
 from api.domain.model.views import ModelView
+from api.domain.router.entities import RouterType
 from api.infrastructure.postgres import PostgresModelQuery
 from api.tests.integration.factories.sql import OrganizationSQLFactory, ProviderSQLFactory, RouterSQLFactory, UserSQLFactory
 

--- a/api/tests/integration/postgres/test_postgresproviderrepository.py
+++ b/api/tests/integration/postgres/test_postgresproviderrepository.py
@@ -4,9 +4,9 @@ import pytest
 from sqlalchemy import select
 
 from api.domain import SortOrder
-from api.domain.model.entities import ModelType
 from api.domain.provider.entities import BasicAuth, HostingZone, Metric, Provider, ProviderSortField, ProviderType, QoSMetric
 from api.domain.provider.errors import ProviderAlreadyExistsError, ProviderNotFoundError
+from api.domain.router.entities import RouterType
 from api.infrastructure.postgres import PostgresProviderRepository
 from api.sql.models import Provider as ProviderTable
 from api.tests.integration.factories.sql import ProviderSQLFactory, RouterSQLFactory, UserSQLFactory
@@ -45,7 +45,7 @@ class TestCreateProvider:
     async def test_create_provider_should_return_created_provider(self, repository, db_session):
         # Arrange
         user = UserSQLFactory(admin_user=True)
-        router = RouterSQLFactory(user=user, type=ModelType.TEXT_GENERATION)
+        router = RouterSQLFactory(user=user, type=RouterType.TEXT_GENERATION)
         await db_session.flush()
 
         # Act
@@ -77,7 +77,7 @@ class TestCreateProvider:
     async def test_create_provider_should_return_provider_already_exists_when_same_url_name_and_router_are_used(self, repository, db_session):
         # Arrange
         user = UserSQLFactory(admin_user=True)
-        router = RouterSQLFactory(user=user, type=ModelType.TEXT_GENERATION)
+        router = RouterSQLFactory(user=user, type=RouterType.TEXT_GENERATION)
         ProviderSQLFactory(type=ProviderType.ALBERT, url="http://test.com/", model_name="duplicate-provider", router=router)
         await db_session.flush()
 

--- a/api/tests/integration/postgres/test_postgresrouterrepository.py
+++ b/api/tests/integration/postgres/test_postgresrouterrepository.py
@@ -596,20 +596,6 @@ class TestUpdateRouter:
         aliases = (await db_session.execute(select(RouterAliasTable).where(RouterAliasTable.router_id == router.id))).scalars().all()
         assert aliases == []
 
-    async def test_update_router_should_not_touch_aliases_when_aliases_is_none(self, repository, db_session):
-        # Arrange
-        user = UserSQLFactory()
-        router = RouterSQLFactory(user=user, name="router-aliases-untouched", alias=["kept-alias"])
-        await db_session.flush()
-
-        # Act
-        await repository.update_router(to_router_domain(router, aliases=["kept-alias"]).model_copy(update={"aliases": None}))
-
-        # Assert
-        await db_session.flush()
-        aliases = (await db_session.execute(select(RouterAliasTable.value).where(RouterAliasTable.router_id == router.id))).scalars().all()
-        assert aliases == ["kept-alias"]
-
     async def test_update_router_should_return_router_name_already_exists_when_name_is_duplicate(self, repository, db_session):
         # Arrange
         user = UserSQLFactory()

--- a/api/tests/integration/postgres/test_postgresrouterrepository.py
+++ b/api/tests/integration/postgres/test_postgresrouterrepository.py
@@ -4,8 +4,7 @@ import pytest
 from sqlalchemy import select
 
 from api.domain import SortField, SortOrder
-from api.domain.model.entities import ModelType as RouterType
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.infrastructure.postgres import PostgresRouterRepository
 from api.sql.models import Provider as ProviderTable

--- a/api/tests/integration/use_case/test_providercapabilitiesprobe.py
+++ b/api/tests/integration/use_case/test_providercapabilitiesprobe.py
@@ -4,8 +4,8 @@ import httpx
 import pytest
 import respx
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.provider.entities import ProviderCapabilities, ProviderType
+from api.domain.router.entities import RouterType
 from api.infrastructure.http import HttpProviderAdapterBuilder, HttpProviderClient
 from api.tests.integration.factories.tei import TeiEmbeddingsResponseFactory, TeiModelsResponseFactory
 from api.tests.integration.factories.vllm import VllmModelsResponseFactory

--- a/api/tests/unit/infrastructure/factories.py
+++ b/api/tests/unit/infrastructure/factories.py
@@ -7,9 +7,10 @@ from faker import Faker
 from openai.types import Embedding
 
 from api.domain.embeddings.entities import CreateEmbeddingsBody, Embeddings
-from api.domain.model.entities import Model, Models, ModelType
+from api.domain.model.entities import Model, Models
 from api.domain.provider.entities import BasicAuth, ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest
 from api.domain.rerank.entities import CreateRerankBody, Rerank, RerankResult
+from api.domain.router.entities import RouterType
 from api.utils.variables import EndpointRoute
 
 fake = Faker()
@@ -132,7 +133,7 @@ class ProviderModelResponseFactory(factory.Factory):
     owned_by = factory.Faker("company")
     max_context_length = factory.Faker("random_int", min=64000, max=245600)
     aliases = factory.LazyFunction(lambda: [fake.bothify(text="model-????-latest")])
-    type = factory.Faker("random_element", elements=list(ModelType))
+    type = factory.Faker("random_element", elements=list(RouterType))
 
 
 class ProviderModelsFormattedResponseFactory(factory.Factory):

--- a/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
+++ b/api/tests/unit/infrastructure/http/adapters/test_modelsadapter.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from api.domain.model.entities import Models, ModelType
+from api.domain.model.entities import Models
 from api.domain.provider.entities import ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
+from api.domain.router.entities import RouterType
 from api.infrastructure.http.adapters.models.albert import AlbertModelsAdapter
 from api.infrastructure.http.adapters.models.mistral import MistralModelsAdapter
 from api.infrastructure.http.adapters.models.openai import OpenaiModelsAdapter
@@ -241,7 +242,7 @@ class TestModelsAdapter:
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
-        assert result.data.data[0].type is ModelType.TEXT_GENERATION
+        assert result.data.data[0].type is RouterType.TEXT_GENERATION
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_context_length"]
         assert result.data.data[0].aliases == response_data["data"][0]["aliases"]
 
@@ -259,7 +260,7 @@ class TestModelsAdapter:
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
-        assert result.data.data[0].type is ModelType.TEXT_GENERATION
+        assert result.data.data[0].type is RouterType.TEXT_GENERATION
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].max_context_length is None
         assert result.data.data[0].aliases == []
@@ -278,7 +279,7 @@ class TestModelsAdapter:
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 3
         assert result.data.data[0].id == response_data["data"][0]["id"]
-        assert result.data.data[0].type is ModelType.TEXT_GENERATION
+        assert result.data.data[0].type is RouterType.TEXT_GENERATION
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_context_length"]
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].aliases == []
@@ -297,7 +298,7 @@ class TestModelsAdapter:
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 1
         assert result.data.data[0].id == response_data["model_id"]
-        assert result.data.data[0].type is ModelType.TEXT_GENERATION
+        assert result.data.data[0].type is RouterType.TEXT_GENERATION
         assert result.data.data[0].max_context_length == response_data["max_input_length"]
         assert result.data.data[0].owned_by == "tei"
         assert result.data.data[0].aliases == []
@@ -316,7 +317,7 @@ class TestModelsAdapter:
         assert isinstance(result.data, Models)
         assert len(result.data.data) == 1
         assert result.data.data[0].id == response_data["data"][0]["id"]
-        assert result.data.data[0].type is ModelType.TEXT_GENERATION
+        assert result.data.data[0].type is RouterType.TEXT_GENERATION
         assert result.data.data[0].max_context_length == response_data["data"][0]["max_model_len"]
         assert result.data.data[0].owned_by == response_data["data"][0]["owned_by"]
         assert result.data.data[0].aliases == []

--- a/api/tests/unit/use_case/admin/providers/test_createproviderusecase.py
+++ b/api/tests/unit/use_case/admin/providers/test_createproviderusecase.py
@@ -2,7 +2,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError, ModelNotFoundError
 from api.domain.provider.entities import HostingZone, ProviderCapabilities, ProviderType
 from api.domain.provider.errors import (
@@ -11,6 +10,7 @@ from api.domain.provider.errors import (
     ProviderInvalidResponseError,
     ProviderNotReachableError,
 )
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterNotFoundError
 from api.tests.unit.use_case.factories import ProviderFactory, RouterFactory
 from api.use_cases.admin.providers import CreateProviderCommand, CreateProviderUseCase, CreateProviderUseCaseSuccess

--- a/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
+++ b/api/tests/unit/use_case/admin/providers/test_updateproviderusecase.py
@@ -2,10 +2,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError
 from api.domain.provider.entities import HostingZone, ProviderType, QoSMetric
 from api.domain.provider.errors import InvalidProviderTypeError, ProviderAlreadyExistsError, ProviderNotFoundError
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterNotFoundError
 from api.tests.unit.use_case.factories import ProviderFactory, RouterFactory
 from api.use_cases.admin.providers._updateproviderusecase import UpdateProviderCommand, UpdateProviderUseCase, UpdateProviderUseCaseSuccess

--- a/api/tests/unit/use_case/admin/routers/test_createrouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_createrouterusecase.py
@@ -2,8 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
-from api.domain.router.entities import RouterLoadBalancingStrategy
+from api.domain.router.entities import RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError
 from api.tests.unit.use_case.factories import RouterFactory
 from api.use_cases.admin.routers import CreateRouterCommand, CreateRouterUseCase

--- a/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
@@ -30,7 +30,7 @@ def full_command(router, **overrides) -> UpdateRouterCommand:
         router_id=router.id,
         name=router.name,
         router_type=router.type,
-        aliases=router.aliases or [],
+        aliases=router.aliases,
         load_balancing_strategy=router.load_balancing_strategy,
         cost_prompt_tokens=router.cost_prompt_tokens,
         cost_completion_tokens=router.cost_completion_tokens,
@@ -158,7 +158,7 @@ class TestUpdateRouterUseCase:
     @pytest.mark.asyncio
     async def test_should_add_aliases_when_router_has_no_aliases_and_command_updates_aliases(self, use_case, router_repository):
         # Arrange
-        router = RouterFactory(id=42, user_id=1, aliases=None)
+        router = RouterFactory(id=42, user_id=1, aliases=[])
         updated_router = router.with_aliases(["new-alias"])
 
         use_case.router_repository.get_router_by_id.return_value = router

--- a/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
+++ b/api/tests/unit/use_case/admin/routers/test_updaterouterusecase.py
@@ -2,8 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
-from api.domain.router.entities import RouterLoadBalancingStrategy
+from api.domain.router.entities import RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 from api.tests.unit.use_case.factories import RouterFactory
 from api.use_cases.admin.routers import UpdateRouterCommand, UpdateRouterUseCase, UpdateRouterUseCaseSuccess

--- a/api/tests/unit/use_case/admin/test_bootstrapmodelsusecase.py
+++ b/api/tests/unit/use_case/admin/test_bootstrapmodelsusecase.py
@@ -2,10 +2,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import InconsistentModelMaxContextLengthError, InconsistentModelVectorSizeError, ModelNotFoundError
 from api.domain.provider.entities import ProviderCapabilities
 from api.domain.provider.errors import ProviderAlreadyExistsError, ProviderInvalidResponseError, ProviderNotReachableError
+from api.domain.router.entities import RouterType
 from api.domain.router.errors import RouterNameAlreadyExistsError
 from api.tests.unit.use_case.factories import (
     ModelConfigurationFactory,

--- a/api/tests/unit/use_case/audio/test_createaudiotranscriptionsusecase.py
+++ b/api/tests/unit/use_case/audio/test_createaudiotranscriptionsusecase.py
@@ -9,9 +9,8 @@ from api.domain.audio.entities import (
     CreateAudioTranscriptionsForm,
 )
 from api.domain.audio.errors import AudioFileSizeLimitExceededError
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.provider.entities import ProviderFormattedResponse
-from api.domain.router.entities import RouterRateLimitState
+from api.domain.router.entities import RouterRateLimitState, RouterType
 from api.domain.usage import UsageRecorder
 from api.tests.unit.use_case.factories import AuthenticatedUserFactory, RouterFactory
 from api.use_cases.audio import (

--- a/api/tests/unit/use_case/embeddings/test_createembeddingsusecase.py
+++ b/api/tests/unit/use_case/embeddings/test_createembeddingsusecase.py
@@ -1,4 +1,4 @@
-from api.domain.model.entities import ModelType as RouterType
+from api.domain.router.entities import RouterType
 from api.use_cases.embeddings import CreateEmbeddingsUseCase
 from api.utils.variables import EndpointRoute
 

--- a/api/tests/unit/use_case/factories.py
+++ b/api/tests/unit/use_case/factories.py
@@ -62,7 +62,7 @@ class RouterFactory(factory.Factory):
     name = factory.Faker("bothify", text="router_####")
     user_id = factory.Faker("random_int", min=1, max=1000)
     type = factory.Faker("random_element", elements=list(RouterType))
-    aliases = None
+    aliases = factory.LazyFunction(list)
     load_balancing_strategy = factory.Faker("random_element", elements=list(RouterLoadBalancingStrategy))
     cost_prompt_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)
     cost_completion_tokens = factory.Faker("pyfloat", left_digits=1, right_digits=4, min_value=0, max_value=1)

--- a/api/tests/unit/use_case/factories.py
+++ b/api/tests/unit/use_case/factories.py
@@ -5,12 +5,11 @@ import factory
 from factory import fuzzy
 
 from api.domain.model.entities import ModelCosts
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.views import ModelView
 from api.domain.organization.entities import Organization
 from api.domain.provider.entities import BasicAuth, HostingZone, Provider, ProviderType
 from api.domain.role.entities import Limit, LimitType, PermissionType, Role
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterType
 from api.domain.user.entities import User
 from api.domain.user.views import AuthenticatedUserView
 from api.schemas.core.configuration import Model as ModelConfiguration

--- a/api/tests/unit/use_case/ocr/test_createocrusecase.py
+++ b/api/tests/unit/use_case/ocr/test_createocrusecase.py
@@ -1,4 +1,4 @@
-from api.domain.model.entities import ModelType as RouterType
+from api.domain.router.entities import RouterType
 from api.use_cases.ocr import CreateOCRUseCase
 from api.utils.variables import EndpointRoute
 

--- a/api/tests/unit/use_case/reranks/test_creatererankusecase.py
+++ b/api/tests/unit/use_case/reranks/test_creatererankusecase.py
@@ -1,4 +1,4 @@
-from api.domain.model.entities import ModelType as RouterType
+from api.domain.router.entities import RouterType
 from api.use_cases.reranks import CreateRerankUseCase
 from api.utils.variables import EndpointRoute
 

--- a/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
+++ b/api/tests/unit/use_case/services/test_providercapabilitiesprobe.py
@@ -5,11 +5,11 @@ import pytest
 
 from api.domain.embeddings.entities import Embeddings
 from api.domain.model.entities import Model, Models
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import ModelNotFoundError, StatusCodeModelError
 from api.domain.provider import ProviderAdapter, ProviderAdapterBuilder, ProviderClient
 from api.domain.provider.entities import ProviderCapabilities, ProviderFormattedResponse, ProviderOriginalResponse, ProviderType
 from api.domain.provider.errors import ProviderInvalidResponseError, ProviderNotReachableError
+from api.domain.router.entities import RouterType
 from api.tests.unit.use_case.factories import ProviderFactory
 from api.use_cases.services import ProviderCapabilitiesProbe
 from api.utils.variables import EndpointRoute

--- a/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
+++ b/api/tests/unit/use_case/test_providerrequestforwadingusecase.py
@@ -5,8 +5,7 @@ import pytest
 
 from api.domain import ForwardablePayload
 from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
-from api.domain.model.entities import ModelJsonResponse
-from api.domain.model.entities import ModelType as RouterType
+from api.domain.model.entities import ProviderJsonResponse
 from api.domain.model.errors import TooBusyModelError
 from api.domain.provider import (
     ProviderAdapter,
@@ -25,7 +24,7 @@ from api.domain.provider.entities import (
 from api.domain.provider.errors import ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.role.entities import Limit, LimitType
 from api.domain.router import RouterRateLimiter, RouterRepository
-from api.domain.router.entities import RouterRateLimitState, RpmRateLimitState, TpmRateLimitState
+from api.domain.router.entities import RouterRateLimitState, RouterType, RpmRateLimitState, TpmRateLimitState
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.usage import UsageRecorder
 from api.domain.usage.entities import EnvironmentalImpacts, Usage
@@ -47,7 +46,7 @@ class ForwardingTestPayload(ForwardablePayload):
         return ["hello"]
 
 
-class ForwardingTestData(ModelJsonResponse):
+class ForwardingTestData(ProviderJsonResponse):
     id: str = "req-1"
     usage: Usage | None = None
 

--- a/api/use_cases/_providerrequestforwardingusecase.py
+++ b/api/use_cases/_providerrequestforwardingusecase.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel
 
 from api.domain import ForwardablePayload
 from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import StatusCodeModelError, TooBusyModelError, UnknownModelError
 from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderLoadBalancer, ProviderMetricsLogger, ProviderRepository
 from api.domain.provider.entities import ProviderFormattedRequest, ProviderFormattedResponse, ProviderOriginalRequest, ProviderOriginalResponse
 from api.domain.provider.errors import NoAvailableProviderError, ProviderAdapterValidationRequestError, ProviderAdapterValidationResponseError
 from api.domain.router import RouterRateLimiter, RouterRepository
-from api.domain.router.entities import Router, RouterRateLimitState
+from api.domain.router.entities import Router, RouterRateLimitState, RouterType
 from api.domain.router.errors import RouterHasNoProvidersError, RouterHasWrongTypeError, RouterNotFoundError, RouterRateLimitExceededError
 from api.domain.usage import UsageRecorder
 from api.domain.usage.entities import Usage

--- a/api/use_cases/admin/routers/_createrouterusecase.py
+++ b/api/use_cases/admin/routers/_createrouterusecase.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.router import RouterRepository
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError
 
 

--- a/api/use_cases/admin/routers/_updaterouterusecase.py
+++ b/api/use_cases/admin/routers/_updaterouterusecase.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.router import RouterRepository
-from api.domain.router.entities import Router, RouterLoadBalancingStrategy
+from api.domain.router.entities import Router, RouterLoadBalancingStrategy, RouterType
 from api.domain.router.errors import RouterAliasAlreadyExistsError, RouterNameAlreadyExistsError, RouterNotFoundError
 
 

--- a/api/use_cases/admin/routers/_updaterouterusecase.py
+++ b/api/use_cases/admin/routers/_updaterouterusecase.py
@@ -36,7 +36,7 @@ class UpdateRouterUseCase:
 
         if command.aliases:
             existing_aliases = await self.router_repository.get_aliases()
-            conflicting_aliases = set(command.aliases) & (set(existing_aliases) - set(router.aliases or []))
+            conflicting_aliases = set(command.aliases) & (set(existing_aliases) - set(router.aliases))
             if conflicting_aliases:
                 return RouterAliasAlreadyExistsError(aliases=list(conflicting_aliases))
 

--- a/api/use_cases/audio/_createaudiotranscriptionsusecase.py
+++ b/api/use_cases/audio/_createaudiotranscriptionsusecase.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass
 from api.domain.audio.entities import AudioTranscriptions, AudioTranscriptionsResponseFormat, CreateAudioTranscriptionsForm
 from api.domain.audio.errors import AudioFileSizeLimitExceededError
 from api.domain.model import ModelEnvironmentalImpactsComputer, ModelTokenizer
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.provider import ProviderAdapterBuilder, ProviderClient, ProviderLoadBalancer, ProviderMetricsLogger, ProviderRepository
 from api.domain.provider.entities import ProviderFormattedResponse
 from api.domain.router import RouterRateLimiter, RouterRepository
-from api.domain.router.entities import Router, RouterRateLimitState
+from api.domain.router.entities import Router, RouterRateLimitState, RouterType
 from api.domain.usage import UsageRecorder
 from api.use_cases._providerrequestforwardingusecase import ForwardingCommand, ProviderRequestForwardingUseCase, ProviderRequestForwardingUseCaseError
 from api.utils.variables import EndpointRoute

--- a/api/use_cases/embeddings/_createembeddingsusecase.py
+++ b/api/use_cases/embeddings/_createembeddingsusecase.py
@@ -1,5 +1,5 @@
 from api.domain.embeddings.entities import CreateEmbeddingsBody, Embeddings
-from api.domain.model.entities import ModelType as RouterType
+from api.domain.router.entities import RouterType
 from api.use_cases._providerrequestforwardingusecase import (
     ForwardingCommand,
     ProviderRequestForwardingUseCase,

--- a/api/use_cases/ocr/_createocrusecase.py
+++ b/api/use_cases/ocr/_createocrusecase.py
@@ -1,5 +1,5 @@
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.ocr.entities import OCR, CreateOCRBody
+from api.domain.router.entities import RouterType
 from api.use_cases._providerrequestforwardingusecase import (
     ForwardingCommand,
     ProviderRequestForwardingUseCase,

--- a/api/use_cases/reranks/_creatererankusecase.py
+++ b/api/use_cases/reranks/_creatererankusecase.py
@@ -1,5 +1,5 @@
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.rerank.entities import CreateRerankBody, Rerank
+from api.domain.router.entities import RouterType
 from api.use_cases._providerrequestforwardingusecase import (
     ForwardingCommand,
     ProviderRequestForwardingUseCase,

--- a/api/use_cases/services/_providercapabilitiesprobe.py
+++ b/api/use_cases/services/_providercapabilitiesprobe.py
@@ -1,9 +1,9 @@
 from api.domain.embeddings.entities import CreateEmbeddingsBody
-from api.domain.model.entities import ModelType as RouterType
 from api.domain.model.errors import ModelNotFoundError
 from api.domain.provider import ProviderAdapter, ProviderAdapterBuilder, ProviderClient
 from api.domain.provider.entities import Provider, ProviderCapabilities, ProviderOriginalRequest, ProviderOriginalResponse, ProviderType
 from api.domain.provider.errors import ProviderInvalidResponseError, ProviderNotReachableError
+from api.domain.router.entities import RouterType
 from api.utils.variables import EndpointRoute
 
 


### PR DESCRIPTION
## Overview

Resolves #1061

`RouterFactory` defaulted `aliases` to `None`, a shape no repository can produce: `PostgresRouterRepository` coalesces the alias aggregate to an empty array (`coalesce(array_agg(...), '{}'::text[])`), so `Router.aliases` is never `None` at runtime, while `RouterResponse.aliases` is a required, non-nullable list. The default unit fixture therefore described an impossible state, and serializing a router built from it raised `ValidationError: Input should be a valid list`.

The issue offered two directions. This PR applies **option 2 — tighten the entity**, which removes the impossible state at the type level instead of only stopping the fixture from lying.

| Layer | Before | After |
|---|---|---|
| `api/domain/router/entities.py` | `aliases: list[str] \| None` | `aliases: list[str]` |
| `api/use_cases/admin/routers/_updaterouterusecase.py` | `set(router.aliases or [])` | `set(router.aliases)` |
| `api/infrastructure/postgres/_postgresrouterrepository.py` | `if router.aliases is not None:` guarding the alias replacement | guard removed — `update_router` always replaces the aliases |
| `api/tests/unit/use_case/factories.py` | `aliases = None` | `aliases = factory.LazyFunction(list)`, matching `ModelConfigurationFactory` and `ModelViewFactory` |

Definition of Done, from the issue's acceptance criteria:

- [x] `RouterFactory()` with no argument builds a router that `RouterResponse.model_validate(..., from_attributes=True)` serializes without error
- [x] The chosen direction is applied consistently — `Router.aliases` is non-nullable, and every producer plus `with_aliases` describe the same set of values
- [ ] *N/A: the criterion targeted `api/tests/unit/infrastructure/fastapi/schemas/test_timestamp_boundary.py`, which does not exist on `main` — it belongs to the still-open #1099. Its explicit `aliases=[]` becomes removable once that branch rebases on this one.*
- [x] Unit and integration suites pass; `openapi.json` unchanged for `RouterResponse.aliases`

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

The HTTP contract is untouched: `RouterResponse` and `UpdateRouterBody` are unchanged, and so is their `openapi.json` output. The one behaviour change is internal and unreachable from production code — see Additional Notes.

## Check lists

### Review checklist

- [ ] Updated or added documentation — *N/A: no user-facing behaviour, API contract or configuration change.*
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks — `ruff check` and `ruff format --check` clean on all 6 changed files

**`api/sql/models.py` has not been modified**, so no Alembic migration is required.

## Deployment checklist

- [ ] Alembic migration has been generated — *N/A*
- [ ] Configuration file has been modified — *N/A*
- [ ] Environment variables have been modified — *N/A*

No schema change and no backfill. `aliases` has never been a column: aliases live in the `router_alias` table (one row per alias, `value` declared `NOT NULL` since its creating migration `2025_11_13_2012-9ba1f6a21f20`). A router without aliases is zero rows, which the read path already coalesces to `[]` — so no existing row can be in the state this PR forbids.

## Additional Notes

- **One integration test was removed:** `test_update_router_should_not_touch_aliases_when_aliases_is_none` covered the deleted `is not None` sentinel and reached it via `model_copy(update={"aliases": None})`; replacement and clearing stay covered by the two other alias tests.
- **That sentinel was unreachable:** `UpdateRouterUseCase` is the only caller of `update_router` and always passes `.with_aliases(command.aliases)` with a `list[str]`.
- **`create_router(aliases: list[str] | None = None)` is left as is:** that `None` is an optional input argument meaning "not provided", not a nullable entity field.

675 unit and 650 integration tests pass; `test_post_response_hooks.py` is excluded for a collection error pre-existing on `main` (`ModuleNotFoundError: api.schemas.admin.providers`).
