### PR TITLE
doc(quickstart): document CLI Python deps and ARM64 compose

### DIFF
--- a/docs/src/content/docs/configuration/dependencies/sentry.mdx
+++ b/docs/src/content/docs/configuration/dependencies/sentry.mdx
@@ -27,8 +27,11 @@ dependencies:
         traces_sample_rate: 1.0
         profiles_sample_rate: 1.0
         enable_tracing: true
+        max_request_body_size: never
 ```
 
 The Sentry dependency accepts all parameters from the [Sentry Python SDK](https://docs.sentry.io/platforms/python/configuration/options/). Only the `dsn` parameter is typically required.
+
+Set `max_request_body_size: never` so Sentry never captures HTTP request bodies. That keeps payload data out of Sentry and enforces zero request-body retention.
 
 <LinkButton href="/configuration/configuration_file" icon="external">Configuration file documentation</LinkButton>

--- a/docs/src/content/docs/configuration/dependencies/sentry.mdx
+++ b/docs/src/content/docs/configuration/dependencies/sentry.mdx
@@ -27,7 +27,6 @@ dependencies:
         traces_sample_rate: 1.0
         profiles_sample_rate: 1.0
         enable_tracing: true
-        max_request_body_size: never
 ```
 
 The Sentry dependency accepts all parameters from the [Sentry Python SDK](https://docs.sentry.io/platforms/python/configuration/options/). Only the `dsn` parameter is typically required.

--- a/docs/src/content/docs/deployment/production.mdx
+++ b/docs/src/content/docs/deployment/production.mdx
@@ -149,6 +149,7 @@ For more information, see [usage monitoring documentation](/features/usage/infer
 For more information, see [Prometheus documentation](/configuration/dependencies/prometheus/). 
 - For error monitoring, configure the optional `dependencies.sentry` section (there is no separate `monitoring_sentry_enabled` setting). 
 For more information, see [Sentry documentation](/configuration/dependencies/sentry/).
+- Set `max_request_body_size: never` so Sentry never captures HTTP request bodies. That keeps payload data out of Sentry and enforces zero request-body retention.
 
 **Example:**
 
@@ -158,6 +159,7 @@ dependencies:
   sentry:
     dsn: ${SENTRY_DSN}
     environment: production
+    max_request_body_size: never
 
 settings:
   [...]

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -56,7 +56,9 @@ import makeQuickstartGif from '../../../assets/make_quickstart.gif';
     - *compose.example.yml* → *compose.yml*
     </Aside>
 
-    <Aside type="tip" title="ARM64 hosts (Apple Silicon)">
+    <details>
+    <summary>ARM64 hosts (Apple Silicon)</summary>
+
     Official OpenGateLLM images are published for `linux/amd64` only. On ARM64, run:
 
     ```bash
@@ -74,8 +76,8 @@ import makeQuickstartGif from '../../../assets/make_quickstart.gif';
         image: ghcr.io/etalab-ia/opengatellm/playground:latest
     ```
 
-    On Docker Desktop for Mac, also enable **Use Rosetta for x86/amd64 emulation on Apple Silicon**.
-    </Aside>
+    On Docker Desktop for Mac, also enable use Rosetta for x86/amd64 emulation on Apple Silicon.
+    </details>
 
     **The bootstrap admin user is created and you can connect to the Playground with the following credentials:**
     - email: `admin`

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -9,6 +9,7 @@ import { Aside, LinkButton, Steps } from '@astrojs/starlight/components';
 import makeQuickstartGif from '../../../assets/make_quickstart.gif';
 
 <Aside type="caution" title="Prerequisites" icon="approve-check-circle">
+- Python 3.12+
 - Docker and Docker Compose
 - An access to a LLM API, eg. OpenAI, vLLM, Ollama... ([see supported model API](/features/supported_models/))
 </Aside>
@@ -18,9 +19,20 @@ import makeQuickstartGif from '../../../assets/make_quickstart.gif';
 
     ```bash
     git clone https://github.com/etalab-ia/OpenGateLLM.git
+    cd OpenGateLLM
     ```
 
-2. **Make quickstart**
+2. **Install Python dependencies**
+
+    `make quickstart` invokes `cli.py`, which needs a few Python packages. Install them with:
+
+    ```bash
+    pip install ".[dev]"
+    ```
+
+    A virtual environment is recommended.
+
+3. **Make quickstart**
 
     Run OpenGateLLM quickstart with the following command:
 
@@ -31,19 +43,39 @@ import makeQuickstartGif from '../../../assets/make_quickstart.gif';
     <div style="display: flex; justify-content: center;">
     <img src={makeQuickstartGif.src} alt="Quickstart command" width="50%"/>
     </div>
-    
+
     The services are running and available at the following URLs:
     - **API – http://localhost:8000/docs**
     - **Playground – http://localhost:8501**
 
     <Aside type="note" title="Quickstart command">
-    This command will launch the OpenGateLLM API and Playground, and their required dependencies, Postgres and Redis, in Docker containers. 
+    This command will launch the OpenGateLLM API and Playground, and their required dependencies, Postgres and Redis, in Docker containers.
     Moreover, it will copy these three files if they don't already exist:
     - *config.example.yml* → *config.yml*
     - *env.example* → *.env*
     - *compose.example.yml* → *compose.yml*
     </Aside>
 
+    <Aside type="tip" title="ARM64 hosts (Apple Silicon)">
+    Official OpenGateLLM images are published for `linux/amd64` only. On ARM64, run:
+
+    ```bash
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 make quickstart
+    ```
+
+    For a persistent setup, add `platform: linux/amd64` to the `api` and `playground` services in your local `compose.yml` (the copy created by the quickstart command — do not edit `compose.example.yml`):
+
+    ```diff lang="yaml"
+      api:
+    +   platform: linux/amd64
+        image: ghcr.io/etalab-ia/opengatellm/api:latest
+      playground:
+    +   platform: linux/amd64
+        image: ghcr.io/etalab-ia/opengatellm/playground:latest
+    ```
+
+    On Docker Desktop for Mac, also enable **Use Rosetta for x86/amd64 emulation on Apple Silicon**.
+    </Aside>
 
     **The bootstrap admin user is created and you can connect to the Playground with the following credentials:**
     - email: `admin`


### PR DESCRIPTION
## Overview

Resolves #910.

`make quickstart` runs `cli.py`, which needs Python packages that were missing from the getting-started page. This PR adds the install step and related setup notes.

- [x] Quickstart documents `pip install ".[dev]"` (and Python 3.12+) before `make quickstart`
- [x] ARM64 / Apple Silicon compose tips are documented without changing `compose.example.yml`, in a collapsed `<details>` section
- [x] Sentry docs recommend `max_request_body_size: never` so request bodies are not retained

**Breaking changes:**

- [x] No breaking changes
- [ ] This PR contains breaking changes (explain below)

## Check lists

### Review checklist

- [x] Updated or added documentation
- [ ] Updated or added unit tests (docs-only change)
- [ ] Updated or added integration tests (docs-only change)
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks

**If [`api/sql/models.py`](https://github.com/etalab-ia/OpenGateLLM/blob/main/api/sql/models.py) has been modified, please confirm that the following steps have been completed:**
- [ ] Alembic migration has been generated
- [ ] Alembic migration upgrade has been tested locally
- [ ] Alembic migration downgrade has been tested locally

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified


Made with [Cursor](https://cursor.com)