### PR TITLE
chore: bump Langfuse to latest, prerequisite for V4 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ api = [
     "gunicorn==25.1.0",
     "humanize==4.16.0",
     "itsdangerous==2.2.0",
-    "langfuse==4.0.6",
+    "langfuse==4.15.1",
     "limits==5.8.0",
     "mistralai==2.0.0",
     "openai==2.15.0",


### PR DESCRIPTION
**Breaking changes:**

- [x] No breaking changes : tested all imports and langfuse SDK usage in the code to make sure nothing breaks with this minor upgrade
- [ ] This PR contains breaking changes (explain below)

See https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#sdk-upgrade

<img width="715" height="264" alt="image" src="https://github.com/user-attachments/assets/a87b7760-86cb-46db-9c60-f8f35c47b106" />
The compatible SDK is langfuse Python SDK ≥ 4.7.0, this change saves us a step in the migration
