### PR TITLE
fix(schemas): lowercase user emails and require model type

### DIFF
--- a/api/infrastructure/fastapi/schemas/admin/users.py
+++ b/api/infrastructure/fastapi/schemas/admin/users.py
@@ -9,8 +9,8 @@ from api.utils.variables import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 
 
 class CreateUserBody(BaseModel):
-    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The user email.")]
-    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1), Field(default=None, description="The user name.")]
+    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254, to_lower=True), Field(..., description="The user email.")]  # fmt: off
+    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(default=None, description="The user name.")]  # fmt: off
     password: Annotated[str, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(description="The user password.")]  # fmt: off
     role_id: Annotated[int, Field(..., description="The role ID.")]
     organization_id: Annotated[int | None, Field(default=None, description="The organization ID.")]
@@ -52,8 +52,8 @@ class UsersResponse(BaseModel):
 
 
 class UserUpdateRequest(BaseModel):
-    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The new user email.")]
-    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1), Field(..., description="The new user name. If null, the user name is removed.")]  # fmt: off
+    email: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=254, to_lower=True), Field(..., description="The new user email.")]  # fmt: off
+    name: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=1, max_length=254), Field(..., description="The new user name. If null, the user name is removed.")]  # fmt: off
     current_password: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(default=None, description="The current user password. Only required to change the password.")]  # fmt: off
     password: Annotated[str | None, StringConstraints(strip_whitespace=True, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH), Field(default=None, description="The new user password. If omitted, the user password is not changed.")]  # fmt: off
     role_id: Annotated[int, Field(..., description="The new role ID.")]

--- a/api/infrastructure/fastapi/schemas/models.py
+++ b/api/infrastructure/fastapi/schemas/models.py
@@ -15,7 +15,7 @@ class ModelCosts(BaseModel):
 class Model(BaseModel):
     object: Annotated[Literal["model"], Field("model", description="Type of the object.")]
     id: Annotated[str, Field(..., description="The model identifier, which can be referenced in the API endpoints.")]
-    type: Annotated[ModelType | None, Field(default=None, description="The type of the model, which can be used to identify the model type.", examples=["text-generation"])]  # fmt: off
+    type: Annotated[ModelType, Field(..., description="The type of the model, which can be used to identify the model type.", examples=["text-generation"])]  # fmt: off
     aliases: Annotated[list[str], Field(default_factory=list, description="Aliases of the model. It will be used to identify the model by users.", examples=[["model-alias", "model-alias-2"]])]  # fmt: off
     created: Annotated[UnixTimestamp, Field(..., description="Time of creation, as Unix timestamp.")]
     owned_by: Annotated[str, Field(..., description="The organization that owns the model.")]


### PR DESCRIPTION
## Summary
- Normalize user emails to lowercase on create/update (`to_lower=True`) and align name max length with email (254).
- Make `Model.type` required — it always comes from `Router.type` and cannot be null.

Closes #1111

## Test plan
- [ ] Create a user with a mixed-case email and confirm it is stored/returned lowercased
- [ ] Update a user email with mixed case and confirm the same
- [ ] `GET /v1/models` still returns `type` for every model (OpenAPI no longer marks it nullable)

Made with [Cursor](https://cursor.com)