### PR TITLE
fix(keys): reject the names the API upserts for itself

### DIFF
--- a/api/domain/key/errors.py
+++ b/api/domain/key/errors.py
@@ -7,6 +7,11 @@ class KeyAlreadyExistsError:
 
 
 @dataclass
+class KeyNameReservedError:
+    name: str
+
+
+@dataclass
 class KeyExpirationInvalidError:
     max_expiration_days: int
 

--- a/api/helpers/_searchtool.py
+++ b/api/helpers/_searchtool.py
@@ -32,6 +32,7 @@ from api.schemas.core.models import RequestContent
 from api.schemas.usage import Usage
 from api.sql.models import Token as KeyTable
 from api.utils.exceptions import WrongSearchMethodException
+from api.utils.variables import SYSTEM_SEARCH_TOOL_KEY_NAME
 
 from ._identityaccessmanager import IdentityAccessManager
 
@@ -189,7 +190,7 @@ Output Format:
 - If none of the documents answer the query, state: "I do not know based on the provided documents."
 """
 
-    SYSTEM_KEY_NAME = "_system_search_tool"
+    SYSTEM_KEY_NAME = SYSTEM_SEARCH_TOOL_KEY_NAME
 
     def __init__(self, opengaterag_url: str, postgres_session: AsyncSession, user_id: int, secret_key: str):
         self.opengaterag_url = opengaterag_url

--- a/api/infrastructure/fastapi/endpoints/admin/keys.py
+++ b/api/infrastructure/fastapi/endpoints/admin/keys.py
@@ -4,7 +4,7 @@ from fastapi import Body, Depends, Path, Query, Security
 
 from api.dependencies import create_key_use_case_factory, delete_key_use_case_factory, get_keys_use_case_factory, get_one_key_use_case_factory
 from api.domain import SortField, SortOrder
-from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNotFoundError
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNameReservedError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
@@ -15,6 +15,7 @@ from api.infrastructure.fastapi.endpoints.exceptions import (
     InternalServerHTTPException,
     KeyAlreadyExistsHTTPException,
     KeyExpirationInvalidHTTPException,
+    KeyNameReservedHTTPException,
     KeyNotFoundHTTPException,
     NotAdminUserHTTPException,
     UserNotFoundHTTPException,
@@ -76,6 +77,8 @@ async def create_key(
             raise KeyAlreadyExistsHTTPException(name)
         case KeyExpirationInvalidError(max_expiration_days=max_expiration_days):
             raise KeyExpirationInvalidHTTPException(max_expiration_days)
+        case KeyNameReservedError(name=name):
+            raise KeyNameReservedHTTPException(name)
         case UserNotFoundError(id=user_id):
             raise UserNotFoundHTTPException(user_id)
 

--- a/api/infrastructure/fastapi/endpoints/exceptions.py
+++ b/api/infrastructure/fastapi/endpoints/exceptions.py
@@ -43,6 +43,14 @@ class InsufficientBudgetHTTPException(HTTPException):
         super().__init__(status_code=self.status_code, detail=self.detail)
 
 
+class KeyNameReservedHTTPException(HTTPException):
+    status_code = 400
+    detail = "Key name {name} is reserved."
+
+    def __init__(self, name: str) -> None:
+        super().__init__(status_code=self.status_code, detail=f"Key name {name} is reserved.")
+
+
 class KeyExpirationInvalidHTTPException(HTTPException):
     status_code = 400
     detail = "Key expiration timestamp cannot be greater than {max_expiration_days} days from now."

--- a/api/infrastructure/fastapi/endpoints/keys.py
+++ b/api/infrastructure/fastapi/endpoints/keys.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Body, Depends, Path, Query, Security
 
 from api.dependencies import create_me_key_use_case_factory, delete_key_use_case_factory, get_keys_use_case_factory, get_one_key_use_case_factory
 from api.domain import SortField, SortOrder
-from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNotFoundError
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNameReservedError, KeyNotFoundError
 from api.domain.user.errors import UserNotFoundError
 from api.domain.user.views import AuthenticatedUserView
 from api.infrastructure.fastapi.accesscontroller import AccessController
@@ -14,6 +14,7 @@ from api.infrastructure.fastapi.endpoints.exceptions import (
     InternalServerHTTPException,
     KeyAlreadyExistsHTTPException,
     KeyExpirationInvalidHTTPException,
+    KeyNameReservedHTTPException,
     KeyNotFoundHTTPException,
     UserNotFoundHTTPException,
 )
@@ -44,14 +45,18 @@ router = APIRouter(prefix="/v1", tags=[RouterName.KEYS.title()])
     path="/me/keys",
     dependencies=[Security(dependency=AccessController())],
     status_code=201,
-    responses=get_documentation_responses([KeyAlreadyExistsHTTPException, KeyExpirationInvalidHTTPException, UserNotFoundHTTPException]),
+    responses=get_documentation_responses(
+        [KeyAlreadyExistsHTTPException, KeyExpirationInvalidHTTPException, KeyNameReservedHTTPException, UserNotFoundHTTPException]
+    ),
     deprecated=True,
 )
 @router.post(
     path=EndpointRoute.KEYS,
     dependencies=[Security(dependency=AccessController())],
     status_code=201,
-    responses=get_documentation_responses([KeyAlreadyExistsHTTPException, KeyExpirationInvalidHTTPException, UserNotFoundHTTPException]),
+    responses=get_documentation_responses(
+        [KeyAlreadyExistsHTTPException, KeyExpirationInvalidHTTPException, KeyNameReservedHTTPException, UserNotFoundHTTPException]
+    ),
 )
 async def create_key(
     body: CreateKeyBody = Body(description="The key creation request."),
@@ -83,6 +88,8 @@ async def create_key(
             raise KeyAlreadyExistsHTTPException(name)
         case KeyExpirationInvalidError(max_expiration_days=max_expiration_days):
             raise KeyExpirationInvalidHTTPException(max_expiration_days)
+        case KeyNameReservedError(name=name):
+            raise KeyNameReservedHTTPException(name)
         case UserNotFoundError(id=user_id):
             raise UserNotFoundHTTPException(user_id)
 

--- a/api/tests/integration/endpoints/admin/keys/test_create_key.py
+++ b/api/tests/integration/endpoints/admin/keys/test_create_key.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_asyncio
 
 from api.dependencies import create_key_use_case_factory
-from api.domain.key.errors import KeyExpirationInvalidError
+from api.domain.key.errors import KeyExpirationInvalidError, KeyNameReservedError
 from api.domain.user.errors import UserNotFoundError
 from api.tests.helpers import create_key
 from api.tests.integration.factories.sql import UserSQLFactory
@@ -55,6 +55,11 @@ class TestCreateKey:
                 KeyExpirationInvalidError(max_expiration_days=365),
                 400,
                 "Key expiration timestamp cannot be greater than 365 days from now.",
+            ),
+            (
+                KeyNameReservedError(name="_system_playground_key"),
+                400,
+                "Key name _system_playground_key is reserved.",
             ),
             (
                 UserNotFoundError(id=99),

--- a/api/tests/integration/endpoints/keys/test_create_key.py
+++ b/api/tests/integration/endpoints/keys/test_create_key.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_asyncio
 
 from api.dependencies import create_me_key_use_case_factory
-from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNameReservedError
 from api.domain.user.errors import UserNotFoundError
 from api.tests.helpers import create_key
 from api.tests.integration.factories.sql import UserSQLFactory
@@ -56,6 +56,11 @@ class TestCreateMeKey:
                 KeyExpirationInvalidError(max_expiration_days=365),
                 400,
                 "Key expiration timestamp cannot be greater than 365 days from now.",
+            ),
+            (
+                KeyNameReservedError(name="_system_playground_key"),
+                400,
+                "Key name _system_playground_key is reserved.",
             ),
             (
                 UserNotFoundError(id=99),

--- a/api/tests/unit/use_case/admin/keys/test_createkeyusecase.py
+++ b/api/tests/unit/use_case/admin/keys/test_createkeyusecase.py
@@ -1,17 +1,19 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import create_autospec, patch
 
 import pytest
 
+from api.domain.key import KeyRepository
 from api.domain.key.entities import Key
-from api.domain.key.errors import KeyExpirationInvalidError
+from api.domain.key.errors import KeyExpirationInvalidError, KeyNameReservedError
 from api.domain.user.errors import UserNotFoundError
 from api.use_cases.admin.keys import CreateKeyCommand, CreateKeyUseCase, CreateKeyUseCaseSuccess
+from api.utils.variables import SYSTEM_PLAYGROUND_KEY_NAME, SYSTEM_SEARCH_TOOL_KEY_NAME
 
 
 @pytest.fixture
 def key_repository():
-    return AsyncMock()
+    return create_autospec(KeyRepository, instance=True, spec_set=True)
 
 
 @pytest.fixture
@@ -117,4 +119,18 @@ class TestCreateKeyUseCase:
         # Assert
         assert isinstance(result, KeyExpirationInvalidError)
         assert result.max_expiration_days == 10
+        key_repository.create_key.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", [SYSTEM_PLAYGROUND_KEY_NAME, SYSTEM_SEARCH_TOOL_KEY_NAME])
+    async def test_should_return_key_name_reserved_error(self, use_case, key_repository, name):
+        # Arrange
+        command = CreateKeyCommand(user_id=1, name=name, expire=None)
+
+        # Act
+        result = await use_case.execute(command)
+
+        # Assert
+        assert isinstance(result, KeyNameReservedError)
+        assert result.name == name
         key_repository.create_key.assert_not_awaited()

--- a/api/use_cases/admin/keys/_createkeyusecase.py
+++ b/api/use_cases/admin/keys/_createkeyusecase.py
@@ -5,8 +5,9 @@ from pydantic import FutureDatetime
 
 from api.domain.key import KeyRepository
 from api.domain.key.entities import Key
-from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError
+from api.domain.key.errors import KeyAlreadyExistsError, KeyExpirationInvalidError, KeyNameReservedError
 from api.domain.user.errors import UserNotFoundError
+from api.utils.variables import RESERVED_KEY_NAMES
 
 
 @dataclass
@@ -21,7 +22,7 @@ class CreateKeyUseCaseSuccess:
     key: Key
 
 
-type CreateKeyUseCaseResult = CreateKeyUseCaseSuccess | KeyAlreadyExistsError | KeyExpirationInvalidError | UserNotFoundError
+type CreateKeyUseCaseResult = CreateKeyUseCaseSuccess | KeyAlreadyExistsError | KeyExpirationInvalidError | KeyNameReservedError | UserNotFoundError
 
 
 class CreateKeyUseCase:
@@ -30,6 +31,9 @@ class CreateKeyUseCase:
         self.key_max_expiration_days = key_max_expiration_days
 
     async def execute(self, command: CreateKeyCommand) -> CreateKeyUseCaseResult:
+        if command.name in RESERVED_KEY_NAMES:
+            return KeyNameReservedError(name=command.name)
+
         expire = command.expire
         if self.key_max_expiration_days:
             max_expires = datetime.now(tz=UTC) + timedelta(days=self.key_max_expiration_days)

--- a/api/utils/variables.py
+++ b/api/utils/variables.py
@@ -3,6 +3,8 @@ from enum import StrEnum
 DEFAULT_APP_NAME: str = "OpenGateLLM"
 DEFAULT_TIMEOUT: int = 300
 SYSTEM_PLAYGROUND_KEY_NAME: str = "_system_playground_key"
+SYSTEM_SEARCH_TOOL_KEY_NAME: str = "_system_search_tool"
+RESERVED_KEY_NAMES: frozenset[str] = frozenset({SYSTEM_PLAYGROUND_KEY_NAME, SYSTEM_SEARCH_TOOL_KEY_NAME})
 MIN_PASSWORD_LENGTH: int = 6
 MAX_PASSWORD_LENGTH: int = 72
 


### PR DESCRIPTION
## Overview

Closes #1109.

Login upserts `_system_playground_key` per user and the search tool upserts `_system_search_tool`, both through `KeyRepository.upsert_key`. `unique_token_name_per_user` makes those names unique per user, and `CreateKeyUseCase` accepted them, so a user, or an admin on their behalf, could create a normal key on that exact row. The next login or search call then took it over through `ON CONFLICT`: token rotated, expiration moved, for no reason the owner could see.

The rule lives in the use case, before the repository is reached, so `POST /v1/keys` and `POST /v1/admin/keys` share one invariant instead of two schema validators. `upsert_key` is untouched: login, SSO and the search tool still rotate their own keys.

- [x] Reserved names lifted into `api/utils/variables.py`: `SYSTEM_SEARCH_TOOL_KEY_NAME` next to `SYSTEM_PLAYGROUND_KEY_NAME`, and `RESERVED_KEY_NAMES` built from both. `SearchTool.SYSTEM_KEY_NAME` now reads the constant instead of repeating the literal
- [x] New domain error `KeyNameReservedError`, returned by `CreateKeyUseCase.execute()` before `create_key`
- [x] `KeyNameReservedHTTPException` → **400**, mapped and documented on both create endpoints
- [x] Unit: the reserved-name branch, and `test_createkeyusecase.py` migrated off bare `AsyncMock` to `create_autospec(KeyRepository, instance=True, spec_set=True)` as the issue asks
- [x] Integration: a `KeyNameReservedError` row added to `test_error_maps_to_correct_http_status` on both create-key endpoint tests

Out of scope, per the issue: hiding system keys from `GET /v1/keys`, forbidding their deletion, playground form validation, migrating keys already created under a reserved name, and PATCH rename (#1090, where the same check applies once it lands).

**Breaking changes:**

- [x] No breaking changes

A name that was accepted and silently collided is now refused with a 400. Keys already created under one of those names are untouched, as the issue states.

## Check lists

### Review checklist

- [x] Updated or added documentation: the two create routes document the new response in their OpenAPI `responses`
- [x] Updated or added unit tests
- [x] Updated or added integration tests
- [x] No debug logs or commented-out code left
- [x] No secrets or environment variables committed in clear text
- [x] Code is linted and formatted using the project pre-commit hooks: `ruff check` and `ruff format` clean on the files touched (the two pre-existing `StrEnum` findings in `api/schemas/` are untouched)

`api/sql/models.py` is not modified.

## Deployment checklist

- [ ] Alembic migration has been generated
- [ ] Configuration file has been modified
- [ ] Environment variables have been modified

None of the three: no schema change, no configuration, no new variable.

## Additional Notes

Verified locally against Postgres and Redis from `compose.example.yml`:

- full suite (`pytest api/tests/unit api/tests/integration`): **1320 passed, 1 skipped**
- the acceptance criteria, driven through the real stack rather than a mocked use case: `POST /v1/keys` with each reserved name answers **400** and **writes no row** (`SELECT` on `Token` comes back empty), while a normal name still answers 201. That check is not committed, since `AGENTS.md` puts mapping at the endpoint layer and the branch at the use-case layer, but it is what confirms the two halves meet.
